### PR TITLE
feat(14): DE similarity Strategy Pattern + SEQUENTIAL pipeline + Phase 14 finishing (dev → main)

### DIFF
--- a/.claude/rules/commit-conventions.md
+++ b/.claude/rules/commit-conventions.md
@@ -1,0 +1,66 @@
+# 커밋 규칙
+
+## PR 전 필수 로컬 검사 (커밋·push 전 반드시 실행)
+
+GitHub Actions CI는 현재 이 레포에 없다. CodeRabbit AI 리뷰만 PR에 자동 연결되므로, 아래 4단계 로컬 검증을 **커밋 전에 반드시** 수동으로 돌린다.
+
+```bash
+conda activate mind-signal
+black .               # 포맷 자동 수정
+isort .               # import 정렬 자동 수정
+flake8 .              # PEP8 린트 (sdk/ 제외)
+pytest                # 단위 테스트 (필요 시 tests/ 디렉토리)
+```
+
+**순서 중요**: black → isort → flake8 → pytest 순으로 실행.
+한 단계라도 실패하면 수정 후 재실행, 전부 통과한 뒤에만 커밋·push한다.
+
+**Conda 환경 주의**: 반드시 `conda activate mind-signal`을 먼저 실행한다. 시스템 Python으로 실행하면 의존성이 깨진다. conda 환경 Python 경로: `C:\Users\gs071\.conda\envs\mind-signal\python.exe`.
+
+**SDK 수정 금지**: `sdk/` 폴더는 Emotiv 제공 원본 코드라 수정 금지. `.flake8`에서도 무시 대상으로 등록되어 있다.
+
+---
+
+## Co-authored-by 작성 방법
+
+모든 커밋 메시지 마지막에 아래 형식으로 고정 작성한다.
+
+```
+Co-authored-by: gs07103 <gwonseok02@gmail.com>
+```
+
+- **이메일**: `gwonseok02@gmail.com` 고정 (`noreply` 주소 사용 금지)
+- Claude Co-Authored-By 추가 금지 — `gs07103` 단독으로만
+
+---
+
+## Conventional Commits 메시지 형식
+
+```
+{type}({scope}): {description}
+```
+
+예시:
+
+```
+feat(streamer): add per-subject Redis channel keying
+fix(analyzer): correct FAA calculation for right-handed subjects
+perf(streamer): reduce pub/sub latency with batch publish
+test(analyzer): cover empty CSV edge case
+```
+
+| 타입 | 용도 |
+|------|------|
+| feat | 새 기능 |
+| fix | 버그 수정 |
+| refactor | 리팩토링 (기능 변경 없는 구조 개선) |
+| style | 포맷·공백 (로직 변경 없음) |
+| docs | 문서 변경 |
+| chore | 빌드·설정·패키지 |
+| test | 테스트 추가·수정 |
+| perf | 성능 개선 |
+| ci | CI 설정 |
+| revert | 이전 커밋 되돌리기 |
+
+- 태스크 1개 = 커밋 1개
+- `main` 브랜치 직접 commit 금지 — 반드시 `feat/#이슈번호-작업내용` 브랜치에서 작업 후 `dev`로 PR

--- a/README.md
+++ b/README.md
@@ -1,20 +1,54 @@
-# Amind-signal-data-engine
+# mind-signal-data-engine
 
-## 1. 📝 프로젝트 개요 (Project Overview)
+## 1. 프로젝트 개요 (Project Overview)
 
-본 프로젝트는 **실시간으로 EGG 데이터 전달 및 데이터를 분석**하는 것을 주요 목표로 합니다.
+**Mind Signal Data Engine**은 EEG(뇌파) 기반 2인 심리 동기화 측정 · 분석 서비스의 **Python 엔진**입니다.
+Emotiv Cortex API로 실시간 EEG를 수신해 Redis Pub/Sub으로 백엔드에 스트리밍하고, FastAPI 독립 서버로 사후 분석 API를 제공합니다.
+
+### 핵심 파이프라인
+
+```
+[실시간 EEG]
+Emotiv App (로컬 실행 필수)
+    ↓ WebSocket (ws://localhost:6868)
+core.main (백엔드가 세션 시작 시 spawn) ──→ Redis pub/sub ──→ 백엔드 ──→ 프론트
+
+[사후 분석]
+server/app.py (FastAPI, 포트 5002)
+    ├─ POST /api/analyze ← 백엔드가 HTTP 프록시로 호출
+    ├─ CSV 읽기 + 통계 계산 + Synchrony
+    └─ LLM용 Markdown 변환 (요청 시)
+```
+
+**전제 조건**: Emotiv App이 로컬에서 반드시 실행 중이어야 합니다. 헤드셋 없이는 streamer가 동작하지 않습니다.
 
 ---
 
-## 2. 🛠️ Tech Stack
+## 2. Tech Stack
 
-* **Environment:** Conda (로컬 가상 환경)
-* **Local (Conda):** Python 3.10
+| 구분 | 기술 |
+| :--- | :--- |
+| **Language** | `Python 3.10` |
+| **Environment** | `Conda` 가상 환경 `mind-signal` |
+| **Framework** | `FastAPI`, `uvicorn` (분석 서버) |
+| **Real-time** | `Emotiv Cortex API` (WebSocket), `Redis Pub/Sub` |
+| **Config** | `pydantic-settings` |
+| **Tunnel** | `pyngrok` (ngrok 자동 등록) |
+| **BLE (실험)** | `bleak` (BLE 직접 연결 테스트용) |
+| **Test** | `pytest` |
+| **Quality** | `black`, `isort`, `flake8` |
+| **SDK** | Emotiv 제공 `sdk/` (수정 금지) |
 
 ---
 
-## 3. 🚀 프로젝트 실행 방법 (Getting Started)
+## 3. 프로젝트 실행 방법 (Getting Started)
 
+### 요구사항
+
+- `Python 3.10` + `Conda` (Miniconda/Anaconda)
+- Emotiv App 설치 및 로컬 실행
+- Emotiv 계정으로 Cortex API CLIENT_ID / CLIENT_SECRET 발급
+- Redis (로컬 Docker — 백엔드 레포 `mind-signal-backend`의 `docker-compose.yml` 사용)
 
 ### 1. 저장소 복제 (Clone)
 
@@ -23,67 +57,107 @@ git clone https://github.com/KWONSEOK02/mind-signal-data-engine.git
 cd mind-signal-data-engine
 ```
 
-
 ### 2. 로컬 가상 환경 설정 (Conda)
 
-#### Python 3.10로 'mind-signal' 환경 생성
+#### Python 3.10으로 `mind-signal` 환경 생성
+
 ```bash
 conda create -n mind-signal python=3.10
 conda activate mind-signal
 ```
 
-#### requirements.txt로 모든 라이브러리 설치
+#### 의존성 설치
+
 ```bash
 pip install -r requirements.txt
 ```
 
-### 3. 각 파일 실행 명령어
- ```bash
- python -m core.main
- python -m core.streamer
- ``` 
+### 3. 환경 변수 설정
+
+`.env.example`을 복사해서 `.env.local` 파일을 생성한 뒤 Emotiv CLIENT_ID / CLIENT_SECRET 등을 채웁니다.
+
+```bash
+cp .env.example .env.local
+```
+
+### 4. 실행 명령어
+
+```bash
+# FastAPI 분석 서버 실행 (포트 5002)
+python run_server.py
+# 또는: uvicorn server.app:app --port 5002 --reload
+
+# 실시간 EEG 스트리머 실행 (백엔드가 세션 시작 시 spawn — 직접 실행 시 인수 필요)
+python -m core.main <groupId> <subjectIndex>
+
+# 독립 스트리머 (참고 — __main__ 블록 없어 즉시 종료됨, 백엔드 spawn 용도)
+python -m core.streamer
+```
+
+---
 
 ## 4. 코드 스타일 관리 (Lint & Format)
+
 협업 시 동일한 코딩 스타일을 유지하기 위해 아래 명령어를 권장합니다.
 
-* **코드 자동 정렬 (Formatter):**
-  ```bash
-  # Black(포맷팅)
-  black .
-  
-  #isort(임포트 정렬)
-  isort .
+### 코드 자동 정렬 (Formatter)
 
-  # 코드 스타일 검사 (Linter):
-  # PEP8 표준 준수 여부 및 잠재적 에러 확인
-  flake8 .
-  ```
+```bash
+# Black (포맷팅)
+black .
+
+# isort (임포트 정렬)
+isort .
+```
+
+### 코드 스타일 검사 (Linter)
+
+```bash
+# PEP8 표준 준수 여부 및 잠재적 에러 확인
+flake8 .
+```
+
+### 테스트
+
+```bash
+pytest
+```
+
+**주의**: 반드시 `conda activate mind-signal`로 환경을 먼저 활성화한 뒤 실행합니다. 시스템 Python으로 실행하면 의존성이 깨집니다.
+
 ---
 
-## 5. 📁 프로젝트 구조
+## 5. 프로젝트 구조
+
 ```
 mind-signal-data-engine/
-├── core/               # 핵심 엔진
-│   ├── analyzer.py     # FAA, ERP 계산 로직 (수학적 연산)
-│   ├── main.py         # 프로그램을 실행하는 엔트리 포인트
-│   └── streamer.py     # Redis로 데이터를 쏘는 실시간 스트리머
-├── sdk/                # 제공받은 원본 소스 코드 (수정 금지)
-│   ├── cortex.py       # 핵심 통신 라이브러리
-│   ├── marker.py       # 마커 로직 참고용
-│   ├── record.py       # 녹화 로직 참고용
-│   └── sub_data.py     # 데이터 구독 참고용
-├── .env.example        # 환경 변수 가이드 
-├── .env.local          # CLIENT_ID, CLIENT_SECRET 보관
-├── .flake8             # 파이썬 코드 스타일 가이드(PEP8) 및 문법 검사 설정 
-├── .gitignore          # 제외 목록
-├── pyproject.toml      # 코드 포맷터(Black, isort) 통합 설정 파일
-├── README.md           # 프로젝트 설명서
-└── requirements.txt    # 의존성 목록
+├── core/                    # 실시간 EEG 파이프라인
+│   ├── analyzer.py          # DSP 알고리즘 (FAA, 5대역 파워 등 — FastAPI에서도 재사용)
+│   ├── main.py              # 백엔드 spawn 진입점 (groupId, subjectIndex 위치 인수)
+│   └── streamer.py          # Redis pub/sub 스트리머
+├── server/                  # FastAPI 독립 서버
+│   ├── app.py               # FastAPI 앱 + lifespan (ngrok + webhook 자동 등록)
+│   ├── config.py            # pydantic-settings 환경변수
+│   ├── routes/              # analyze, health, export 라우트
+│   └── services/            # analysis, markdown, webhook 서비스
+├── sdk/                     # ⚠️ 수정 금지 (Emotiv 제공 원본)
+│   ├── cortex.py            # 핵심 통신 라이브러리
+│   ├── marker.py            # 마커 로직 참고용
+│   ├── record.py            # 녹화 로직 참고용
+│   └── sub_data.py          # 데이터 구독 참고용
+├── tests/                   # pytest 단위 테스트
+├── scripts/                 # 진단 · E2E 스크립트 (BLE 테스트 등)
+├── certificates/            # Emotiv 연결용 SSL 인증서
+├── base44/                  # (참고 자료)
+├── .env.example             # 환경 변수 가이드 (Git 추적)
+├── .env.local               # CLIENT_ID, CLIENT_SECRET 등 (Git 추적 제외)
+├── .flake8                  # PEP8 검사 설정 (sdk/ 제외)
+├── .gitignore               # 제외 목록
+├── pyproject.toml           # Black · isort 통합 설정
+├── run_server.py            # uvicorn 실행 스크립트
+├── requirements.txt         # 의존성 목록
+└── README.md                # 프로젝트 설명서
 ```
-
-## 6. 🤝 협업 가이드라인 (Contribution Guidelines)
-
----
 
 ### 파일별 핵심 역할 요약 (팀원 공유용)
 
@@ -94,82 +168,149 @@ mind-signal-data-engine/
 
 ---
 
-### Git Workflow
-- `master` (Production): 최종 배포 브랜치
-- `develop` (Staging): 개발 완료 코드를 병합하는 메인 브랜치
-- `feat/*`, `fix/*`, `docs/*`: 기능별, 목적별 브랜치
+## 6. 협업 가이드라인 (Contribution Guidelines)
 
-### 작업 흐름
-1. `develop` 브랜치에서 `feat/my-new-feature` 브랜치를 생성하여 작업을 시작합니다.
-2. 기능 완료 후 **Pull Request(PR)** 를 생성합니다.
-3. 1명 이상의 팀원에게 **Approve(리뷰 승인)** 를 받습니다.
-4. Merge 전, `develop` 최신 변경 사항을 `pull` 하여 충돌을 최소화합니다.
+### Git Workflow
+
+- `main` (Production): 최종 배포 브랜치 — 직접 push 금지. `dev`에서만 PR 올림
+- `dev` (Staging): 개발 통합 브랜치 — 모든 `feat/*` 기능 브랜치의 PR 대상
+- `feat/#{이슈번호}-{작업명}`: 이슈 기반 기능 브랜치
+- `fix/#{이슈번호}-{작업명}`: 이슈 기반 버그 수정 브랜치
+- `docs/#{이슈번호}-{작업명}`: 문서 작업 브랜치
+- `refactor/#{이슈번호}-{작업명}`, `chore/#{이슈번호}-{작업명}`: 그 외 목적별 브랜치
+
+### 작업 흐름 (모든 변경은 이슈 기반)
+
+모든 코드 변경은 반드시 **GitHub Issue를 먼저 생성**한 뒤 진행합니다. **`main` 직접 commit은 금지**이며, `dev` 직접 commit도 원칙적으로 금지합니다. 오타·로컬 세팅·사소한 문서 수정도 예외 없이 이슈 → 브랜치 → PR 절차를 따릅니다.
+
+1. **Issue 생성**: GitHub Issues → New Issue → 템플릿 선택 후 작업 내용 등록 (제목: `feat: 작업 내용`)
+2. **브랜치 생성**: 이슈 페이지 Development → Create a branch → **base를 `dev`로 설정** → `타입/#{이슈번호}-{작업명}` 형식
+3. **개발**: 기능 구현. 커밋 전 로컬 검증(§7) 통과 필수
+4. **PR**: **base를 `dev`로 설정**하여 PR 생성 (main 아님). Reviewers / Assignees / Labels 지정
+5. **코드리뷰**: 팀원 1명 이상의 Approve + CodeRabbit 리뷰 확인
+6. **머지**: 승인 완료 후 `feat/*` → `dev` 머지
+7. **Issue Close**: 머지 직후 해당 이슈 close
+8. **릴리스**: `dev`가 안정화되면 `dev` → `main` PR을 별도 생성, CodeRabbit 리뷰 통과 후 머지
 
 ### 프로젝트 규칙
-- **PR은 작은 단위로.** 하나의 PR은 하나의 기능에만 집중합니다.
-- 세부 작업은 체크리스트로 관리합니다.
-- 작업 충돌을 방지하기 위해 회의 중 역할을 명확히 나눕니다.
+
+- **PR은 작은 단위로.** 하나의 PR은 하나의 이슈 · 하나의 기능에만 집중합니다.
+- 세부 작업은 이슈 체크리스트로 관리합니다.
+- 머지 직전 `dev` 최신 변경 사항을 `pull` 하여 충돌을 최소화합니다.
 
 ### 개발 가이드라인
-- 코딩 스타일: **PEP8 준수**, `flake8` 권장
+
+- 코딩 스타일: **PEP8 준수**, `flake8` 검사 통과 필수
 - 함수·클래스 주석: **Google Style Docstring**
+- 주석 종결 어미: 명사형 (`~함`, `~사용`, `~완료`, `~처리`)
 - 모든 팀원은 동일한 `requirements.txt` 환경에서 개발합니다.
-
-### 커밋 및 브랜치 컨벤션
-- 커밋 메시지 및 브랜치는 **Conventional Commits 규칙 준수**
-  - 예시:  
-    - `feat(agent): Add A2C agent logic`  
-    - `fix(reward): Fix reward calculation bug`
-
-📄 상세 컨벤션 문서 (Notion)  
-https://www.notion.so/27167d3af687803ca8c1ec0a66bbeb59?source=copy_link
+- **`sdk/` 폴더는 절대 수정 금지** — Emotiv 제공 원본 코드
 
 ---
 
-## 📝 커밋 컨벤션
-**Conventional Commits** 규칙 준수
+## 7. CI 파이프라인 & AI 코드 리뷰
 
-- `feat:` 새 기능
-- `fix:` 버그 수정
-- `docs:` 문서 변경
-- `style:` 코드 포매팅, 세미콜론
-- `refactor:` 코드 리팩토링
-- `perf:` 성능 개선
-- `test:` 테스트 관련
-- `chore:` 빌드/배포/패키지
-- `ci:` CI 설정
-- `revert:` 이전 커밋 되돌리기
+이 레포에는 현재 GitHub Actions CI가 없습니다. **로컬 검증 + CodeRabbit AI 리뷰** 조합으로 품질을 유지합니다.
 
-**메시지 형식**
 ```
-feat(agent): add PPO multi-agent training
-fix(reward): correct negative reward assignment
-perf(train): reduce inference time by caching model
+  PR 생성
+     ↓
+┌─── 로컬 검증 (커밋 전 필수) ───────────────────┐
+│ 1. black .        → 포맷 자동 정렬            │
+│ 2. isort .        → import 정렬               │  ← 커밋 전
+│ 3. flake8 .       → PEP8 린트 (sdk/ 제외)     │     통과 필수
+│ 4. pytest         → 단위 테스트               │
+└────────────────────────────────────────────────┘
+     ↓ PR push
+┌─── CodeRabbit AI 리뷰 ────────────────────────┐
+│ • 로직 / 성능 / 보안 / 테스트 커버리지        │
+│ • SDK 수정 여부 / 환경변수 하드코딩           │
+└────────────────────────────────────────────────┘
 ```
----
 
-## 🌱 Git 브랜치 네이밍 컨벤션 (요약)
+### 로컬에서 잡아야 하는 것
 
-- **feature/** → 새로운 기능 / 알고리즘 / 환경 추가  
-  예) `feature/ppo-agent`, `feature/gomoku-env-enhancement`
+| 도구 | 검증 항목 |
+| :--- | :--- |
+| **Black** | 포맷, 들여쓰기, 줄바꿈 |
+| **isort** | import 순서 (표준 라이브러리 → 서드파티 → 로컬) |
+| **flake8** | PEP8, 사용하지 않는 변수, 길이 초과 |
+| **pytest** | 단위 테스트 (Cortex 연결 없이 동작하는 범위) |
 
-- **fix/** → 버그 수정  
-  예) `fix/reward-calculation`, `fix/model-forward-error`
+### PR 전 로컬에서 확인하는 법
 
-- **hotfix/** → 긴급 수정  
-  예) `hotfix/training-crash-epoch-100`
+```bash
+conda activate mind-signal
+black .
+isort .
+flake8 .
+pytest
+```
 
-- **refactor/** → 코드 구조 개선  
-  예) `refactor/env-clean-structure`, `refactor/agent-base-class`
+순서: `black → isort → flake8 → pytest` — 한 단계라도 실패하면 멈추고 수정 후 재실행.
 
-- **docs/** → 문서 작업  
-  예) `docs/update-readme-install-guide`, `docs/add-evaluation-results`
-
----
-참고 자료 링크
-
-*🔗 [Emotiv Cortex API Python 공식 예제 저장소](https://github.com/Emotiv/cortex-example/tree/master/python)
-
-*🔗 [Emotiv Cortex API](https://emotiv.gitbook.io/cortex-api)
+> 향후 GitHub Actions 도입 시 위 4단계를 그대로 `.github/workflows/ci.yml`로 옮길 예정입니다.
 
 ---
+
+## 8. 커밋 메시지 컨벤션
+
+**Conventional Commits** 규칙을 따릅니다. Gitmoji 이모지는 사용하지 않습니다.
+
+### 형식
+
+```
+{type}({scope}): {description}
+```
+
+예시:
+
+```
+feat(streamer): add per-subject Redis channel keying
+fix(analyzer): correct FAA calculation for right-handed subjects
+perf(streamer): reduce pub/sub latency with batch publish
+test(analyzer): cover empty CSV edge case
+```
+
+### 타입 목록
+
+| 타입 | 용도 |
+|------|------|
+| feat | 새 기능 |
+| fix | 버그 수정 |
+| refactor | 리팩토링 (기능 변경 없는 구조 개선) |
+| style | 포맷·공백 (로직 변경 없음) |
+| docs | 문서 변경 |
+| chore | 빌드·설정·패키지 |
+| test | 테스트 추가·수정 |
+| perf | 성능 개선 |
+| ci | CI 설정 |
+| revert | 이전 커밋 되돌리기 |
+
+- 태스크 1개 = 커밋 1개
+- `main` 브랜치 직접 commit 금지 — 반드시 `feat/#{이슈번호}-{작업명}` 브랜치에서 작업 후 `dev`로 PR
+
+---
+
+## 9. 브랜치 네이밍 컨벤션
+
+```
+{타입}/#{이슈번호}-{작업명}
+```
+
+예시:
+
+- `feat/#14-sequential-analysis-pipeline`
+- `fix/#27-faa-calculation-error`
+- `docs/#31-readme-structure-update`
+- `refactor/#22-analyzer-split-dsp`
+- `chore/#18-upgrade-pydantic-settings`
+
+이슈에서 "Create a branch"로 자동 생성할 때 base branch는 항상 `dev`로 설정합니다.
+
+---
+
+## 참고 자료
+
+- [Emotiv Cortex API Python 공식 예제 저장소](https://github.com/Emotiv/cortex-example/tree/master/python)
+- [Emotiv Cortex API 문서](https://emotiv.gitbook.io/cortex-api)

--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -108,7 +108,27 @@ async def analyze_pipeline(
             status_code=403, detail="인증 실패: 유효하지 않은 시크릿 키임"
         )
 
-    # 2. 전체 파이프라인 실행함
+    # 2. 모드별 파이프라인 분기 실행함
+    if body.mode == "SEQUENTIAL":
+        # SEQUENTIAL 모드: 시분할 측정 결과의 반응 유사도 계산 수행함
+        from server.services.analysis import analyze_pipeline_sequential
+
+        seq_result = analyze_pipeline_sequential(
+            group_id=body.group_id,
+            algorithm=body.algorithm,
+        )
+        # SEQUENTIAL 응답: BE는 similarity_features 사용, subjects는 빈 리스트 반환함
+        return PipelineResponse(
+            group_id=body.group_id,
+            subjects=[],
+            similarity_features=seq_result["similarity_features"],
+            pair_features=None,
+            y_score=None,
+            synchrony_score=None,
+            pipeline_params={},
+        )
+
+    # DUAL / BTI → 기존 파이프라인 실행함 (변경 없음)
     from server.services.analysis import run_full_pipeline
 
     result = run_full_pipeline(
@@ -135,9 +155,10 @@ async def analyze_pipeline(
             md_sections.append(dataframe_to_markdown(result["dataframes"]))
         # Feature 매트릭스 Markdown
         for subj in result.get("subjects", []):
-            md_sections.append(
-                features_to_markdown(subj["subject_index"], subj["features"])
-            )
+            if "features" in subj:
+                md_sections.append(
+                    features_to_markdown(subj["subject_index"], subj["features"])
+                )
         result["markdown"] = "\n\n---\n\n".join(md_sections)
 
     # dataframes는 응답에서 제외함

--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel
 
@@ -68,6 +70,8 @@ class PipelineRequest(BaseModel):
     params: PipelineParams = PipelineParams()
     satisfaction_scores: dict[int, float] | None = None  # {1: 7.5, 2: 6.0}
     include_markdown: bool = False
+    mode: Literal["DUAL", "SEQUENTIAL", "BTI"] = "DUAL"  # 실험 모드 선택
+    algorithm: str = "default"  # SEQUENTIAL 전용 유사도 알고리즘 선택
 
 
 class SubjectFeatureResult(BaseModel):
@@ -89,6 +93,7 @@ class PipelineResponse(BaseModel):
     synchrony_score: float | None = None
     pipeline_params: dict
     markdown: str | None = None
+    similarity_features: dict | None = None  # SEQUENTIAL 모드 전용 유사도 결과
 
 
 @router.post("/analyze/pipeline")

--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -115,6 +115,7 @@ async def analyze_pipeline(
 
         seq_result = analyze_pipeline_sequential(
             group_id=body.group_id,
+            subject_indices=body.subject_indices,
             algorithm=body.algorithm,
         )
         # SEQUENTIAL 응답: BE는 similarity_features 사용, subjects는 빈 리스트 반환함

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -175,6 +175,63 @@ def compute_session_analysis(group_id: str, subject_indices: list[int]) -> dict:
 
 
 # ──────────────────────────────────────────────
+# SEQUENTIAL 모드 파이프라인
+# ──────────────────────────────────────────────
+
+
+def analyze_pipeline_sequential(
+    group_id: str,
+    algorithm: str = "default",
+) -> dict:
+    """SEQUENTIAL 모드 분석 파이프라인을 실행함.
+
+    두 피실험자를 시분할로 측정한 CSV를 로드하여 반응 유사도를 계산함.
+    FAA는 raw EEG 채널 배열이 필요하므로 초기 버전에서는 None으로 처리함 (RR3).
+    pair_features / y_score / synchrony_score는 DUAL 전용이므로 None 반환함.
+    """
+    # 1. Subject 1 CSV 로드 수행함
+    csv_files_a = find_csv_files(group_id, subject_index=1)
+    if not csv_files_a:
+        raise ValueError(
+            f"group_id={group_id} subject_index=1 CSV 미발견"
+        )
+    df_a = load_session_data(csv_files_a[0])
+
+    # 2. Subject 2 CSV 로드 수행함
+    csv_files_b = find_csv_files(group_id, subject_index=2)
+    if not csv_files_b:
+        raise ValueError(
+            f"group_id={group_id} subject_index=2 CSV 미발견"
+        )
+    df_b = load_session_data(csv_files_b[0])
+
+    # 3. compute_subject_summary로 waves_mean 확보함 (N2: run_full_pipeline 대신)
+    summary_a = compute_subject_summary(df_a)
+    summary_b = compute_subject_summary(df_b)
+
+    # 4. Scalar 기반 input contract 구성함 (I6: faa_mean=None 초기 처리)
+    a_data = {"waves_mean": summary_a["waves_mean"], "faa_mean": None}
+    b_data = {"waves_mean": summary_b["waves_mean"], "faa_mean": None}
+
+    # 5. Strategy 호출하여 유사도 계산 수행함
+    from server.services.similarity import compute as compute_similarity
+
+    similarity_features = compute_similarity(a_data, b_data, algorithm=algorithm)
+
+    return {
+        "group_id": group_id,
+        "subjects": [
+            {"subject_index": 1, **summary_a},
+            {"subject_index": 2, **summary_b},
+        ],
+        "similarity_features": similarity_features,
+        "pair_features": None,   # DUAL 전용 필드
+        "y_score": None,         # DUAL 전용 필드
+        "synchrony_score": None,  # DUAL 전용 필드 (ADR-14-004)
+    }
+
+
+# ──────────────────────────────────────────────
 # 파이프라인 단계별 함수 (알고리즘 명세 기반)
 # ──────────────────────────────────────────────
 

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -181,6 +181,7 @@ def compute_session_analysis(group_id: str, subject_indices: list[int]) -> dict:
 
 def analyze_pipeline_sequential(
     group_id: str,
+    subject_indices: list[int],
     algorithm: str = "default",
 ) -> dict:
     """SEQUENTIAL 모드 분석 파이프라인을 실행함.
@@ -188,20 +189,37 @@ def analyze_pipeline_sequential(
     두 피실험자를 시분할로 측정한 CSV를 로드하여 반응 유사도를 계산함.
     FAA는 raw EEG 채널 배열이 필요하므로 초기 버전에서는 None으로 처리함 (RR3).
     pair_features / y_score / synchrony_score는 DUAL 전용이므로 None 반환함.
+
+    Args:
+        group_id: 그룹 식별자
+        subject_indices: 정확히 2명의 피실험자 인덱스 목록 (예: [1, 2], [3, 4])
+        algorithm: 유사도 알고리즘 식별자
+
+    Raises:
+        ValueError: subject_indices가 정확히 2개가 아닌 경우
     """
-    # 1. Subject 1 CSV 로드 수행함
-    csv_files_a = find_csv_files(group_id, subject_index=1)
+    # 입력 검증 — SEQUENTIAL 모드는 정확히 2명 필요함
+    if len(subject_indices) != 2:
+        raise ValueError(
+            f"SEQUENTIAL mode requires exactly 2 subject_indices, "
+            f"got {len(subject_indices)}"
+        )
+
+    idx_a, idx_b = subject_indices[0], subject_indices[1]
+
+    # 1. Subject A CSV 로드 수행함
+    csv_files_a = find_csv_files(group_id, subject_index=idx_a)
     if not csv_files_a:
         raise ValueError(
-            f"group_id={group_id} subject_index=1 CSV 미발견"
+            f"group_id={group_id} subject_index={idx_a} CSV 미발견"
         )
     df_a = load_session_data(csv_files_a[0])
 
-    # 2. Subject 2 CSV 로드 수행함
-    csv_files_b = find_csv_files(group_id, subject_index=2)
+    # 2. Subject B CSV 로드 수행함
+    csv_files_b = find_csv_files(group_id, subject_index=idx_b)
     if not csv_files_b:
         raise ValueError(
-            f"group_id={group_id} subject_index=2 CSV 미발견"
+            f"group_id={group_id} subject_index={idx_b} CSV 미발견"
         )
     df_b = load_session_data(csv_files_b[0])
 
@@ -221,8 +239,8 @@ def analyze_pipeline_sequential(
     return {
         "group_id": group_id,
         "subjects": [
-            {"subject_index": 1, **summary_a},
-            {"subject_index": 2, **summary_b},
+            {"subject_index": idx_a, **summary_a},
+            {"subject_index": idx_b, **summary_b},
         ],
         "similarity_features": similarity_features,
         "pair_features": None,   # DUAL 전용 필드

--- a/server/services/similarity/README.md
+++ b/server/services/similarity/README.md
@@ -1,0 +1,11 @@
+# Similarity Strategies
+
+## 새 알고리즘 추가 방법 (논문 읽고 수식 업데이트 시)
+
+1. `similarity/<your_strategy_name>.py` 파일 생성
+2. `SimilarityStrategy` 상속 + `name` 설정 + `compute(a, b)` 구현
+3. `@register` 데코레이터 추가
+4. `__init__.py`에 `from . import <your_strategy_name>` 한 줄 추가
+5. `/api/analyze/pipeline` 요청 시 body에 `"algorithm": "<your_strategy_name>"` 전달
+
+기존 `cosine_pearson_faa` 코드 변경 없음. DB 스키마 변경 없음 (JSONB 저장).

--- a/server/services/similarity/__init__.py
+++ b/server/services/similarity/__init__.py
@@ -1,0 +1,15 @@
+from ._registry import REGISTRY, get
+from . import cosine_pearson_faa  # noqa: F401 — 등록 트리거
+
+
+def compute(
+    subject_a: dict,
+    subject_b: dict,
+    algorithm: str = "default",
+) -> dict:
+    """외부에서 호출하는 단일 entry point임."""
+    strategy = get(algorithm)
+    return strategy.compute(subject_a, subject_b)
+
+
+__all__ = ["compute", "REGISTRY"]

--- a/server/services/similarity/_base.py
+++ b/server/services/similarity/_base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class SimilarityStrategy(ABC):
+    """Similarity 계산 전략의 ABC. 새 논문/수식 추가 시 이 클래스를 상속해 구현."""
+
+    name: str  # registry key (e.g. "cosine_pearson_faa", "lstm_based_2026")
+
+    @abstractmethod
+    def compute(self, subject_a_data: dict, subject_b_data: dict) -> dict:
+        """Return similarity features dict (shape is strategy-specific)."""

--- a/server/services/similarity/_registry.py
+++ b/server/services/similarity/_registry.py
@@ -1,0 +1,24 @@
+from typing import Type
+
+from ._base import SimilarityStrategy
+
+REGISTRY: dict[str, Type[SimilarityStrategy]] = {}
+
+
+def register(
+    strategy_cls: Type[SimilarityStrategy],
+) -> Type[SimilarityStrategy]:
+    """Decorator: @register on new strategy class auto-registers it."""
+    REGISTRY[strategy_cls.name] = strategy_cls
+    return strategy_cls
+
+
+def get(name: str = "default") -> SimilarityStrategy:
+    """이름으로 전략 인스턴스를 반환함"""
+    if name == "default":
+        name = "cosine_pearson_faa"
+    if name not in REGISTRY:
+        raise ValueError(
+            f"Unknown similarity strategy: {name}. Available: {list(REGISTRY.keys())}"
+        )
+    return REGISTRY[name]()

--- a/server/services/similarity/cosine_pearson_faa.py
+++ b/server/services/similarity/cosine_pearson_faa.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from ._base import SimilarityStrategy
+from ._registry import register
+
+
+@register
+class CosinePearsonFAAStrategy(SimilarityStrategy):
+    """코사인 유사도 + FAA 절대 차이 기반 반응 유사도 전략임"""
+
+    name = "cosine_pearson_faa"
+
+    def compute(self, a: dict, b: dict) -> dict:
+        """스칼라 기반 input contract으로 유사도를 계산함.
+
+        Input contract:
+          a = {
+            "waves_mean": {
+                "delta": float, "theta": float, "alpha": float,
+                "beta": float, "gamma": float
+            },
+            "faa_mean": float | None,
+          }
+          b = same
+        """
+        # 1) 대역별 5-요소 벡터의 코사인 유사도 계산함
+        band_order = ["delta", "theta", "alpha", "beta", "gamma"]
+        vec_a = np.array([a["waves_mean"][band] for band in band_order])
+        vec_b = np.array([b["waves_mean"][band] for band in band_order])
+        overall_cosine = self._cosine(vec_a, vec_b)
+
+        # 개별 대역 파워 절대 차이 계산함 (추가 진단 정보)
+        band_ratio_diff = {
+            band: abs(a["waves_mean"][band] - b["waves_mean"][band])
+            for band in band_order
+        }
+
+        # 2) FAA 절대 차이 계산함 (scalar 차이, 시계열 없으므로 피어슨 상관 제외)
+        faa_diff = None
+        if a.get("faa_mean") is not None and b.get("faa_mean") is not None:
+            faa_diff = abs(a["faa_mean"] - b["faa_mean"])
+
+        # 3) overall similarity_score 정규화 (0~1 범위)
+        similarity_score = self._normalize(overall_cosine, faa_diff)
+
+        return {
+            "algorithm": self.name,
+            "similarity_score": similarity_score,
+            "overall_cosine": overall_cosine,
+            "band_ratio_diff": band_ratio_diff,
+            "faa_absolute_diff": faa_diff,
+        }
+
+    def _cosine(self, a: np.ndarray, b: np.ndarray) -> float:
+        """두 벡터의 코사인 유사도를 계산함"""
+        return float(
+            np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12)
+        )
+
+    def _normalize(self, cosine: float, faa_diff: float | None) -> float:
+        """cosine 유사도를 0~1로 정규화하고 FAA 차이 감점을 적용함.
+
+        FAA 차이가 클수록 유사도 감소 (단순 선형 감점, 교수 면담 후 가중치 조정 가능).
+        """
+        # cosine은 -1~1 범위. 0~1로 정규화함
+        score = (cosine + 1) / 2
+
+        # FAA 차이 클수록 유사도 감소 (faa_diff 2 이상 시 최대 50% 감점)
+        if faa_diff is not None:
+            score *= max(0.0, 1.0 - min(faa_diff / 2.0, 0.5))
+
+        return float(max(0.0, min(1.0, score)))

--- a/server/services/similarity/cosine_pearson_faa.py
+++ b/server/services/similarity/cosine_pearson_faa.py
@@ -22,25 +22,69 @@ class CosinePearsonFAAStrategy(SimilarityStrategy):
             "faa_mean": float | None,
           }
           b = same
+
+        Raises:
+            ValueError: waves_mean에 필수 대역이 누락된 경우
+            ValueError: waves_mean에 NaN 또는 Inf 값이 포함된 경우
         """
-        # 1) 대역별 5-요소 벡터의 코사인 유사도 계산함
         band_order = ["delta", "theta", "alpha", "beta", "gamma"]
-        vec_a = np.array([a["waves_mean"][band] for band in band_order])
-        vec_b = np.array([b["waves_mean"][band] for band in band_order])
+
+        # 0) 필수 대역 존재 여부 검증 수행함
+        waves_a = a.get("waves_mean", {})
+        waves_b = b.get("waves_mean", {})
+        missing_a = [band for band in band_order if band not in waves_a]
+        missing_b = [band for band in band_order if band not in waves_b]
+        if missing_a or missing_b:
+            raise ValueError(
+                f"Missing bands in waves_mean: "
+                f"subject_a={missing_a}, subject_b={missing_b}. "
+                f"Expected all of {band_order}."
+            )
+
+        # 1) 대역별 5-요소 벡터 구성 수행함
+        vec_a = np.array([waves_a[band] for band in band_order], dtype=float)
+        vec_b = np.array([waves_b[band] for band in band_order], dtype=float)
+
+        # NaN/Inf 방어 검증 수행함
+        if np.any(np.isnan(vec_a)) or np.any(np.isnan(vec_b)):
+            raise ValueError(
+                "NaN detected in waves_mean — "
+                "likely data quality issue (empty session or filter divergence)"
+            )
+        if np.any(np.isinf(vec_a)) or np.any(np.isinf(vec_b)):
+            raise ValueError(
+                "Inf detected in waves_mean — likely filter divergence"
+            )
+
+        # 영벡터 방어 처리 — 진짜 빈 데이터와 직교를 구별함
+        norm_a = np.linalg.norm(vec_a)
+        norm_b = np.linalg.norm(vec_b)
+        if norm_a < 1e-12 or norm_b < 1e-12:
+            return {
+                "algorithm": self.name,
+                "similarity_score": None,
+                "overall_cosine": None,
+                "band_ratio_diff": {band: 0.0 for band in band_order},
+                "faa_absolute_diff": None,
+                "degraded": True,
+                "degraded_reason": "zero_norm",
+            }
+
+        # 2) 코사인 유사도 계산 수행함
         overall_cosine = self._cosine(vec_a, vec_b)
 
         # 개별 대역 파워 절대 차이 계산함 (추가 진단 정보)
         band_ratio_diff = {
-            band: abs(a["waves_mean"][band] - b["waves_mean"][band])
+            band: abs(waves_a[band] - waves_b[band])
             for band in band_order
         }
 
-        # 2) FAA 절대 차이 계산함 (scalar 차이, 시계열 없으므로 피어슨 상관 제외)
+        # 3) FAA 절대 차이 계산함 (scalar 차이, 시계열 없으므로 피어슨 상관 제외)
         faa_diff = None
         if a.get("faa_mean") is not None and b.get("faa_mean") is not None:
             faa_diff = abs(a["faa_mean"] - b["faa_mean"])
 
-        # 3) overall similarity_score 정규화 (0~1 범위)
+        # 4) overall similarity_score 정규화 (0~1 범위)
         similarity_score = self._normalize(overall_cosine, faa_diff)
 
         return {
@@ -60,10 +104,12 @@ class CosinePearsonFAAStrategy(SimilarityStrategy):
     def _normalize(self, cosine: float, faa_diff: float | None) -> float:
         """cosine 유사도를 0~1로 정규화하고 FAA 차이 감점을 적용함.
 
+        대역 파워는 음수가 없으므로 cosine ∈ [0, 1]. (cosine+1)/2 매핑은
+        직교(cosine=0)를 0.5로 올려 의미가 왜곡되므로 직접 사용함.
         FAA 차이가 클수록 유사도 감소 (단순 선형 감점, 교수 면담 후 가중치 조정 가능).
         """
-        # cosine은 -1~1 범위. 0~1로 정규화함
-        score = (cosine + 1) / 2
+        # 대역 파워는 비음수 → cosine ∈ [0, 1]. 직접 clamp 적용함
+        score = max(0.0, cosine)
 
         # FAA 차이 클수록 유사도 감소 (faa_diff 2 이상 시 최대 50% 감점)
         if faa_diff is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,9 @@ def valid_pipeline_result():
             "baseline_duration_sec": BASELINE_ROWS,
             "band_cols": DEFAULT_BAND_COLS,
             "n_windows_per_stimulus": N_WINDOWS,
-            "total_features_per_subject": N_STIMULI * N_WINDOWS * len(DEFAULT_BAND_COLS),
+            "total_features_per_subject": (
+                N_STIMULI * N_WINDOWS * len(DEFAULT_BAND_COLS)
+            ),
         },
         "dataframes": {},
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 """파이프라인 테스트 공통 fixture 정의함"""
 
 from collections import OrderedDict
-from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd

--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -226,6 +226,48 @@ class TestAnalyzePipelineModeField:
         data = response.json()
         assert data["similarity_features"] is not None
 
+    @patch("server.services.analysis.analyze_pipeline_sequential")
+    def test_sequential_subject_indices_passed_through(
+        self,
+        mock_seq_pipeline,
+        test_client,
+        pipeline_secret_header,
+    ):
+        """mode=SEQUENTIAL + subject_indices=[1,2] → 서비스 호출 시 subject_indices 전달됨"""
+        mock_seq_pipeline.return_value = {
+            "group_id": TEST_GROUP_ID,
+            "subjects": [],
+            "similarity_features": {
+                "algorithm": "cosine_pearson_faa",
+                "similarity_score": 0.7,
+                "overall_cosine": 0.5,
+                "band_ratio_diff": {
+                    "delta": 0.1,
+                    "theta": 0.1,
+                    "alpha": 0.1,
+                    "beta": 0.1,
+                    "gamma": 0.1,
+                },
+                "faa_absolute_diff": None,
+            },
+            "pair_features": None,
+            "y_score": None,
+            "synchrony_score": None,
+        }
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={
+                "group_id": TEST_GROUP_ID,
+                "subject_indices": [1, 2],
+                "mode": "SEQUENTIAL",
+            },
+            headers=pipeline_secret_header,
+        )
+        assert response.status_code == 200
+        # mock 호출 인수에 subject_indices=[1, 2]가 포함되어 있음
+        _, call_kwargs = mock_seq_pipeline.call_args
+        assert call_kwargs["subject_indices"] == [1, 2]
+
     def test_mode_invalid_returns_422(
         self, test_client, pipeline_secret_header
     ):

--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -2,9 +2,9 @@
 
 from unittest.mock import patch
 
-import pytest
+import pytest  # noqa: F401
 
-from tests.conftest import TEST_GROUP_ID, TEST_SECRET
+from tests.conftest import TEST_GROUP_ID, TEST_SECRET  # noqa: F401
 
 
 class TestAnalyzePipelineEndpoint:
@@ -29,7 +29,9 @@ class TestAnalyzePipelineEndpoint:
         assert response.status_code == 403
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_valid_request_returns_200(self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result):
+    def test_valid_request_returns_200(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
         """올바른 요청 → 200 반환함"""
         mock_pipeline.return_value = valid_pipeline_result
         response = test_client.post(
@@ -40,7 +42,9 @@ class TestAnalyzePipelineEndpoint:
         assert response.status_code == 200
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_response_group_id_matches(self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result):
+    def test_response_group_id_matches(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
         """응답 JSON의 group_id가 요청과 일치함"""
         mock_pipeline.return_value = valid_pipeline_result
         response = test_client.post(
@@ -52,7 +56,9 @@ class TestAnalyzePipelineEndpoint:
         assert data["group_id"] == TEST_GROUP_ID
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_response_has_pipeline_params(self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result):
+    def test_response_has_pipeline_params(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
         """응답 pipeline_params에 필수 키 존재함"""
         mock_pipeline.return_value = valid_pipeline_result
         response = test_client.post(
@@ -65,7 +71,9 @@ class TestAnalyzePipelineEndpoint:
         assert "stimulus_duration_sec" in data["pipeline_params"]
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_include_markdown_true(self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result):
+    def test_include_markdown_true(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
         """include_markdown=true 시 markdown 필드가 None이 아님"""
         # features_to_markdown이 호출되려면 subjects에 features가 있어야 함
         mock_pipeline.return_value = valid_pipeline_result
@@ -82,7 +90,9 @@ class TestAnalyzePipelineEndpoint:
         assert data["markdown"] is not None
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_include_markdown_false(self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result):
+    def test_include_markdown_false(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
         """include_markdown=false(기본값) 시 markdown=None임"""
         mock_pipeline.return_value = valid_pipeline_result
         response = test_client.post(
@@ -94,7 +104,9 @@ class TestAnalyzePipelineEndpoint:
         assert data["markdown"] is None
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_satisfaction_scores_returns_y_score(self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result):
+    def test_satisfaction_scores_returns_y_score(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
         """satisfaction_scores 포함 요청 시 y_score가 None이 아님"""
         mock_pipeline.return_value = valid_pipeline_result
         response = test_client.post(
@@ -110,7 +122,9 @@ class TestAnalyzePipelineEndpoint:
         assert data["y_score"] is not None
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_csv_not_found_in_response(self, mock_pipeline, test_client, pipeline_secret_header):
+    def test_csv_not_found_in_response(
+        self, mock_pipeline, test_client, pipeline_secret_header
+    ):
         """CSV 없는 subject의 응답 처리 검증함"""
         # subjects에 error가 없는 정상 응답을 반환하되, 최소 구조만 갖춤
         mock_pipeline.return_value = {
@@ -152,3 +166,70 @@ class TestAnalyzePipelineEndpoint:
             headers=pipeline_secret_header,
         )
         assert response.status_code == 422
+
+
+class TestAnalyzePipelineModeField:
+    """mode / algorithm 필드 검증 테스트 수행함"""
+
+    @patch("server.services.analysis.run_full_pipeline")
+    def test_omitting_mode_defaults_to_dual(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
+        """mode 미포함 body → DUAL 기본값 적용, 기존 동작 유지함"""
+        mock_pipeline.return_value = valid_pipeline_result
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={"group_id": TEST_GROUP_ID, "subject_indices": [1, 2]},
+            headers=pipeline_secret_header,
+        )
+        assert response.status_code == 200
+
+    @patch("server.services.analysis.run_full_pipeline")
+    def test_mode_sequential_accepted(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
+        """mode=SEQUENTIAL body → 422 없이 요청 수락함"""
+        mock_pipeline.return_value = valid_pipeline_result
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={
+                "group_id": TEST_GROUP_ID,
+                "subject_indices": [1, 2],
+                "mode": "SEQUENTIAL",
+            },
+            headers=pipeline_secret_header,
+        )
+        # SEQUENTIAL 분기에서 mock이 적절히 처리되면 200, 아니면 500 허용
+        # 중요한 것은 422(validation error)가 아니어야 함
+        assert response.status_code != 422
+
+    def test_mode_invalid_returns_422(
+        self, test_client, pipeline_secret_header
+    ):
+        """mode=INVALID → 422 validation error 반환함"""
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={
+                "group_id": TEST_GROUP_ID,
+                "subject_indices": [1, 2],
+                "mode": "INVALID",
+            },
+            headers=pipeline_secret_header,
+        )
+        assert response.status_code == 422
+
+    @patch("server.services.analysis.run_full_pipeline")
+    def test_response_allows_similarity_features_none(
+        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
+        """응답 similarity_features=None이어도 기존 DUAL 호출 정상 처리함"""
+        mock_pipeline.return_value = valid_pipeline_result
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={"group_id": TEST_GROUP_ID, "subject_indices": [1, 2]},
+            headers=pipeline_secret_header,
+        )
+        data = response.json()
+        assert response.status_code == 200
+        # similarity_features 필드가 없거나 None임
+        assert data.get("similarity_features") is None

--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -184,12 +184,34 @@ class TestAnalyzePipelineModeField:
         )
         assert response.status_code == 200
 
-    @patch("server.services.analysis.run_full_pipeline")
+    @patch("server.services.analysis.analyze_pipeline_sequential")
     def test_mode_sequential_accepted(
-        self, mock_pipeline, test_client, pipeline_secret_header, valid_pipeline_result
+        self,
+        mock_seq_pipeline,
+        test_client,
+        pipeline_secret_header,
     ):
         """mode=SEQUENTIAL body → 422 없이 요청 수락함"""
-        mock_pipeline.return_value = valid_pipeline_result
+        mock_seq_pipeline.return_value = {
+            "group_id": TEST_GROUP_ID,
+            "subjects": [],
+            "similarity_features": {
+                "algorithm": "cosine_pearson_faa",
+                "similarity_score": 0.8,
+                "overall_cosine": 0.6,
+                "band_ratio_diff": {
+                    "delta": 0.1,
+                    "theta": 0.2,
+                    "alpha": 0.05,
+                    "beta": 0.15,
+                    "gamma": 0.1,
+                },
+                "faa_absolute_diff": None,
+            },
+            "pair_features": None,
+            "y_score": None,
+            "synchrony_score": None,
+        }
         response = test_client.post(
             "/api/analyze/pipeline",
             json={
@@ -199,9 +221,10 @@ class TestAnalyzePipelineModeField:
             },
             headers=pipeline_secret_header,
         )
-        # SEQUENTIAL 분기에서 mock이 적절히 처리되면 200, 아니면 500 허용
-        # 중요한 것은 422(validation error)가 아니어야 함
-        assert response.status_code != 422
+        # SEQUENTIAL 분기에서 올바르게 처리되면 200 반환함
+        assert response.status_code == 200
+        data = response.json()
+        assert data["similarity_features"] is not None
 
     def test_mode_invalid_returns_422(
         self, test_client, pipeline_secret_header

--- a/tests/routes/test_similarity_integration.py
+++ b/tests/routes/test_similarity_integration.py
@@ -1,0 +1,146 @@
+"""SEQUENTIAL 파이프라인 및 similarity 엣지 케이스 통합 테스트 수행함"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.conftest import TEST_GROUP_ID
+
+
+# ──────────────────────────────────────────────
+# Fixture
+# ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def identical_waves_df():
+    """두 피실험자가 동일한 뇌파 패턴을 보이는 60행 DataFrame 반환함"""
+    np.random.seed(42)
+    n = 60
+    base_data = {
+        "delta": np.full(n, 0.5),
+        "theta": np.full(n, 0.3),
+        "alpha": np.full(n, 0.8),
+        "beta": np.full(n, 0.4),
+        "gamma": np.full(n, 0.2),
+        "focus": np.full(n, 0.5),
+        "engagement": np.full(n, 0.5),
+        "interest": np.full(n, 0.5),
+        "excitement": np.full(n, 0.5),
+        "stress": np.full(n, 0.5),
+        "relaxation": np.full(n, 0.5),
+    }
+    return pd.DataFrame(base_data)
+
+
+# ──────────────────────────────────────────────
+# TestSequentialIntegration
+# ──────────────────────────────────────────────
+
+
+class TestSequentialIntegration:
+    """route → service → similarity 전체 경로 통합 검증 수행함"""
+
+    def test_unknown_algorithm_via_pipeline_raises_value_error(
+        self, test_client, pipeline_secret_header, identical_waves_df
+    ):
+        """알 수 없는 algorithm → ValueError 발생함 (서비스 레이어 검증)"""
+        with patch(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [
+                Path(f"/fake/subject_{subject_index}_{group_id}.csv")
+            ],
+        ), patch(
+            "server.services.analysis.load_session_data",
+            lambda path: identical_waves_df.copy(),
+        ):
+            # TestClient는 기본적으로 서버 예외를 그대로 re-raise함
+            # ValueError를 직접 확인함
+            with pytest.raises(ValueError, match="Unknown similarity strategy"):
+                test_client.post(
+                    "/api/analyze/pipeline",
+                    json={
+                        "group_id": TEST_GROUP_ID,
+                        "subject_indices": [1, 2],
+                        "mode": "SEQUENTIAL",
+                        "algorithm": "nonexistent_algo_xyz",
+                    },
+                    headers=pipeline_secret_header,
+                )
+
+    def test_sequential_identical_waves_similarity_score_near_one(
+        self, test_client, pipeline_secret_header, identical_waves_df
+    ):
+        """동일 뇌파 패턴 두 피실험자 → similarity_score ≥ 0.95 (통합 경로)"""
+        with patch(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [
+                Path(f"/fake/subject_{subject_index}_{group_id}.csv")
+            ],
+        ), patch(
+            "server.services.analysis.load_session_data",
+            lambda path: identical_waves_df.copy(),
+        ):
+            response = test_client.post(
+                "/api/analyze/pipeline",
+                json={
+                    "group_id": TEST_GROUP_ID,
+                    "subject_indices": [1, 2],
+                    "mode": "SEQUENTIAL",
+                },
+                headers=pipeline_secret_header,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["similarity_features"] is not None
+            assert data["similarity_features"]["similarity_score"] >= 0.95
+
+    def test_sequential_response_pair_features_is_none(
+        self, test_client, pipeline_secret_header, identical_waves_df
+    ):
+        """SEQUENTIAL 모드 route 응답 → pair_features=None (DUAL 전용 필드)"""
+        with patch(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [
+                Path(f"/fake/subject_{subject_index}_{group_id}.csv")
+            ],
+        ), patch(
+            "server.services.analysis.load_session_data",
+            lambda path: identical_waves_df.copy(),
+        ):
+            response = test_client.post(
+                "/api/analyze/pipeline",
+                json={
+                    "group_id": TEST_GROUP_ID,
+                    "subject_indices": [1, 2],
+                    "mode": "SEQUENTIAL",
+                },
+                headers=pipeline_secret_header,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["pair_features"] is None
+            assert data["y_score"] is None
+            assert data["synchrony_score"] is None
+
+    def test_dual_regression_via_route_similarity_features_none(
+        self, test_client, pipeline_secret_header, valid_pipeline_result
+    ):
+        """DUAL 모드 route 응답 → similarity_features=None (SEQUENTIAL 전용 필드)"""
+        with patch("server.services.analysis.run_full_pipeline") as mock_pipeline:
+            mock_pipeline.return_value = valid_pipeline_result
+            response = test_client.post(
+                "/api/analyze/pipeline",
+                json={
+                    "group_id": TEST_GROUP_ID,
+                    "subject_indices": [1, 2],
+                    "mode": "DUAL",
+                },
+                headers=pipeline_secret_header,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["similarity_features"] is None

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -459,7 +459,7 @@ class TestAnalyzePipelineSequential:
             "server.services.analysis.load_session_data",
             lambda path: waves_df.copy(),
         )
-        result = analyze_pipeline_sequential(TEST_GROUP_ID)
+        result = analyze_pipeline_sequential(TEST_GROUP_ID, subject_indices=[1, 2])
         assert isinstance(result["similarity_features"], dict)
         assert "similarity_score" in result["similarity_features"]
 
@@ -475,17 +475,17 @@ class TestAnalyzePipelineSequential:
             "server.services.analysis.load_session_data",
             lambda path: waves_df.copy(),
         )
-        result = analyze_pipeline_sequential(TEST_GROUP_ID)
+        result = analyze_pipeline_sequential(TEST_GROUP_ID, subject_indices=[1, 2])
         assert result["pair_features"] is None
 
     def test_sequential_csv_not_found_raises_value_error(self, monkeypatch):
-        """subject 1 CSV 없을 때 ValueError 발생함"""
+        """subject 첫 번째 인덱스 CSV 없을 때 ValueError 발생함"""
         monkeypatch.setattr(
             "server.services.analysis.find_csv_files",
             lambda group_id, subject_index: [],
         )
-        with pytest.raises(ValueError, match="subject_index=1 CSV 미발견"):
-            analyze_pipeline_sequential(TEST_GROUP_ID)
+        with pytest.raises(ValueError, match="CSV 미발견"):
+            analyze_pipeline_sequential(TEST_GROUP_ID, subject_indices=[1, 2])
 
     def test_sequential_csv_not_found_subject2_raises_value_error(
         self, monkeypatch, waves_df
@@ -505,8 +505,47 @@ class TestAnalyzePipelineSequential:
             "server.services.analysis.load_session_data",
             lambda path: waves_df.copy(),
         )
-        with pytest.raises(ValueError, match="subject_index=2 CSV 미발견"):
-            analyze_pipeline_sequential(TEST_GROUP_ID)
+        with pytest.raises(ValueError, match="CSV 미발견"):
+            analyze_pipeline_sequential(TEST_GROUP_ID, subject_indices=[1, 2])
+
+    def test_sequential_uses_provided_indices_not_hardcoded(
+        self, monkeypatch, waves_df
+    ):
+        """subject_indices=[5, 7] → 실제 5, 7 인덱스로 CSV 탐색 수행함"""
+        called_indices = []
+
+        def mock_find(group_id, subject_index):
+            called_indices.append(subject_index)
+            return [Path(f"/fake/subject_{subject_index}_{group_id}.csv")]
+
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            mock_find,
+        )
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: waves_df.copy(),
+        )
+        result = analyze_pipeline_sequential(TEST_GROUP_ID, subject_indices=[5, 7])
+        assert 5 in called_indices
+        assert 7 in called_indices
+        assert 1 not in called_indices
+        assert 2 not in called_indices
+        # 반환된 subjects 인덱스도 5, 7이어야 함
+        subject_idx_in_result = [s["subject_index"] for s in result["subjects"]]
+        assert subject_idx_in_result == [5, 7]
+
+    def test_sequential_single_index_raises_value_error(self, monkeypatch):
+        """subject_indices=[1] (길이 != 2) → ValueError 발생함"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [],
+        )
+        with pytest.raises(
+            ValueError,
+            match="SEQUENTIAL mode requires exactly 2 subject_indices",
+        ):
+            analyze_pipeline_sequential(TEST_GROUP_ID, subject_indices=[1])
 
     def test_dual_regression_pair_features_not_none(self, monkeypatch, full_session_df):
         """DUAL 모드 기존 run_full_pipeline 동작 유지 — pair_features 존재함"""

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -13,6 +13,7 @@ from tests.conftest import (
     TEST_GROUP_ID,
 )
 from server.services.analysis import (
+    analyze_pipeline_sequential,
     average_by_timestamp,
     build_pair_features,
     compute_baseline,
@@ -198,7 +199,10 @@ class TestExtractFeatures:
         for s in range(n_stim):
             stim_wins = []
             for w in range(n_win):
-                data = {band: [float(s + w + i) * 0.1 for i in range(10)] for band in band_cols}
+                data = {
+                    band: [float(s + w + i) * 0.1 for i in range(10)]
+                    for band in band_cols
+                }
                 stim_wins.append(pd.DataFrame(data))
             windows.append(stim_wins)
         return windows
@@ -405,9 +409,121 @@ class TestRunFullPipeline:
     def test_band_cols_default(self):
         """band_cols=None 시 기본값 사용됨"""
         result = run_full_pipeline(TEST_GROUP_ID, [1, 2])
-        assert result["pipeline_params"]["band_cols"] == ["alpha", "beta", "theta", "gamma"]
+        assert result["pipeline_params"]["band_cols"] == [
+            "alpha", "beta", "theta", "gamma"
+        ]
 
     def test_synchrony_score_mocked(self):
         """MindSignalAnalyzer.calculate_synchrony Mock → 0.75 반환함"""
         result = run_full_pipeline(TEST_GROUP_ID, [1, 2])
         assert result["synchrony_score"] == 0.75
+
+
+# ──────────────────────────────────────────────
+# TestAnalyzePipelineSequential
+# ──────────────────────────────────────────────
+
+
+class TestAnalyzePipelineSequential:
+    """SEQUENTIAL 모드 분기 analyze_pipeline_sequential 검증함"""
+
+    @pytest.fixture
+    def waves_df(self):
+        """5대역 + EmotivMetrics 컬럼을 포함한 최소 측정 DataFrame 반환함"""
+        np.random.seed(1)
+        n = 60  # TRIM_START(15) + effective(30) + TRIM_END(15) 최소 충족
+        data = {
+            "delta": np.random.uniform(0.1, 1.0, n),
+            "theta": np.random.uniform(0.1, 1.0, n),
+            "alpha": np.random.uniform(0.1, 1.0, n),
+            "beta": np.random.uniform(0.1, 1.0, n),
+            "gamma": np.random.uniform(0.1, 1.0, n),
+            "focus": np.random.uniform(0, 1, n),
+            "engagement": np.random.uniform(0, 1, n),
+            "interest": np.random.uniform(0, 1, n),
+            "excitement": np.random.uniform(0, 1, n),
+            "stress": np.random.uniform(0, 1, n),
+            "relaxation": np.random.uniform(0, 1, n),
+        }
+        return pd.DataFrame(data)
+
+    def test_sequential_returns_similarity_features(self, monkeypatch, waves_df):
+        """SEQUENTIAL 모드 → similarity_features dict 반환함"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [
+                Path(f"/fake/subject_{subject_index}_{group_id}.csv")
+            ],
+        )
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: waves_df.copy(),
+        )
+        result = analyze_pipeline_sequential(TEST_GROUP_ID)
+        assert isinstance(result["similarity_features"], dict)
+        assert "similarity_score" in result["similarity_features"]
+
+    def test_sequential_pair_features_is_none(self, monkeypatch, waves_df):
+        """SEQUENTIAL 모드 → pair_features=None (DUAL 전용 필드)"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [
+                Path(f"/fake/subject_{subject_index}_{group_id}.csv")
+            ],
+        )
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: waves_df.copy(),
+        )
+        result = analyze_pipeline_sequential(TEST_GROUP_ID)
+        assert result["pair_features"] is None
+
+    def test_sequential_csv_not_found_raises_value_error(self, monkeypatch):
+        """subject 1 CSV 없을 때 ValueError 발생함"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, subject_index: [],
+        )
+        with pytest.raises(ValueError, match="subject_index=1 CSV 미발견"):
+            analyze_pipeline_sequential(TEST_GROUP_ID)
+
+    def test_sequential_csv_not_found_subject2_raises_value_error(
+        self, monkeypatch, waves_df
+    ):
+        """subject 1은 CSV 있지만 subject 2 CSV 없을 때 ValueError 발생함"""
+
+        def mock_find(group_id, subject_index):
+            if subject_index == 1:
+                return [Path(f"/fake/subject_1_{group_id}.csv")]
+            return []
+
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            mock_find,
+        )
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: waves_df.copy(),
+        )
+        with pytest.raises(ValueError, match="subject_index=2 CSV 미발견"):
+            analyze_pipeline_sequential(TEST_GROUP_ID)
+
+    def test_dual_regression_pair_features_not_none(self, monkeypatch, full_session_df):
+        """DUAL 모드 기존 run_full_pipeline 동작 유지 — pair_features 존재함"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, idx: [Path(f"/fake/subject_{idx}_{group_id}.csv")],
+        )
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: full_session_df.copy(),
+        )
+        mock_analyzer = MagicMock()
+        mock_analyzer.calculate_synchrony.return_value = 0.75
+        monkeypatch.setattr(
+            "server.services.analysis.MindSignalAnalyzer",
+            lambda: mock_analyzer,
+        )
+        result = run_full_pipeline(TEST_GROUP_ID, [1, 2])
+        # DUAL 모드: pair_features 반드시 존재함 (회귀 검증)
+        assert result["pair_features"] is not None

--- a/tests/services/test_markdown.py
+++ b/tests/services/test_markdown.py
@@ -1,7 +1,5 @@
 """markdown 서비스 features_to_markdown 함수 단위 테스트 수행함"""
 
-import pytest
-
 from server.services.markdown import features_to_markdown
 
 
@@ -26,7 +24,7 @@ class TestFeaturesToMarkdown:
         """파이프(|) 구분자 기반 테이블 행 존재함"""
         result = features_to_markdown(1, sample_features)
         lines = result.split("\n")
-        pipe_lines = [l for l in lines if "|" in l]
+        pipe_lines = [line for line in lines if "|" in line]
         assert len(pipe_lines) > 0
 
     def test_band_names_in_header(self, sample_features):
@@ -39,7 +37,7 @@ class TestFeaturesToMarkdown:
         """데이터 행이 '| W' 형태로 시작함"""
         result = features_to_markdown(1, sample_features)
         lines = result.split("\n")
-        w_lines = [l for l in lines if l.strip().startswith("| W")]
+        w_lines = [line for line in lines if line.strip().startswith("| W")]
         assert len(w_lines) > 0
 
     def test_feature_count_footer(self, sample_features):

--- a/tests/services/test_similarity.py
+++ b/tests/services/test_similarity.py
@@ -1,0 +1,163 @@
+"""similarity Strategy Pattern 패키지 단위 테스트 수행함"""
+
+import pytest
+
+
+class TestRegistry:
+    def test_registry_contains_cosine_pearson_faa_after_import(self):
+        """import 후 REGISTRY에 'cosine_pearson_faa' 키 존재함"""
+        from server.services.similarity import REGISTRY
+
+        assert "cosine_pearson_faa" in REGISTRY
+
+    def test_unknown_algorithm_raises_value_error(self):
+        """존재하지 않는 알고리즘 이름 → ValueError 발생함"""
+        from server.services.similarity import compute
+
+        a = {
+            "waves_mean": {
+                "delta": 1.0,
+                "theta": 0.0,
+                "alpha": 0.0,
+                "beta": 0.0,
+                "gamma": 0.0,
+            },
+            "faa_mean": None,
+        }
+        with pytest.raises(ValueError, match="Unknown similarity strategy"):
+            compute(a, a, algorithm="nonexistent_algo")
+
+
+class TestCosinePearsonFAAStrategy:
+    """CosinePearsonFAAStrategy.compute 검증함"""
+
+    @pytest.fixture
+    def identical_subject(self):
+        """동일한 waves_mean + faa_mean=None 피실험자 데이터 반환함"""
+        return {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+
+    @pytest.fixture
+    def alpha_only_subject(self):
+        """alpha=1.0, 나머지=0.0인 피실험자 데이터 반환함"""
+        return {
+            "waves_mean": {
+                "delta": 0.0,
+                "theta": 0.0,
+                "alpha": 1.0,
+                "beta": 0.0,
+                "gamma": 0.0,
+            },
+            "faa_mean": None,
+        }
+
+    @pytest.fixture
+    def beta_only_subject(self):
+        """beta=1.0, 나머지=0.0인 피실험자 데이터 반환함"""
+        return {
+            "waves_mean": {
+                "delta": 0.0,
+                "theta": 0.0,
+                "alpha": 0.0,
+                "beta": 1.0,
+                "gamma": 0.0,
+            },
+            "faa_mean": None,
+        }
+
+    def test_identical_inputs_similarity_score_near_one(self, identical_subject):
+        """동일 입력 → similarity_score가 1.0에 매우 가까움"""
+        from server.services.similarity import compute
+
+        result = compute(identical_subject, identical_subject)
+        assert result["similarity_score"] >= 0.95
+
+    def test_orthogonal_vectors_overall_cosine_zero(
+        self, alpha_only_subject, beta_only_subject
+    ):
+        """직교 벡터 (alpha전용 vs beta전용) → overall_cosine == 0.0"""
+        from server.services.similarity import compute
+
+        result = compute(alpha_only_subject, beta_only_subject)
+        assert abs(result["overall_cosine"]) < 1e-9
+
+    def test_faa_mean_none_both_returns_dict_without_key_error(self, identical_subject):
+        """faa_mean=None 양측 → KeyError 없이 dict 반환, faa_absolute_diff is None"""
+        from server.services.similarity import compute
+
+        result = compute(identical_subject, identical_subject)
+        assert isinstance(result, dict)
+        assert result["faa_absolute_diff"] is None
+
+    def test_return_keys_complete(self, identical_subject):
+        """반환 dict에 필수 키 5개 모두 존재함"""
+        from server.services.similarity import compute
+
+        result = compute(identical_subject, identical_subject)
+        required_keys = {
+            "algorithm",
+            "similarity_score",
+            "overall_cosine",
+            "band_ratio_diff",
+            "faa_absolute_diff",
+        }
+        assert required_keys == set(result.keys())
+
+    def test_algorithm_field_value(self, identical_subject):
+        """algorithm 필드 값이 'cosine_pearson_faa'임"""
+        from server.services.similarity import compute
+
+        result = compute(identical_subject, identical_subject)
+        assert result["algorithm"] == "cosine_pearson_faa"
+
+    def test_similarity_score_range_zero_to_one(
+        self, alpha_only_subject, beta_only_subject
+    ):
+        """similarity_score는 항상 0~1 범위임"""
+        from server.services.similarity import compute
+
+        result = compute(alpha_only_subject, beta_only_subject)
+        assert 0.0 <= result["similarity_score"] <= 1.0
+
+    def test_faa_mean_provided_both_computes_absolute_diff(self):
+        """faa_mean 양측 모두 제공 시 faa_absolute_diff = abs(a - b)"""
+        from server.services.similarity import compute
+
+        a = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": 1.5,
+        }
+        b = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": 0.5,
+        }
+        result = compute(a, b)
+        assert abs(result["faa_absolute_diff"] - 1.0) < 1e-9
+
+    def test_band_ratio_diff_has_five_bands(self, identical_subject):
+        """band_ratio_diff dict에 5개 대역 키 존재함"""
+        from server.services.similarity import compute
+
+        result = compute(identical_subject, identical_subject)
+        expected_bands = {"delta", "theta", "alpha", "beta", "gamma"}
+        assert set(result["band_ratio_diff"].keys()) == expected_bands

--- a/tests/services/test_similarity.py
+++ b/tests/services/test_similarity.py
@@ -161,3 +161,131 @@ class TestCosinePearsonFAAStrategy:
         result = compute(identical_subject, identical_subject)
         expected_bands = {"delta", "theta", "alpha", "beta", "gamma"}
         assert set(result["band_ratio_diff"].keys()) == expected_bands
+
+    def test_missing_band_raises_value_error(self):
+        """waves_mean에 대역 누락 시 ValueError 발생함"""
+        from server.services.similarity import compute
+
+        a = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                # alpha 누락
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        b = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        with pytest.raises(ValueError, match="Missing bands in waves_mean"):
+            compute(a, b)
+
+    def test_nan_in_waves_mean_raises_value_error(self):
+        """waves_mean에 NaN 포함 시 ValueError 발생함"""
+        from server.services.similarity import compute
+
+        a = {
+            "waves_mean": {
+                "delta": float("nan"),
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        b = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        with pytest.raises(ValueError, match="NaN detected in waves_mean"):
+            compute(a, b)
+
+    def test_inf_in_waves_mean_raises_value_error(self):
+        """waves_mean에 Inf 포함 시 ValueError 발생함"""
+        from server.services.similarity import compute
+
+        a = {
+            "waves_mean": {
+                "delta": float("inf"),
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        b = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        with pytest.raises(ValueError, match="Inf detected in waves_mean"):
+            compute(a, b)
+
+    def test_zero_vector_returns_none_similarity_score_and_degraded(self):
+        """모든 대역=0인 영벡터 → similarity_score=None + degraded=True 반환함"""
+        from server.services.similarity import compute
+
+        zero_subject = {
+            "waves_mean": {
+                "delta": 0.0,
+                "theta": 0.0,
+                "alpha": 0.0,
+                "beta": 0.0,
+                "gamma": 0.0,
+            },
+            "faa_mean": None,
+        }
+        normal_subject = {
+            "waves_mean": {
+                "delta": 0.5,
+                "theta": 0.3,
+                "alpha": 0.8,
+                "beta": 0.4,
+                "gamma": 0.2,
+            },
+            "faa_mean": None,
+        }
+        result = compute(zero_subject, normal_subject)
+        assert result["similarity_score"] is None
+        assert result["degraded"] is True
+        assert result["degraded_reason"] == "zero_norm"
+
+    def test_orthogonal_score_zero_not_half(
+        self, alpha_only_subject, beta_only_subject
+    ):
+        """직교 벡터 → similarity_score=0.0 (이전 (cosine+1)/2 매핑의 0.5 아님)"""
+        from server.services.similarity import compute
+
+        result = compute(alpha_only_subject, beta_only_subject)
+        assert abs(result["similarity_score"]) < 1e-9
+
+    def test_identical_vectors_score_near_one_with_new_normalize(
+        self, identical_subject
+    ):
+        """동일 벡터 → max(0, cosine) 매핑에서도 similarity_score ≈ 1.0"""
+        from server.services.similarity import compute
+
+        result = compute(identical_subject, identical_subject)
+        assert result["similarity_score"] >= 0.95


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/14-dual-ble-resolution` (ANALYSIS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## Summary

Phase 14 DE similarity Strategy Pattern + SEQUENTIAL pipeline 분기 + verify Round 2 fix + team-workflow README 정렬을 main으로 릴리스.

### 포함된 변경 (9 commits)

**Phase 14 SEQUENTIAL + Strategy Pattern (PR #12 merged into dev)**
- `feat(similarity)` Strategy Pattern package — cosine_pearson_faa default + @register 데코레이터 + _registry.py
- `feat(routes)` /pipeline request에 mode + algorithm 필드 추가
- `feat(analysis)` SEQUENTIAL branch — compute_subject_summary 사용
- `test(analysis)` SEQUENTIAL pipeline + similarity edge cases integration

**CodeRabbit feedback**
- `fix(analysis)` subject_indices propagation + band 방어 + NaN 처리

**Verify Round 1/2 fix**
- `style(tests)` E501 위반 (conftest, analysis_pipeline test)
- `style(tests)` F401 + E741 pre-existing 위반 정리

**Team workflow align**
- `docs(readme)` FastAPI 실행 가이드 + CI section + issue-based flow + main direct commit 금지

### 검증 (로컬 실측, `627f3bb`)

- ✅ pytest (87 passed, conda env mind-signal)
- ✅ flake8 server/ tests/ (0)

---

Ref: `.plans/14-dual-ble-resolution/CHECKLIST.md`