### PR TITLE
fix(17.5.2): empty DUAL_2PC_GROUP_ID env crash

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -66,8 +66,9 @@ async def lifespan(app: FastAPI):
     app.state.heartbeat_task = None  # 분기 2는 미생성 → shutdown 가드용
     app.state.assign_lock = asyncio.Lock()
 
-    # 모드 판별
-    has_group_id = settings.dual_2pc_group_id is not None
+    # 모드 판별 — 빈 문자열("") env를 None과 동등하게 취급함 (Phase 17.5.2)
+    # pydantic이 `DUAL_2PC_GROUP_ID=` 빈 값을 ""로 파싱해 is not None 통과하는 버그 방지
+    has_group_id = bool(settings.dual_2pc_group_id)
     has_subject_index = settings.dual_2pc_subject_index is not None
 
     try:

--- a/tests/test_lifespan_dual_2pc.py
+++ b/tests/test_lifespan_dual_2pc.py
@@ -112,6 +112,24 @@ async def test_lifespan_pending_shutdown_no_crash(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_lifespan_empty_string_group_id_treated_as_pending(monkeypatch):
+    """분기 2 추가 케이스 — DUAL_2PC_GROUP_ID="" (빈 문자열)도 pending 처리함 (Phase 17.5.2)"""
+    monkeypatch.setattr(settings, "engine_secret_key", TEST_VALID_SECRET)
+    # pydantic이 `DUAL_2PC_GROUP_ID=` 빈 값을 ""로 파싱하는 케이스 재현함
+    monkeypatch.setattr(settings, "dual_2pc_group_id", "")
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", 1)
+    monkeypatch.setattr(settings, "registration_mode", "local")
+    monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+
+    mod = _import_fresh_app()
+    async with _run_lifespan(mod.app):
+        # 빈 문자열이면 pending 분기로 빠져야 함 — register-dual 호출 안 함
+        assert mod.app.state.registered_group_id is None
+        assert mod.app.state.heartbeat_task is None
+        assert mod.app.state.subject_index == 1
+
+
+@pytest.mark.asyncio
 async def test_lifespan_single_legacy_register(monkeypatch, httpx_mock):
     """분기 3 — 둘 다 없음 → SEQUENTIAL register + single heartbeat 확인함"""
     monkeypatch.setattr(settings, "engine_secret_key", TEST_VALID_SECRET)


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/17.5-de-runtime-group-assign` (EEG-W103)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## Summary

팀장 노트북에서 `DUAL_2PC_GROUP_ID=` 빈 env 때문에 lifespan이 분기 1로 잘못 진입해 BE 400 에러로 기동 실패. `bool()` 체크로 빈 문자열을 None과 동등 처리.

## Root cause

pydantic의 `str | None = None`은 env `DUAL_2PC_GROUP_ID=`을 **빈 문자열 `""`로 파싱**. 기존 `is not None` 체크를 통과해 분기 1 `register_to_backend_dual(group_id="", ...)` 호출 → BE 400.

## Fix

`has_group_id = bool(settings.dual_2pc_group_id)` — 빈 문자열도 falsy.

## Verify

- black/isort/flake8 clean
- pytest: **116 passed** (기존 115 + 신규 1)

## Test plan

- [x] 빈 문자열 env → pending 분기 진입 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **버그 수정**
  * Dual 2PC 모드에서 빈 문자열 설정 값을 누락된 것으로 올바르게 처리하도록 개선했습니다.

* **테스트**
  * Dual 2PC 모드의 빈 그룹 ID 처리 시나리오에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->