### PR TITLE
feat(17.5): DE runtime group assign (hot-fix)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,14 @@ FASTAPI_PORT=5002
 # Registration mode
 REGISTRATION_MODE=local          # local | ngrok
 BACKEND_URL=http://localhost:5000
+# ⚠️ placeholder 값(your-shared-secret-here / change-me-in-production)은 Preflight hard-gate에 의해 lifespan이 abort됨
 ENGINE_SECRET_KEY=your-shared-secret-here
 LAN_IP=                          # 빈 값이면 socket.gethostbyname 자동 탐지
 
-# DUAL_2PC 세션 env (launcher에서 주입, 비-DUAL_2PC 기동 시 비워둠)
+# DUAL_2PC 세션 env (Phase 17.5)
+# 방식 1 (즉시 등록, backward-compat): GROUP_ID + SUBJECT_INDEX 둘 다 설정
+# 방식 2 (pending, 권장): SUBJECT_INDEX만 설정. groupId는 /control/assign-group 런타임 주입
+# 방식 3 (SEQUENTIAL): 둘 다 비움
 DUAL_2PC_GROUP_ID=
 DUAL_2PC_SUBJECT_INDEX=
 

--- a/scripts/assign_group.ps1
+++ b/scripts/assign_group.ps1
@@ -1,0 +1,29 @@
+# DUAL_2PC 세션에 groupId 주입 wrapper (PowerShell 버전) — Phase 17.5
+# Usage: .\scripts\assign_group.ps1 -GroupId <id> -DeA <url> -DeB <url> [-Secret <s>]
+#   Secret: optional. 생략 시 env ENGINE_SECRET_KEY 사용함
+
+param(
+  [Parameter(Mandatory = $true)][string]$GroupId,
+  [Parameter(Mandatory = $true)][string]$DeA,
+  [Parameter(Mandatory = $true)][string]$DeB,
+  [string]$Secret = $env:ENGINE_SECRET_KEY
+)
+
+if (-not $Secret) {
+  Write-Error "secret missing: -Secret <s> or set env ENGINE_SECRET_KEY"
+  exit 1
+}
+
+$headers = @{
+  "Content-Type"    = "application/json"
+  "X-Engine-Secret" = $Secret
+}
+$body = @{ group_id = $GroupId } | ConvertTo-Json -Compress
+
+Write-Host "[assign] DE A -> $DeA/control/assign-group"
+Invoke-RestMethod -Method POST -Uri "$DeA/control/assign-group" -Headers $headers -Body $body
+
+Write-Host "[assign] DE B -> $DeB/control/assign-group"
+Invoke-RestMethod -Method POST -Uri "$DeB/control/assign-group" -Headers $headers -Body $body
+
+Write-Host "[assign] done"

--- a/scripts/assign_group.sh
+++ b/scripts/assign_group.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# DUAL_2PC 세션에 groupId 주입 wrapper — Phase 17.5
+# Usage: ./scripts/assign_group.sh <group_id> <de_url_1> <de_url_2> [secret]
+#   secret: optional 4번째 인자. 생략 시 env ENGINE_SECRET_KEY 사용함
+# Example: ./scripts/assign_group.sh 507f1f77... https://abc.ngrok.app https://xyz.ngrok.app mysecret
+set -e
+
+GROUP_ID="$1"
+DE_A="$2"
+DE_B="$3"
+ENGINE_SECRET="${4:-${ENGINE_SECRET_KEY:-}}"
+
+if [ -z "$GROUP_ID" ] || [ -z "$DE_A" ] || [ -z "$DE_B" ]; then
+  echo "Usage: $0 <group_id> <de_url_1> <de_url_2> [secret]" >&2
+  exit 1
+fi
+if [ -z "$ENGINE_SECRET" ]; then
+  echo "[error] secret missing: pass as 4th arg or set ENGINE_SECRET_KEY env" >&2
+  exit 1
+fi
+
+echo "[assign] DE A → ${DE_A}/control/assign-group"
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Engine-Secret: ${ENGINE_SECRET}" \
+  -d "{\"group_id\": \"${GROUP_ID}\"}" \
+  "${DE_A}/control/assign-group"
+echo ""
+
+echo "[assign] DE B → ${DE_B}/control/assign-group"
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Engine-Secret: ${ENGINE_SECRET}" \
+  -d "{\"group_id\": \"${GROUP_ID}\"}" \
+  "${DE_B}/control/assign-group"
+echo ""
+
+echo "[assign] done"

--- a/server/app.py
+++ b/server/app.py
@@ -6,20 +6,43 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 
 from server.config import settings
-from server.routes import analyze, export, health, stream
+from server.routes import analyze, control, export, health, stream
 from server.services.webhook import (
     register_to_backend,
     register_to_backend_dual,
     start_heartbeat,
+    start_heartbeat_dual,
 )
 
 load_dotenv(".env.local")
 
+# Preflight hard-gate: ENGINE_SECRET_KEY가 placeholder면 lifespan 기동 차단함 (Phase 17.5)
+# placeholder 상태로 공개 ngrok URL에 /control/assign-group이 열리는 사고 방지
+PLACEHOLDER_SECRETS = {
+    "your-shared-secret-here",
+    "change-me-in-production",
+    "",
+}
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """서버 시작 시 URL 결정 + 백엔드 등록 + heartbeat 수행함"""
-    # --- startup ---
+    """서버 시작 시 URL 결정 + 백엔드 등록(모드별 분기) + heartbeat 수행함.
+
+    분기 (Phase 17.5 도입):
+    1) dual_2pc_group_id + subject_index 둘 다 env → 즉시 register-dual +
+       dual heartbeat (backward-compat)
+    2) subject_index만 env → pending 상태 기동 → /control/assign-group 대기
+       (heartbeat 미생성)
+    3) 둘 다 없음 → SEQUENTIAL register + single heartbeat (backward-compat)
+    """
+    # Preflight hard-gate: placeholder secret 감지 시 abort 수행함
+    if settings.engine_secret_key in PLACEHOLDER_SECRETS:
+        print(
+            f"DE startup aborted: ENGINE_SECRET_KEY is placeholder "
+            f"('{settings.engine_secret_key}'). 실제 값을 .env.local 또는 환경변수로 설정할 것."
+        )
+        raise SystemExit(1)
 
     # public_url 결정 (registration_mode 기반)
     if settings.registration_mode == "ngrok":
@@ -32,38 +55,60 @@ async def lifespan(app: FastAPI):
         lan_ip = settings.lan_ip or socket.gethostbyname(socket.gethostname())
         public_url = f"http://{lan_ip}:{settings.fastapi_port}"
 
+    # app.state 초기화 (Phase 17.5) — 모든 분기 공통
     app.state.public_url = public_url
+    app.state.subject_index = settings.dual_2pc_subject_index
+    app.state.secret_key = settings.engine_secret_key
+    app.state.registered_group_id = None
+    app.state.heartbeat_task = None  # 분기 2는 미생성 → shutdown 가드용
+    app.state.assign_lock = asyncio.Lock()
 
-    # DUAL_2PC 모드 판별 (env 주입 여부)
-    is_dual_2pc = (
-        settings.dual_2pc_group_id is not None
-        and settings.dual_2pc_subject_index is not None
-    )
+    # 모드 판별
+    has_group_id = settings.dual_2pc_group_id is not None
+    has_subject_index = settings.dual_2pc_subject_index is not None
 
     try:
-        if is_dual_2pc:
+        if has_group_id and has_subject_index:
+            # 분기 1: 즉시 DUAL_2PC 등록
             await register_to_backend_dual(
                 public_url,
                 settings.dual_2pc_group_id,
                 settings.dual_2pc_subject_index,
                 settings.engine_secret_key,
             )
+            app.state.registered_group_id = settings.dual_2pc_group_id
+            app.state.heartbeat_task = asyncio.create_task(
+                start_heartbeat_dual(
+                    public_url,
+                    settings.dual_2pc_group_id,
+                    settings.dual_2pc_subject_index,
+                    settings.engine_secret_key,
+                )
+            )
+        elif has_subject_index:
+            # 분기 2: pending — BE 등록 하지 않음. /control/assign-group 대기함
+            print(
+                f"DE pending: subject_index={settings.dual_2pc_subject_index}, "
+                f"awaiting POST /control/assign-group"
+            )
         else:
+            # 분기 3: SEQUENTIAL (backward-compat)
             await register_to_backend(public_url, settings.engine_secret_key)
+            app.state.heartbeat_task = asyncio.create_task(
+                start_heartbeat(public_url, settings.engine_secret_key)
+            )
     except Exception as e:
         # [RC3-1 반영] DE 서버 전체가 print() 사용 — 기존 convention 유지
         print(f"DE registration failed: {e}")
         raise SystemExit(1)
 
-    # heartbeat task (기존 — 5분마다 백엔드에 재등록)
-    heartbeat_task = asyncio.create_task(
-        start_heartbeat(public_url, settings.engine_secret_key)
-    )
-
     yield
 
     # --- shutdown ---
-    heartbeat_task.cancel()
+    # heartbeat_task 가드 (분기 2는 None 가능)
+    if app.state.heartbeat_task is not None:
+        app.state.heartbeat_task.cancel()
+
     if settings.registration_mode == "ngrok":
         from pyngrok import ngrok
 
@@ -80,3 +125,4 @@ app.include_router(health.router, tags=["Health"])
 app.include_router(analyze.router, prefix="/api", tags=["Analyze"])
 app.include_router(export.router, prefix="/api", tags=["Export"])
 app.include_router(stream.router, prefix="/api", tags=["Stream"])
+app.include_router(control.router, tags=["Control"])

--- a/server/routes/control.py
+++ b/server/routes/control.py
@@ -1,0 +1,99 @@
+"""Control 라우터 — DUAL_2PC runtime groupId 주입 엔드포인트 제공함 (Phase 17.5)"""
+
+import asyncio
+
+import httpx
+from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from server.services.webhook import (
+    register_to_backend_dual,
+    start_heartbeat_dual,
+)
+
+router = APIRouter()
+
+
+class AssignGroupRequest(BaseModel):
+    """/control/assign-group 요청 바디 스키마임"""
+
+    group_id: str = Field(
+        ..., min_length=1, description="DUAL_2PC groupId (MongoDB ObjectId 24자 hex)"
+    )
+
+
+@router.post("/control/assign-group")
+async def assign_group(
+    body: AssignGroupRequest,
+    request: Request,
+    x_engine_secret: str = Header(alias="X-Engine-Secret"),
+):
+    """DUAL_2PC groupId 런타임 주입 + BE /register-dual 트리거 처리함.
+
+    멱등 계약:
+    - pending → register-dual 호출 후 200 registered + heartbeat 시작함
+    - same group_id 재호출 → 200 already_registered (register 재호출 금지, heartbeat 재생성 금지)
+    - different group_id → 409 group_id_conflict 반환함
+    - secret mismatch → 401 invalid_secret 반환함
+    - BE 실패 → 502 backend_register_failed 반환함 + state는 pending 유지(재시도 가능)
+
+    asyncio.Lock으로 race 방지함 — 동시 2건 요청 시 직렬화 처리함.
+    """
+    app = request.app
+
+    # secret 검증 (401)
+    if x_engine_secret != app.state.secret_key:
+        raise HTTPException(status_code=401, detail={"error": "invalid_secret"})
+
+    # subject_index 설정 여부 확인 (pending 모드가 아니면 config 에러)
+    if app.state.subject_index is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "not_pending_mode",
+                "reason": "DUAL_2PC_SUBJECT_INDEX env 필수",
+            },
+        )
+
+    # Lock 내부에서 state 전이 — race 방지함
+    async with app.state.assign_lock:
+        current = app.state.registered_group_id
+
+        # 멱등: same group_id → backend 재호출 금지, heartbeat 재생성 금지
+        if current == body.group_id:
+            return {"status": "already_registered", "groupId": body.group_id}
+
+        # 다른 groupId 이미 등록됨 → 409
+        if current is not None:
+            raise HTTPException(
+                status_code=409,
+                detail={"error": "group_id_conflict", "current": current},
+            )
+
+        # 신규 등록 경로: BE /register-dual 호출함
+        try:
+            await register_to_backend_dual(
+                app.state.public_url,
+                body.group_id,
+                app.state.subject_index,
+                app.state.secret_key,
+            )
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
+            # 실패 시 state pending 유지 (재시도 허용함)
+            raise HTTPException(
+                status_code=502,
+                detail={"error": "backend_register_failed", "detail": str(e)},
+            )
+
+        # 등록 성공 — state 업데이트 + heartbeat 시작함
+        app.state.registered_group_id = body.group_id
+        app.state.heartbeat_task = asyncio.create_task(
+            start_heartbeat_dual(
+                app.state.public_url,
+                body.group_id,
+                app.state.subject_index,
+                app.state.secret_key,
+            )
+        )
+
+        return {"status": "registered", "groupId": body.group_id}

--- a/server/services/webhook.py
+++ b/server/services/webhook.py
@@ -51,7 +51,7 @@ async def register_to_backend_dual(
 
 
 async def start_heartbeat(public_url: str, secret_key: str):
-    """주기적으로 백엔드에 엔진 URL을 재등록하는 heartbeat 태스크임"""
+    """주기적으로 백엔드에 엔진 URL을 재등록하는 heartbeat 태스크임 (SEQUENTIAL mode 전용)"""
     while True:
         await asyncio.sleep(HEARTBEAT_INTERVAL_SEC)
         try:
@@ -61,3 +61,21 @@ async def start_heartbeat(public_url: str, secret_key: str):
             # R2-1: register_to_backend가 RC-7로 naked 됐으므로 여기서 명시 보호
             # [RC3-1 반영] DE 서버 전체가 print() 사용 — 기존 convention 유지
             print(f"heartbeat register failed (non-fatal): {e}")
+
+
+async def start_heartbeat_dual(
+    public_url: str,
+    group_id: str,
+    subject_index: int,
+    secret_key: str,
+):
+    """DUAL_2PC mode 전용 heartbeat — 5분마다 register-dual 재호출함 (Phase 17.5)"""
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SEC)
+        try:
+            await register_to_backend_dual(
+                public_url, group_id, subject_index, secret_key
+            )
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
+            # heartbeat transient error 허용함 (log-and-continue)
+            print(f"dual heartbeat register failed (non-fatal): {e}")

--- a/tests/routes/test_control.py
+++ b/tests/routes/test_control.py
@@ -1,0 +1,204 @@
+"""control 라우터 pytest — /control/assign-group 9건 (Phase 17.5)"""
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_httpx import HTTPXMock
+
+from server.config import settings
+from server.routes import control
+
+TEST_SECRET = "test-engine-secret"
+TEST_GROUP_ID = "507f1f77bcf86cd799439011"
+ANOTHER_GROUP_ID = "aaaaaaaaaaaaaaaaaaaaaaaa"
+BACKEND_DUAL_URL = f"{settings.backend_url}/api/engine/register-dual"
+
+
+def _build_pending_app():
+    """pending 상태 DE app 생성함 (lifespan 없이 state만 초기화)"""
+    app = FastAPI()
+    app.include_router(control.router)
+    app.state.public_url = "http://testhost:5002"
+    app.state.subject_index = 1
+    app.state.secret_key = TEST_SECRET
+    app.state.registered_group_id = None
+    app.state.heartbeat_task = None
+    app.state.assign_lock = asyncio.Lock()
+    return app
+
+
+@pytest.fixture
+def pending_app():
+    """pending app fixture — teardown 시 heartbeat_task 정리함"""
+    app = _build_pending_app()
+    yield app
+    # teardown: heartbeat_task cancel 수행함
+    if app.state.heartbeat_task is not None:
+        app.state.heartbeat_task.cancel()
+
+
+def _assign(client: TestClient, group_id: str, secret: str = TEST_SECRET):
+    """공통 assign-group 요청 헬퍼 반환함"""
+    return client.post(
+        "/control/assign-group",
+        json={"group_id": group_id},
+        headers={"X-Engine-Secret": secret},
+    )
+
+
+def test_assign_group_new_registration_returns_200(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """pending 상태에서 신규 assign → 200 registered + state 전이 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    resp = _assign(client, TEST_GROUP_ID)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "registered"
+    assert body["groupId"] == TEST_GROUP_ID
+    assert pending_app.state.registered_group_id == TEST_GROUP_ID
+    assert pending_app.state.heartbeat_task is not None
+
+
+def test_assign_group_idempotent_same_group_returns_200(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """이미 X로 등록된 상태에서 X 재호출 → 200 already_registered 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    first = _assign(client, TEST_GROUP_ID)
+    assert first.status_code == 200
+
+    second = _assign(client, TEST_GROUP_ID)
+    assert second.status_code == 200
+    assert second.json()["status"] == "already_registered"
+    assert second.json()["groupId"] == TEST_GROUP_ID
+
+
+def test_assign_group_idempotent_no_backend_re_call(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """same group_id 재호출 시 register_to_backend_dual 호출 카운트 1 유지 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    _assign(client, TEST_GROUP_ID)
+    _assign(client, TEST_GROUP_ID)
+    _assign(client, TEST_GROUP_ID)
+
+    # httpx_mock은 등록된 요청 순서로 매칭함. 총 호출 수가 1이어야 멱등 성립함
+    requests = httpx_mock.get_requests(url=BACKEND_DUAL_URL)
+    assert len(requests) == 1
+
+
+def test_assign_group_idempotent_no_heartbeat_duplicate(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """same group_id 재호출 시 heartbeat_task 동일 객체(재생성 안 됨) 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    _assign(client, TEST_GROUP_ID)
+    task_first = pending_app.state.heartbeat_task
+    assert task_first is not None
+
+    _assign(client, TEST_GROUP_ID)
+    task_second = pending_app.state.heartbeat_task
+
+    # 재호출이 heartbeat 재생성을 하지 않아야 함 — 동일 Task 객체여야 함
+    assert task_second is task_first
+
+
+def test_assign_group_concurrent_requests_serialized(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """동시 2건 요청 → Lock 직렬화 → 하나 registered, 다른 하나 already_registered 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+
+    # TestClient는 동기 wrapper라 asyncio.gather로 httpx.AsyncClient 사용함
+    from httpx import ASGITransport, AsyncClient
+
+    async def _concurrent():
+        transport = ASGITransport(app=pending_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            payload = {"group_id": TEST_GROUP_ID}
+            headers = {"X-Engine-Secret": TEST_SECRET}
+            return await asyncio.gather(
+                ac.post("/control/assign-group", json=payload, headers=headers),
+                ac.post("/control/assign-group", json=payload, headers=headers),
+            )
+
+    results = asyncio.get_event_loop().run_until_complete(_concurrent())
+
+    statuses = sorted([r.json()["status"] for r in results])
+    assert statuses == ["already_registered", "registered"]
+    # backend 호출은 정확히 1회만 발생해야 함 (Lock 직렬화 증거)
+    requests = httpx_mock.get_requests(url=BACKEND_DUAL_URL)
+    assert len(requests) == 1
+
+
+def test_assign_group_different_group_returns_409(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """X 등록됨 + Y 호출 → 409 group_id_conflict 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    _assign(client, TEST_GROUP_ID)
+    resp = _assign(client, ANOTHER_GROUP_ID)
+
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["detail"]["error"] == "group_id_conflict"
+    assert body["detail"]["current"] == TEST_GROUP_ID
+
+
+def test_assign_group_invalid_body_returns_422(pending_app: FastAPI):
+    """잘못된 body → FastAPI validation 422 확인함 (pydantic 기본)"""
+    client = TestClient(pending_app)
+    resp = client.post(
+        "/control/assign-group",
+        json={},
+        headers={"X-Engine-Secret": TEST_SECRET},
+    )
+    # FastAPI/pydantic 기본 unprocessable entity
+    assert resp.status_code == 422
+
+
+def test_assign_group_invalid_secret_returns_401(pending_app: FastAPI):
+    """헤더 secret mismatch → 401 invalid_secret 확인함"""
+    client = TestClient(pending_app)
+    resp = _assign(client, TEST_GROUP_ID, secret="wrong-secret")
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "invalid_secret"
+
+
+def test_assign_group_backend_failure_returns_502(
+    pending_app: FastAPI, httpx_mock: HTTPXMock
+):
+    """BE /register-dual 실패 → 502 + state pending 유지 + 재시도 가능 확인함"""
+    # 첫 호출은 실패함
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=500)
+
+    client = TestClient(pending_app)
+    resp = _assign(client, TEST_GROUP_ID)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["error"] == "backend_register_failed"
+    # state는 pending 유지 — 재시도 가능함
+    assert pending_app.state.registered_group_id is None
+    assert pending_app.state.heartbeat_task is None
+
+    # 두번째 호출은 성공 → 정상 register 가능 확인함
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    resp2 = _assign(client, TEST_GROUP_ID)
+    assert resp2.status_code == 200
+    assert resp2.json()["status"] == "registered"
+    assert pending_app.state.registered_group_id == TEST_GROUP_ID

--- a/tests/services/test_heartbeat_dual.py
+++ b/tests/services/test_heartbeat_dual.py
@@ -1,0 +1,69 @@
+"""start_heartbeat_dual pytest — DUAL heartbeat 신규 함수 검증함 (Phase 17.5)"""
+
+import asyncio
+from unittest.mock import patch
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from server.config import settings
+from server.services import webhook
+from server.services.webhook import start_heartbeat_dual
+
+TEST_GROUP_ID = "507f1f77bcf86cd799439011"
+BACKEND_DUAL_URL = f"{settings.backend_url}/api/engine/register-dual"
+
+
+@pytest.mark.asyncio
+async def test_start_heartbeat_dual_calls_register_to_backend_dual(httpx_mock):
+    """heartbeat 한 tick 후 register_to_backend_dual 호출 확인함"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+
+    # HEARTBEAT_INTERVAL_SEC을 0.05s로 monkeypatch — 1 tick 빠르게 트리거함
+    with patch.object(webhook, "HEARTBEAT_INTERVAL_SEC", 0.05):
+        task = asyncio.create_task(
+            start_heartbeat_dual(
+                "http://testhost:5002", TEST_GROUP_ID, 1, "test-secret"
+            )
+        )
+        # 1 tick 이상 대기함
+        await asyncio.sleep(0.12)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # register-dual 호출 1회 이상 발생 확인함
+    requests = httpx_mock.get_requests(url=BACKEND_DUAL_URL)
+    assert len(requests) >= 1
+
+
+@pytest.mark.asyncio
+async def test_start_heartbeat_dual_handles_transient_errors(
+    httpx_mock: HTTPXMock,
+):
+    """httpx.RequestError 발생 시 log-and-continue — task 죽지 않음 확인함"""
+    # 하나의 exception만 설정 — 남은 mock 검증 실패 회피함
+    httpx_mock.add_exception(httpx.ConnectTimeout("simulated timeout"))
+
+    with patch.object(webhook, "HEARTBEAT_INTERVAL_SEC", 0.02):
+        task = asyncio.create_task(
+            start_heartbeat_dual(
+                "http://testhost:5002", TEST_GROUP_ID, 1, "test-secret"
+            )
+        )
+        # 1 tick 대기함
+        await asyncio.sleep(0.04)
+        # exception 발생 후에도 task가 살아있는지 확인함 (log-and-continue 핵심)
+        assert not task.done()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # exception도 request로 카운트됨 — 최소 1회 호출 발생
+    requests = httpx_mock.get_requests(url=BACKEND_DUAL_URL)
+    assert len(requests) >= 1

--- a/tests/test_lifespan_dual_2pc.py
+++ b/tests/test_lifespan_dual_2pc.py
@@ -1,0 +1,121 @@
+"""lifespan 3분기 + preflight + shutdown 가드 pytest (Phase 17.5)"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+
+from server.config import settings
+from server.services import webhook
+
+TEST_VALID_SECRET = "test-valid-secret"
+TEST_GROUP_ID = "507f1f77bcf86cd799439011"
+BACKEND_URL = f"{settings.backend_url}/api/engine/register"
+BACKEND_DUAL_URL = f"{settings.backend_url}/api/engine/register-dual"
+
+
+@asynccontextmanager
+async def _run_lifespan(app: FastAPI):
+    """lifespan contextmanager 래퍼 — startup + yield + shutdown 수행함"""
+    async with app.router.lifespan_context(app):
+        yield
+
+
+def _import_fresh_app():
+    """import 캐시 bypass 후 server.app 모듈 재로딩함"""
+    import importlib
+
+    import server.app as mod
+
+    return importlib.reload(mod)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_placeholder_secret_aborts(monkeypatch):
+    """preflight hard-gate — placeholder secret 감지 시 SystemExit(1) 발생 확인함"""
+    monkeypatch.setattr(settings, "engine_secret_key", "your-shared-secret-here")
+    monkeypatch.setattr(settings, "dual_2pc_group_id", None)
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", None)
+
+    mod = _import_fresh_app()
+
+    with pytest.raises(SystemExit) as exc_info:
+        async with _run_lifespan(mod.app):
+            pass
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_dual_env_immediate_register(monkeypatch, httpx_mock):
+    """분기 1 — dual env 둘 다 있음 → register-dual 즉시 호출 + heartbeat 생성 확인함"""
+    monkeypatch.setattr(settings, "engine_secret_key", TEST_VALID_SECRET)
+    monkeypatch.setattr(settings, "dual_2pc_group_id", TEST_GROUP_ID)
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", 1)
+    monkeypatch.setattr(settings, "registration_mode", "local")
+    monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+
+    # HEARTBEAT_INTERVAL_SEC을 길게 (테스트 중 tick 발생 방지)
+    with patch.object(webhook, "HEARTBEAT_INTERVAL_SEC", 3600):
+        mod = _import_fresh_app()
+        async with _run_lifespan(mod.app):
+            assert mod.app.state.registered_group_id == TEST_GROUP_ID
+            assert mod.app.state.heartbeat_task is not None
+            assert not mod.app.state.heartbeat_task.done()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_pending_no_register_no_heartbeat(monkeypatch):
+    """분기 2 — subject_index만 있음 → 등록 안 함 + heartbeat None 확인함"""
+    monkeypatch.setattr(settings, "engine_secret_key", TEST_VALID_SECRET)
+    monkeypatch.setattr(settings, "dual_2pc_group_id", None)
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", 2)
+    monkeypatch.setattr(settings, "registration_mode", "local")
+    monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+
+    mod = _import_fresh_app()
+    async with _run_lifespan(mod.app):
+        assert mod.app.state.registered_group_id is None
+        assert mod.app.state.heartbeat_task is None
+        assert mod.app.state.subject_index == 2
+        # assign_lock이 초기화됨 확인함
+        assert isinstance(mod.app.state.assign_lock, asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_pending_shutdown_no_crash(monkeypatch):
+    """분기 2 shutdown crash 방지 — heartbeat_task None 가드 확인함 (rev.2 C-NEW-1)"""
+    monkeypatch.setattr(settings, "engine_secret_key", TEST_VALID_SECRET)
+    monkeypatch.setattr(settings, "dual_2pc_group_id", None)
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", 1)
+    monkeypatch.setattr(settings, "registration_mode", "local")
+    monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+
+    mod = _import_fresh_app()
+    # shutdown 시 heartbeat_task가 None이어도 AttributeError/UnboundLocalError 없이 종료해야 함
+    async with _run_lifespan(mod.app):
+        assert mod.app.state.heartbeat_task is None
+    # 여기까지 도달하면 shutdown 정상 종료 확인됨
+
+
+@pytest.mark.asyncio
+async def test_lifespan_single_legacy_register(monkeypatch, httpx_mock):
+    """분기 3 — 둘 다 없음 → SEQUENTIAL register + single heartbeat 확인함"""
+    monkeypatch.setattr(settings, "engine_secret_key", TEST_VALID_SECRET)
+    monkeypatch.setattr(settings, "dual_2pc_group_id", None)
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", None)
+    monkeypatch.setattr(settings, "registration_mode", "local")
+    monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+
+    httpx_mock.add_response(url=BACKEND_URL, method="POST", status_code=200)
+
+    with patch.object(webhook, "HEARTBEAT_INTERVAL_SEC", 3600):
+        mod = _import_fresh_app()
+        async with _run_lifespan(mod.app):
+            assert mod.app.state.registered_group_id is None
+            assert mod.app.state.heartbeat_task is not None
+            # heartbeat는 single mode — dual이 아닌 legacy register 대상
+            assert not mod.app.state.heartbeat_task.done()


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/17.5-de-runtime-group-assign` (EEG-W103)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## Summary

Phase 17 실기기 직전 발견한 UX 블로커 수정. 팀장 노트북(subject 2)에서 `python run_server.py` 한 줄로 DE 기동 가능하게 함. `DUAL_2PC_GROUP_ID` 수동 env 주입 제거.

DE-only 변경. BE/FE main HEAD 유지. 사용자 제약 "Python에서 끝낼 수 있는 수정만 승인".

## Changes

### Code (3)
- `server/services/webhook.py` — `start_heartbeat_dual` 신규 함수 추가
- `server/routes/control.py` — **신규** `POST /control/assign-group` (멱등 + Lock)
- `server/app.py` — lifespan 3분기 + placeholder preflight + shutdown 가드

### Config/Scripts (3)
- `.env.example` — DUAL_2PC 3 방식 주석 + placeholder 경고
- `scripts/assign_group.sh` — bash wrapper
- `scripts/assign_group.ps1` — PowerShell wrapper

### Tests (3 files, +16 cases)
- `tests/routes/test_control.py` — 9 cases (멱등/race/409/401/400/502)
- `tests/services/test_heartbeat_dual.py` — 2 cases
- `tests/test_lifespan_dual_2pc.py` — 5 cases (분기 1/2/3 + shutdown + preflight)

## 계약

`POST /control/assign-group` with `X-Engine-Secret` 헤더 + `{group_id}` body.

| 상태 | HTTP |
|------|------|
| pending → 신규 | 200 registered |
| same groupId | 200 already_registered (idempotent) |
| different groupId | 409 conflict |
| secret mismatch | 401 invalid_secret |
| BE 실패 | 502 backend_register_failed (재시도 가능) |

Race 방지: `asyncio.Lock` 으로 핸들러 전체 보호.

## Verify

- black/isort/flake8: clean
- pytest: **115 passed** (기존 99 + 신규 16)

## Review 이력

- plan-review-deep rev.1 → request-changes (Critical 3건)
- plan-review-deep rev.2 → request-changes (Critical 2건 신규)
- rev.2 inline patch → execute 진입
- Opus + Codex 병렬 review 각 2 round

## Test plan

- [x] black/isort/flake8 clean
- [x] pytest 115/115 PASS
- [ ] 실기기 dry-run (mock DE pending 2대 + assign_group.sh)
- [ ] 실기기 real EMOTIV Scenario 1

## Note

DE는 dev까지만 머지 (정책). main 머지 없음. Heroku/Vercel 재배포 불필요.

⚠️ **실기기 전 BLOCKING**: Heroku `ENGINE_SECRET_KEY=your-shared-secret-here` placeholder 상태. DE Preflight가 이 값을 감지하면 `SystemExit(1)`로 abort하므로, 실제 값으로 반드시 교체 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 런타임에 그룹 ID를 동적으로 할당할 수 있는 제어 엔드포인트 추가
  * 이중 2PC 구성 모드 지원 (즉시 등록, 대기, 순차 모드)
  * 보안 키 검증을 통한 시작 시 안전성 강화

* **개선 사항**
  * 그룹 ID 할당을 위한 스크립트 유틸리티 추가
  * 향상된 하트비트 및 등록 메커니즘

<!-- end of auto-generated comment: release notes by coderabbit.ai -->