### PR TITLE
fix(17.5.3): unbuffered stdout for ngrok URL log visibility

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -1,6 +1,13 @@
-import uvicorn
+import os
 
-from server.config import settings
+# Phase 17.5.3 — Windows uvicorn reloader 환경에서 print() stdout buffering으로
+# lifespan 로그가 누락되는 현상 방지함. reloader process가 worker stdout을 pipe
+# forwarding하는 과정에서 flush 지연 + 터미널 라인 잘림 발생 가능.
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+import uvicorn  # noqa: E402
+
+from server.config import settings  # noqa: E402
 
 if __name__ == "__main__":
     uvicorn.run(

--- a/server/app.py
+++ b/server/app.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
 
         tunnel = ngrok.connect(settings.fastapi_port, bind_tls=True)
         public_url = tunnel.public_url
-        print(f"ngrok 퍼블릭 URL 발급됨: {public_url}")
+        print(f"ngrok 퍼블릭 URL 발급됨: {public_url}", flush=True)
     else:  # local
         lan_ip = settings.lan_ip or socket.gethostbyname(socket.gethostname())
         public_url = f"http://{lan_ip}:{settings.fastapi_port}"


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/17.5-de-runtime-group-assign` (EEG-W103)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## Summary

Windows uvicorn reloader 환경에서 `ngrok 퍼블릭 URL 발급됨` 로그가 터미널에 출력되지 않는 현상 수정. 로직은 정상이고 화면 표시 문제였음.

## Root cause (Opus 진단)

`uvicorn.run(reload=True)` → reloader process가 worker process의 stdout을 pipe forwarding. Python `print()`의 기본 line-buffered stdout이 reloader forwarding 경로에서 flush 지연 발생. `DE pending:`의 `DE` 접두어 잘림 현상이 직접 증거.

## Fix

1. `run_server.py` — `PYTHONUNBUFFERED=1` setdefault (근본)
2. `server/app.py` — ngrok URL print에 `flush=True` (즉시성)

## Verify

- black/isort/flake8 clean
- pytest: 116 passed (변경 없음)

## Test plan

- [x] pytest 회귀 없음
- [ ] 팀장 노트북에서 pull 후 재기동 시 ngrok URL 즉시 표시 확인