### PR TITLE
refactor(17.5.1): relax placeholder preflight to WARN

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -16,8 +16,10 @@ from server.services.webhook import (
 
 load_dotenv(".env.local")
 
-# Preflight hard-gate: ENGINE_SECRET_KEY가 placeholder면 lifespan 기동 차단함 (Phase 17.5)
-# placeholder 상태로 공개 ngrok URL에 /control/assign-group이 열리는 사고 방지
+# Preflight soft-check: ENGINE_SECRET_KEY가 placeholder면 WARNING 로그만 출력함
+# (Phase 17.5.1 — abort 제거). 실기기 테스트 등 placeholder 그대로 쓰다가 실험 후
+# 보완하는 흐름을 허용함. 공개 ngrok URL에 /control/assign-group 노출 리스크는
+# 경고로만 안내함
 PLACEHOLDER_SECRETS = {
     "your-shared-secret-here",
     "change-me-in-production",
@@ -36,13 +38,14 @@ async def lifespan(app: FastAPI):
        (heartbeat 미생성)
     3) 둘 다 없음 → SEQUENTIAL register + single heartbeat (backward-compat)
     """
-    # Preflight hard-gate: placeholder secret 감지 시 abort 수행함
+    # Preflight soft-check: placeholder secret 감지 시 WARNING만 출력함 (Phase 17.5.1)
     if settings.engine_secret_key in PLACEHOLDER_SECRETS:
         print(
-            f"DE startup aborted: ENGINE_SECRET_KEY is placeholder "
-            f"('{settings.engine_secret_key}'). 실제 값을 .env.local 또는 환경변수로 설정할 것."
+            "[WARN] ENGINE_SECRET_KEY가 placeholder 값임 "
+            f"('{settings.engine_secret_key}'). /control/assign-group이 "
+            "공개 ngrok URL에서 사실상 검증 없이 열림. 실기기 테스트 후 "
+            "실제 값으로 교체 권장함."
         )
-        raise SystemExit(1)
 
     # public_url 결정 (registration_mode 기반)
     if settings.registration_mode == "ngrok":

--- a/tests/test_lifespan_dual_2pc.py
+++ b/tests/test_lifespan_dual_2pc.py
@@ -33,18 +33,28 @@ def _import_fresh_app():
 
 
 @pytest.mark.asyncio
-async def test_lifespan_placeholder_secret_aborts(monkeypatch):
-    """preflight hard-gate — placeholder secret 감지 시 SystemExit(1) 발생 확인함"""
+async def test_lifespan_placeholder_secret_warns_but_continues(
+    monkeypatch, httpx_mock, capsys
+):
+    """preflight soft-check — placeholder secret 경고 로그 출력 후 정상 기동 확인함 (Phase 17.5.1)"""
     monkeypatch.setattr(settings, "engine_secret_key", "your-shared-secret-here")
     monkeypatch.setattr(settings, "dual_2pc_group_id", None)
     monkeypatch.setattr(settings, "dual_2pc_subject_index", None)
+    monkeypatch.setattr(settings, "registration_mode", "local")
+    monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
 
-    mod = _import_fresh_app()
+    # SEQUENTIAL register 모의함
+    httpx_mock.add_response(url=BACKEND_URL, method="POST", status_code=200)
 
-    with pytest.raises(SystemExit) as exc_info:
+    with patch.object(webhook, "HEARTBEAT_INTERVAL_SEC", 3600):
+        mod = _import_fresh_app()
+        # placeholder 상태여도 lifespan abort 없이 정상 진입해야 함
         async with _run_lifespan(mod.app):
-            pass
-    assert exc_info.value.code == 1
+            captured = capsys.readouterr()
+            assert "[WARN]" in captured.out
+            assert "placeholder" in captured.out
+            # 기동은 계속 진행됨
+            assert mod.app.state.assign_lock is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/17.5-de-runtime-group-assign` (EEG-W103)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## Summary

Phase 17.5에서 도입한 `SystemExit(1)` preflight가 실기기 당일 placeholder secret으로 바로 기동하는 흐름을 막는 역효과. abort 제거하고 WARNING 로그만 남김.

## Rationale

사용자 피드백: "일단 비밀키 값을 기본 버전으로 넣고 그 이후에 수정하면 되는 거 아님?" — 사실 맞는 지적. 미리 무작위 문자열로 바꿀 필요 없이 실기기 후 보완해도 됨.

## Changes

- `server/app.py` — Preflight SystemExit(1) 제거, WARN print로 교체
- `tests/test_lifespan_dual_2pc.py` — placeholder abort test → placeholder warn+continue test로 변경

## Verify

- black/isort/flake8 clean
- pytest: **115 passed** (115 유지)

## Test plan

- [x] placeholder secret 상태로 lifespan 통과 검증
- [x] WARN 로그 capsys 확인