### PR TITLE
Phase 17 + 17.6 dual-2pc → dev

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -10,7 +10,9 @@ from server.routes import analyze, export, health, stream
 from server.services.webhook import (
     register_to_backend,
     register_to_backend_dual,
+    register_to_backend_pending,
     start_heartbeat,
+    unregister_to_backend_pending,
 )
 
 load_dotenv(".env.local")
@@ -39,9 +41,15 @@ async def lifespan(app: FastAPI):
         settings.dual_2pc_group_id is not None
         and settings.dual_2pc_subject_index is not None
     )
+    # pending mode 판별: subject_index만 주입, group_id 미정 상태
+    has_subject_index = (
+        settings.dual_2pc_subject_index is not None
+        and settings.dual_2pc_group_id is None
+    )
 
     try:
         if is_dual_2pc:
+            # 분기 1: groupId + subjectIndex 모두 확정 — register_to_backend_dual 호출함
             await register_to_backend_dual(
                 public_url,
                 settings.dual_2pc_group_id,
@@ -55,6 +63,35 @@ async def lifespan(app: FastAPI):
         print(f"DE registration failed: {e}")
         raise SystemExit(1)
 
+    # Phase 17.6 LD-22/LD-18: 분기 2 — pending mode (groupId 미정, subjectIndex만 있음)
+    # 독립 try/except로 외부 SystemExit 전파 차단함
+    if has_subject_index:
+        pending_registered = False
+        for attempt in range(3):
+            try:
+                await register_to_backend_pending(
+                    public_url,
+                    settings.dual_2pc_subject_index,
+                    settings.engine_secret_key,
+                )
+                pending_registered = True
+                break
+            except Exception as e:  # 분기 2 내부 catch — 외부 SystemExit 차단함
+                print(
+                    f"[WARN] pending registration attempt {attempt + 1}/3 실패함: {e}"
+                )
+                if attempt < 2:
+                    await asyncio.sleep(2**attempt)  # 1s, 2s
+        if not pending_registered:
+            print(
+                "[WARN] pending registration 3회 실패함. DE 계속 실행, "
+                "수동 fallback 의존."
+            )
+        # 분기 2 내부 raise 금지 — yield까지 정상 진행
+        app.state.pending_registered = pending_registered
+    else:
+        app.state.pending_registered = False
+
     # heartbeat task (기존 — 5분마다 백엔드에 재등록)
     heartbeat_task = asyncio.create_task(
         start_heartbeat(public_url, settings.engine_secret_key)
@@ -64,6 +101,15 @@ async def lifespan(app: FastAPI):
 
     # --- shutdown ---
     heartbeat_task.cancel()
+
+    # Phase 17.6 LD-26: pending entry 삭제 호출함 (DE shutdown 시 soft-fail)
+    if has_subject_index and getattr(app.state, "pending_registered", False):
+        await unregister_to_backend_pending(
+            app.state.public_url,
+            settings.dual_2pc_subject_index,
+            settings.engine_secret_key,
+        )
+
     if settings.registration_mode == "ngrok":
         from pyngrok import ngrok
 

--- a/server/app.py
+++ b/server/app.py
@@ -2,6 +2,7 @@ import asyncio
 import socket
 from contextlib import asynccontextmanager
 
+import httpx
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
@@ -124,7 +125,8 @@ async def lifespan(app: FastAPI):
                 )
                 pending_registered = True
                 break
-            except Exception as e:  # 분기 2 내부 catch — 외부 SystemExit 차단함
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                # Fail-Fast: httpx 예외만 catch — 설정/직렬화 오류는 propagate
                 print(
                     f"[WARN] pending registration attempt {attempt + 1}/3 실패함: {e}"
                 )

--- a/server/services/webhook.py
+++ b/server/services/webhook.py
@@ -50,6 +50,52 @@ async def register_to_backend_dual(
     )
 
 
+async def register_to_backend_pending(
+    public_url: str,
+    subject_index: int,
+    secret_key: str,
+) -> None:
+    """BE에 pending DE URL 사전 등록 호출함 (groupId 미정 상태)."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{settings.backend_url}/api/engine/register-pending",
+            headers={"Content-Type": "application/json"},
+            json={
+                "subjectIndex": subject_index,
+                "engineUrl": public_url,
+                "secretKey": secret_key,
+            },
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        print(f"[pending registration] subject={subject_index} url={public_url} OK")
+
+
+async def unregister_to_backend_pending(
+    public_url: str,
+    subject_index: int,
+    secret_key: str,
+) -> None:
+    """BE에 pending entry 삭제 호출함 (DE shutdown 시). soft-fail."""
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.request(
+                "DELETE",
+                f"{settings.backend_url}/api/engine/register-pending",
+                headers={"Content-Type": "application/json"},
+                json={
+                    "subjectIndex": subject_index,
+                    "engineUrl": public_url,
+                    "secretKey": secret_key,
+                },
+                timeout=5.0,
+            )
+        print(f"[pending unregister] subject={subject_index} url={public_url} OK")
+    except Exception as e:
+        # soft-fail: shutdown 흐름이라 raise 금지
+        print(f"[WARN] pending unregister failed (soft): {e}")
+
+
 async def start_heartbeat(public_url: str, secret_key: str):
     """주기적으로 백엔드에 엔진 URL을 재등록하는 heartbeat 태스크임"""
     while True:

--- a/server/services/webhook.py
+++ b/server/services/webhook.py
@@ -79,7 +79,7 @@ async def unregister_to_backend_pending(
     """BE에 pending entry 삭제 호출함 (DE shutdown 시). soft-fail."""
     try:
         async with httpx.AsyncClient() as client:
-            await client.request(
+            response = await client.request(
                 "DELETE",
                 f"{settings.backend_url}/api/engine/register-pending",
                 headers={"Content-Type": "application/json"},
@@ -90,9 +90,10 @@ async def unregister_to_backend_pending(
                 },
                 timeout=5.0,
             )
+            response.raise_for_status()
         print(f"[pending unregister] subject={subject_index} url={public_url} OK")
-    except Exception as e:
-        # soft-fail: shutdown 흐름이라 raise 금지
+    except httpx.HTTPError as e:
+        # soft-fail: shutdown 흐름이라 raise 금지 — httpx 예외만 catch
         print(f"[WARN] pending unregister failed (soft): {e}")
 
 

--- a/tests/test_register_pending.py
+++ b/tests/test_register_pending.py
@@ -1,0 +1,177 @@
+"""register_to_backend_pending / unregister_to_backend_pending 단위 테스트 모음"""
+
+import json
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from server.services.webhook import (
+    register_to_backend_pending,
+    unregister_to_backend_pending,
+)
+
+# ──────────────────────────────────────────────
+# 테스트 상수
+# ──────────────────────────────────────────────
+MOCK_BACKEND_URL = "http://mock-backend:5000"
+MOCK_ENGINE_URL = "https://superexcited-thad-fluffiest.ngrok-free.dev"
+MOCK_SUBJECT_INDEX = 1
+MOCK_SECRET_KEY = "test-secret"
+REGISTER_PENDING_URL = f"{MOCK_BACKEND_URL}/api/engine/register-pending"
+
+
+# ──────────────────────────────────────────────
+# T1: BE 200 OK → 정상 호출 + camelCase payload 검증
+# ──────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_register_to_backend_pending_success(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BE 200 응답 시 register_to_backend_pending 정상 호출 + camelCase payload 검증함"""
+    from server.config import settings
+
+    monkeypatch.setattr(settings, "backend_url", MOCK_BACKEND_URL)
+
+    # BE 200 OK 응답 등록
+    httpx_mock.add_response(
+        url=REGISTER_PENDING_URL,
+        method="POST",
+        json={"message": "OK"},
+        status_code=200,
+    )
+
+    await register_to_backend_pending(
+        public_url=MOCK_ENGINE_URL,
+        subject_index=MOCK_SUBJECT_INDEX,
+        secret_key=MOCK_SECRET_KEY,
+    )
+
+    # 전송된 요청 검증 — POST + camelCase 필드명
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "POST"
+    assert str(request.url) == REGISTER_PENDING_URL
+
+    body = json.loads(request.content)
+    assert body == {
+        "subjectIndex": MOCK_SUBJECT_INDEX,
+        "engineUrl": MOCK_ENGINE_URL,
+        "secretKey": MOCK_SECRET_KEY,
+    }
+
+
+# ──────────────────────────────────────────────
+# T2: BE 403 응답 → HTTPStatusError raise 확인 (secret mismatch 시나리오)
+# ──────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_register_to_backend_pending_403_secret_mismatch(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BE 403 반환 시 httpx.HTTPStatusError raise됨 (secretKey 불일치 시나리오)"""
+    from server.config import settings
+
+    monkeypatch.setattr(settings, "backend_url", MOCK_BACKEND_URL)
+
+    # BE 403 Forbidden 응답 등록
+    httpx_mock.add_response(
+        url=REGISTER_PENDING_URL,
+        method="POST",
+        status_code=403,
+        json={"error": "Forbidden", "message": "Invalid secret key"},
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await register_to_backend_pending(
+            public_url=MOCK_ENGINE_URL,
+            subject_index=MOCK_SUBJECT_INDEX,
+            secret_key="wrong-secret",
+        )
+
+    # 403 상태코드 응답 예외 확인
+    assert exc_info.value.response.status_code == 403
+
+
+# ──────────────────────────────────────────────
+# T3: BE 미응답(네트워크 에러) → soft-fail 확인 (raise 없음)
+# ──────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_unregister_pending_soft_fail_on_network_error(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BE 미응답(ConnectError) 시 unregister_to_backend_pending soft-fail — raise 안 함"""
+    from server.config import settings
+
+    monkeypatch.setattr(settings, "backend_url", MOCK_BACKEND_URL)
+
+    # 네트워크 에러 시뮬레이션
+    httpx_mock.add_exception(
+        httpx.ConnectError("Connection refused"),
+        url=REGISTER_PENDING_URL,
+        method="DELETE",
+    )
+
+    # soft-fail이므로 예외 전파 없음 — 정상 반환 기대
+    await unregister_to_backend_pending(
+        public_url=MOCK_ENGINE_URL,
+        subject_index=MOCK_SUBJECT_INDEX,
+        secret_key=MOCK_SECRET_KEY,
+    )
+    # 여기까지 도달하면 soft-fail 성공
+
+
+# ──────────────────────────────────────────────
+# T4: lifespan pending retry — 3회 503 후 soft-fail (SystemExit 없음)
+# ──────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_lifespan_pending_retry_3times_on_503(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BE 503 3회 연속 → HTTPStatusError raise됨. retry는 lifespan 분기 2가 처리함."""
+    from server.config import settings
+
+    monkeypatch.setattr(settings, "backend_url", MOCK_BACKEND_URL)
+
+    # 3회 503 응답 등록 — lifespan retry 루프가 3회 호출함을 전제
+    for _ in range(3):
+        httpx_mock.add_response(
+            url=REGISTER_PENDING_URL,
+            method="POST",
+            status_code=503,
+            json={"error": "Service Unavailable"},
+        )
+
+    # lifespan retry 루프 시뮬레이션: asyncio.sleep 패치 (대기 없이 즉시 진행)
+    import asyncio
+
+    monkeypatch.setattr(
+        asyncio, "sleep", lambda *a, **kw: asyncio.coroutine(lambda: None)()
+    )
+
+    # register_to_backend_pending 자체는 3회 시도 시 마지막에 HTTPStatusError raise
+    # lifespan 분기 2는 이 예외를 잡아 soft-fail 처리 — 단위 테스트에서는 raise 확인
+    attempt_count = 0
+    pending_registered = False
+    for attempt in range(3):
+        try:
+            await register_to_backend_pending(
+                public_url=MOCK_ENGINE_URL,
+                subject_index=MOCK_SUBJECT_INDEX,
+                secret_key=MOCK_SECRET_KEY,
+            )
+            pending_registered = True
+            break
+        except Exception:
+            attempt_count += 1
+
+    # 3회 모두 실패 → pending_registered=False, SystemExit 없음
+    assert attempt_count == 3
+    assert pending_registered is False
+
+    # 3회 요청 전송 확인
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3

--- a/tests/test_register_pending.py
+++ b/tests/test_register_pending.py
@@ -146,11 +146,13 @@ async def test_lifespan_pending_retry_3times_on_503(
         )
 
     # lifespan retry 루프 시뮬레이션: asyncio.sleep 패치 (대기 없이 즉시 진행)
+    # asyncio.coroutine은 Python 3.11+ 제거됨 → async def noop 사용함
     import asyncio
 
-    monkeypatch.setattr(
-        asyncio, "sleep", lambda *a, **kw: asyncio.coroutine(lambda: None)()
-    )
+    async def _noop_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
 
     # register_to_backend_pending 자체는 3회 시도 시 마지막에 HTTPStatusError raise
     # lifespan 분기 2는 이 예외를 잡아 soft-fail 처리 — 단위 테스트에서는 raise 확인


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/17-dual-2pc-wiring-fix` (SESSION-W105)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## Summary
- Phase 17 wiring + 17.6 hotfix 모두 dev로 머지
- 17.6 머지 commit: `39eb43b` (2026-04-29)
- dev에는 17.5 시리즈만 있고 17 wiring 자체가 미머지였음 → 이번 PR로 17 + 17.6 함께 propagate

## 변경
- 17 wiring (5 commits): mock-de + assign-group + REGISTRATION_MODE refactor + DUAL_2PC analyze dispatch + scripts
- 17.6 hotfix (1 commit): T1b pending registry BE registration + soft-fail retry + DELETE cleanup

## 검증
- 103 tests PASS (이전 99 + T1b 4)

## 후속
- dev → main create merge로 propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 엔진 '대기(pending)' 등록 흐름이 개선되어, 특정 구성에서 백엔드에 대기 등록을 시도할 때 3회까지 지수 백오프로 재시도하고 실패가 서비스 시작을 중단시키지 않도록 하며, 종료 시 조건부로 대기 등록 해제를 수행합니다.

* **Tests**
  * 대기 등록/해제의 성공·권한 오류·네트워크 오류 및 재시도 동작을 검증하는 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->