### PR TITLE
docs(env): clean phase 17 ngrok artifact + add phase 18 proxy mode env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,25 @@
 FASTAPI_PORT=5002
 
 # Registration mode
+# Phase 18 proxy mode 도입 후 default = local. ngrok은 Phase 17 잔재로 Phase 18 환경에서 사용 시
+# public_url을 proxy /register로 보낼 때 ngrok URL 등록 risk 발생함. proxy mode 환경에선 local 의무.
 REGISTRATION_MODE=local          # local | ngrok
 BACKEND_URL=http://localhost:5000
 # ⚠️ placeholder 값(your-shared-secret-here / change-me-in-production)은 Preflight hard-gate에 의해 lifespan이 abort됨
 ENGINE_SECRET_KEY=your-shared-secret-here
-LAN_IP=                          # 빈 값이면 socket.gethostbyname 자동 탐지
+# LAN_IP — 운영자 시점 명시 override 권장 (5/26 D-0 시연 학습)
+# 분기:
+#   operator PC = proxy 동일 머신 시점 → 127.0.0.1 (loopback)
+#   노트북 B = DE_B 별개 머신 시점 → 핫스팟 어댑터 IPv4 (예: 192.168.137.X)
+# 빈 값 시 socket.gethostbyname 자동 탐지하나 다중 인터페이스 환경에서 부정확 가능
+LAN_IP=
+
+# Phase 18 proxy mode 전용 env (proxy mode 비사용 시 빈 값 유지)
+# ALIGNMENT_LOCATION=proxy 설정 시 DE_A 또는 DE_B는 측정 데이터를 proxy /ingest로 forward함
+# operator PC = proxy 동일 머신: PROXY_URL=http://127.0.0.1:5050
+# 노트북 B = DE_B 별개 머신: PROXY_URL=http://<operator PC AP IPv4>:5050 (Windows 핫스팟 broadcast 또는 유선 LAN 경로)
+ALIGNMENT_LOCATION=
+PROXY_URL=
 
 # DUAL_2PC 세션 env (Phase 17.5)
 # 방식 1 (즉시 등록, backward-compat): GROUP_ID + SUBJECT_INDEX 둘 다 설정
@@ -15,7 +29,7 @@ LAN_IP=                          # 빈 값이면 socket.gethostbyname 자동 탐
 DUAL_2PC_GROUP_ID=
 DUAL_2PC_SUBJECT_INDEX=
 
-# ngrok (REGISTRATION_MODE=ngrok 때만)
+# ngrok (REGISTRATION_MODE=ngrok 때만, Phase 17 잔재. Phase 18 proxy mode 환경에서 미사용 권장)
 NGROK_AUTH_TOKEN=
 
 # External API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,16 @@ ENGINE_SECRET_KEY=<shared_secret>
 
 Redis 채널은 `core.main`의 인수(groupId, subjectIndex)로 동적 결정 — 환경변수 불필요.
 
+### Phase migration 환경변수 cleanup 룰
+
+Phase migration 진행 시 `.env.local` 또는 `.env.example`에 박제된 환경변수 중 이전 Phase 전용으로 남아 있는 값은 cleanup 의무. 5/26 D-0 시연 setup 도중 노출된 사례:
+
+- Phase 17 `REGISTRATION_MODE=ngrok` 잔재 — Phase 18 proxy mode 환경에서 사용 시 `public_url`을 proxy `/register`로 보낼 때 ngrok URL 등록 risk 발생함. proxy mode 환경에선 `REGISTRATION_MODE=local` 의무함.
+- Phase 18 `ALIGNMENT_LOCATION` + `PROXY_URL` 신규 추가 — proxy mode 활성화 트리거. `.env.example`에 빈 값 default 박제로 proxy mode 미사용 시 자연 비활성화 정합함.
+- `LAN_IP` 운영자 명시 override 권장 — 5/26 D-0 학교 Wi-Fi 환경에서 `socket.gethostbyname` 자동 탐지가 다중 인터페이스(학교 Wi-Fi + 핫스팟 broadcast) 시 부정확 발견함. 분기 박제: operator PC = proxy 동일 머신 시 `127.0.0.1`, 노트북 B = DE_B 별개 머신 시 핫스팟 어댑터 IPv4.
+
+Phase migration PR scope에 `.env.example` 정합 확인 + AGENTS.md 본 절 amend 의무 (transitive 상속 박제 갭 차단). 옵시디언 [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]] 핵심 발견 6 + [[2026-05-26-track-1-doc-governance-correction-done]] 핵심 발견 2 정합.
+
 ---
 
 ## 5. 코드 스타일

--- a/scripts/realdevice/start-realdevice-dual-2pc.ps1
+++ b/scripts/realdevice/start-realdevice-dual-2pc.ps1
@@ -1,0 +1,297 @@
+﻿# Mind Signal Phase 18.1 dual-2pc operator PC starter
+# Real EMOTIV device + BE + DE_A + proxy 통합 기동. 시연/실측용.
+# Idempotent. 별도 PowerShell 창에서 각 서버 띄움.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-dual-2pc.ps1
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-dual-2pc.ps1 -SkipRedis -SkipProxy
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-dual-2pc.ps1 -OperatorIp 100.117.42.107
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-dual-2pc.ps1 -Production
+#
+# Stop: stop-realdevice-dual-2pc.ps1 (별도 파일)
+#
+# References:
+# - 2026-05-27 cross-machine Tailscale GREEN [[project_mind_signal_phase18_mcafee_removed_cross_machine_green]]
+# - mind-signal-d0-setup.ps1 (firewall + .env.local 갱신, 별도 책임)
+# - [[feedback_start_process_conda_hook]] conda activate hook 안정성
+
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = "C:\Users\gs071\Team-project",
+    [string]$EngineSecret = "",
+    [int]$BackendPort = 5000,
+    [int]$DePort = 5002,
+    [int]$ProxyPort = 5050,
+    [string]$CondaEnv = "mind-signal",
+    [string]$OperatorIp = "",
+    [switch]$SkipRedis,
+    [switch]$SkipProxy,
+    [switch]$Production,
+    [int]$HealthcheckTimeoutSec = 60,
+    [int]$EmotivCortexPort = 6868
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step  { param($S,$M) Write-Host "[$S] $M" -ForegroundColor Yellow }
+function Write-OK    { param($M) Write-Host "  $M" -ForegroundColor Green }
+function Write-Warn2 { param($M) Write-Host "  $M" -ForegroundColor DarkYellow }
+function Write-Fail  { param($M) Write-Host "  $M" -ForegroundColor Red }
+
+function Get-OperatorTailscaleIp {
+    try {
+        $ip = (& "C:\Program Files\Tailscale\tailscale.exe" ip -4 2>$null | Select-Object -First 1).Trim()
+        if ($ip -and $ip -match '^\d+\.\d+\.\d+\.\d+$') { return $ip }
+    } catch { }
+    return ""
+}
+
+function Wait-HttpHealthy {
+    param(
+        [string]$Url,
+        [int]$TimeoutSec,
+        [string]$ServiceName
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    $attempt = 0
+    while ((Get-Date) -lt $deadline) {
+        $attempt++
+        try {
+            $resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 3 -ErrorAction Stop
+            if ($resp.StatusCode -ge 200 -and $resp.StatusCode -lt 400) {
+                Write-OK ("[$ServiceName] healthy after $attempt attempt(s): $Url -> $($resp.StatusCode)")
+                return $true
+            }
+        } catch {
+            # not ready yet, retry
+        }
+        Start-Sleep -Seconds 1
+    }
+    Write-Fail ("[$ServiceName] healthcheck timeout after $TimeoutSec sec: $Url")
+    return $false
+}
+
+function Test-PortInUse {
+    param([int]$Port)
+    $r = Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue
+    return $null -ne $r
+}
+
+# 0. Pre-flight
+Write-Host ""
+Write-Host "=== Mind Signal Realdevice Dual-2PC Starter (operator PC) ===" -ForegroundColor Cyan
+Write-Host ("ProjectRoot:  " + $ProjectRoot) -ForegroundColor Gray
+Write-Host ("Production:   " + $Production) -ForegroundColor Gray
+Write-Host ""
+
+# Resolve ENGINE_SECRET_KEY: param > env var > BE .env.local
+if (-not $EngineSecret) { $EngineSecret = $env:ENGINE_SECRET_KEY }
+if (-not $EngineSecret) {
+    $beEnvPath = Join-Path $ProjectRoot "mind-signal-backend\.env.local"
+    if (Test-Path $beEnvPath) {
+        $line = Get-Content $beEnvPath | Where-Object { $_ -match "^ENGINE_SECRET_KEY=" } | Select-Object -First 1
+        if ($line) { $EngineSecret = ($line -split "=", 2)[1].Trim('"').Trim() }
+    }
+}
+if (-not $EngineSecret) {
+    Write-Host "  ENGINE_SECRET_KEY not found. Pass -EngineSecret, set `$env:ENGINE_SECRET_KEY, or add to BE .env.local" -ForegroundColor Red
+    exit 2
+}
+
+Write-Step "0/9" "Pre-flight (Tailscale + third-party AV + conda env)"
+
+# 0a. Tailscale running
+$tsService = Get-Service -Name Tailscale -ErrorAction SilentlyContinue
+if (-not $tsService -or $tsService.Status -ne "Running") {
+    Write-Fail "Tailscale service not running. Start Tailscale UI first."
+    exit 2
+}
+Write-OK "Tailscale service Running"
+
+# 0b. Resolve operator IP
+if (-not $OperatorIp) { $OperatorIp = Get-OperatorTailscaleIp }
+if (-not $OperatorIp) {
+    Write-Fail "Operator Tailscale IP resolve failed. Pass -OperatorIp explicitly."
+    exit 2
+}
+Write-OK ("Operator IP = " + $OperatorIp)
+
+# 0c. Third-party AV check (McAfee/Norton/AhnLab 등)
+$avBlockers = @("mc-fw-host", "mcshield", "norton", "navapsvc", "ahnlab")
+$avFound = Get-Service -ErrorAction SilentlyContinue | Where-Object {
+    $svc = $_
+    $avBlockers | Where-Object { $svc.Name -like "*$_*" -or $svc.DisplayName -like "*$_*" } | Select-Object -First 1
+}
+if ($avFound) {
+    Write-Warn2 "Third-party AV/Firewall detected. May block inbound TCP. See [[feedback_windows_third_party_av_firewall_layer]]"
+    $avFound | ForEach-Object { Write-Warn2 ("  - " + $_.DisplayName + " (" + $_.Status + ")") }
+} else {
+    Write-OK "No third-party AV firewall blockers detected"
+}
+
+# 0d. Conda env exists (default: .conda\envs, fallback: miniconda3\envs)
+$condaCandidates = @(
+    "C:\Users\gs071\.conda\envs\$CondaEnv",
+    "C:\Users\gs071\miniconda3\envs\$CondaEnv"
+)
+$condaPath = $condaCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $condaPath) {
+    Write-Fail ("Conda env not found in any of: " + ($condaCandidates -join ", "))
+    exit 2
+}
+Write-OK ("Conda env $CondaEnv at " + $condaPath)
+
+# 0e. EMOTIV launcher (warn only, 사용자 위임)
+if (Test-PortInUse -Port $EmotivCortexPort) {
+    Write-OK ("EMOTIV Cortex listening on port " + $EmotivCortexPort)
+} else {
+    Write-Warn2 ("EMOTIV Cortex (port " + $EmotivCortexPort + ") not running. Launch EMOTIV Launcher 후 헤드셋 페어링 필요.")
+}
+
+Write-Host ""
+
+# 1. Docker Redis
+Write-Step "1/9" "Docker Redis"
+if ($SkipRedis) {
+    Write-Warn2 "SkipRedis flag set"
+} else {
+    docker info > $null 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Docker Desktop not running. Start it first then re-run."
+        exit 3
+    }
+    $existing = docker ps -a --filter "name=mind-signal-redis" --format "{{.Names}}" 2>$null
+    if ($existing -match "mind-signal-redis") {
+        $running = docker ps --filter "name=mind-signal-redis" --format "{{.Names}}" 2>$null
+        if ($running -match "mind-signal-redis") {
+            Write-OK "Redis container already running"
+        } else {
+            docker start mind-signal-redis | Out-Null
+            Write-OK "Redis container started (existing)"
+        }
+    } else {
+        Push-Location (Join-Path $ProjectRoot "mind-signal-backend")
+        docker-compose up -d | Out-Null
+        Pop-Location
+        Write-OK "Redis container created via docker-compose"
+    }
+}
+
+Write-Host ""
+
+# 2. BE
+# 환경변수 주입은 PowerShell 의 $env: 로 사전 set 후 Start-Process 자식 cmd 가 부모 env 상속하도록 함.
+# cmd /k 안에서 "set X=val && npm" 패턴은 Start-Process ArgumentList 처리 시 자식 npm process 까지 환경변수 전달이 안 되는 사례 실측 ([[feedback_powershell_start_process_env_inject]]).
+$env:ENGINE_SECRET_KEY = $EngineSecret
+$env:NODE_ENV = 'local'
+Write-Step "2/9" "Backend (port $BackendPort)"
+if (Test-PortInUse -Port $BackendPort) {
+    Write-Warn2 ("Port " + $BackendPort + " already in use. Assuming BE already running.")
+} else {
+    $beDir = Join-Path $ProjectRoot "mind-signal-backend"
+    $beCmd = if ($Production) { "npm run build && npm start" } else { "npm run dev" }
+    $beArgs = "/k cd /d `"$beDir`" && $beCmd"
+    Start-Process -FilePath "cmd.exe" -ArgumentList $beArgs -WindowStyle Normal
+    Write-OK "Backend terminal launched (env inherited from PowerShell scope)"
+}
+
+Write-Host ""
+
+# 3. BE healthcheck
+Write-Step "3/9" "Backend healthcheck (GET /api-docs)"
+$beHealthy = Wait-HttpHealthy -Url "http://localhost:$BackendPort/api-docs" -TimeoutSec $HealthcheckTimeoutSec -ServiceName "BE"
+if (-not $beHealthy) {
+    Write-Fail "Backend failed to become healthy. Check BE terminal output."
+    exit 4
+}
+
+Write-Host ""
+
+# 4. DE_A
+# $env: 사전 set 으로 자식 cmd + conda + python 까지 환경변수 정합 전달.
+$env:LAN_IP = $OperatorIp
+$env:PROXY_URL = "http://${OperatorIp}:$ProxyPort"
+$env:BACKEND_URL = "http://localhost:$BackendPort"
+if ($Production) { $env:UVICORN_RELOAD = 'false' }
+Write-Step "4/9" "Data Engine A (port $DePort)"
+if (Test-PortInUse -Port $DePort) {
+    Write-Warn2 ("Port " + $DePort + " already in use. Assuming DE_A already running.")
+} else {
+    $deDir = Join-Path $ProjectRoot "mind-signal-data-engine"
+    $deCmd = "conda activate $CondaEnv && python run_server.py"
+    $deArgs = "/k cd /d `"$deDir`" && $deCmd"
+    Start-Process -FilePath "cmd.exe" -ArgumentList $deArgs -WindowStyle Normal
+    Write-OK "DE_A terminal launched (env inherited from PowerShell scope)"
+}
+
+Write-Host ""
+
+# 5. DE_A healthcheck
+Write-Step "5/9" "DE_A healthcheck (GET /health)"
+$deHealthy = Wait-HttpHealthy -Url "http://localhost:$DePort/health" -TimeoutSec $HealthcheckTimeoutSec -ServiceName "DE_A"
+if (-not $deHealthy) {
+    Write-Fail "DE_A failed to become healthy. Check DE_A terminal output."
+    exit 5
+}
+
+Write-Host ""
+
+# 6. Proxy
+Write-Step "6/9" "Proxy (port $ProxyPort)"
+if ($SkipProxy) {
+    Write-Warn2 "SkipProxy flag set"
+} elseif (Test-PortInUse -Port $ProxyPort) {
+    Write-OK ("Port " + $ProxyPort + " already listening. Assuming proxy already running.")
+} else {
+    $proxyDir = Join-Path $ProjectRoot "mind-signal-proxy"
+    # ENGINE_SECRET_KEY, BACKEND_URL 은 BE 단계에서 이미 $env: set 됨. PROXY_PORT 만 추가.
+    $env:PROXY_PORT = "$ProxyPort"
+    $proxyArgs = "/k cd /d `"$proxyDir`" && npm start"
+    Start-Process -FilePath "cmd.exe" -ArgumentList $proxyArgs -WindowStyle Normal
+    Write-OK "Proxy terminal launched (env inherited from PowerShell scope)"
+}
+
+Write-Host ""
+
+# 7. Proxy healthcheck
+Write-Step "7/9" "Proxy healthcheck (GET /health)"
+if (-not $SkipProxy) {
+    $proxyHealthy = Wait-HttpHealthy -Url "http://localhost:$ProxyPort/health" -TimeoutSec $HealthcheckTimeoutSec -ServiceName "Proxy"
+    if (-not $proxyHealthy) {
+        Write-Fail "Proxy failed to become healthy."
+        exit 6
+    }
+}
+
+Write-Host ""
+
+# 8. Cross-machine Tailscale endpoint verification (self-curl from Tailscale IP)
+Write-Step "8/9" "Tailscale endpoint self-verification"
+$tsProxy = Wait-HttpHealthy -Url "http://${OperatorIp}:$ProxyPort/health" -TimeoutSec 5 -ServiceName "Proxy-via-Tailscale"
+if (-not $tsProxy) {
+    Write-Warn2 "Proxy not accessible via Tailscale IP. firewall/listen address 확인 필요."
+}
+
+Write-Host ""
+
+# 9. Status report
+Write-Step "9/9" "Status report"
+Write-Host ""
+Write-Host "  Service endpoints (operator PC):" -ForegroundColor Cyan
+Write-Host ("    BE:       http://localhost:" + $BackendPort + "/api-docs") -ForegroundColor Gray
+Write-Host ("    DE_A:     http://localhost:" + $DePort + "/health") -ForegroundColor Gray
+Write-Host ("    Proxy:    http://localhost:" + $ProxyPort + "/health") -ForegroundColor Gray
+Write-Host ("    Proxy(TS): http://" + $OperatorIp + ":" + $ProxyPort + "/health") -ForegroundColor Gray
+Write-Host ""
+Write-Host "  Notebook B side (시연 시 노트북 B에서 실행):" -ForegroundColor Cyan
+Write-Host ("    Tailscale 동일 tailnet 로그인 확인") -ForegroundColor Gray
+Write-Host ('    curl http://' + $OperatorIp + ':' + $ProxyPort + '/health  (응답 200 + {"status":"ok"} 기대)') -ForegroundColor Gray
+Write-Host ("    .\start-realdevice-notebook-b.ps1 -OperatorIp " + $OperatorIp + "  (별도 스크립트 생성 필요)") -ForegroundColor Gray
+Write-Host ""
+Write-Host "  EMOTIV 페어링 (사용자 직접):" -ForegroundColor Cyan
+Write-Host ("    1. EMOTIV Launcher 기동 (이미 떠 있으면 skip)") -ForegroundColor Gray
+Write-Host ("    2. USB 동글 연결 + 헤드셋 페어링") -ForegroundColor Gray
+Write-Host ("    3. Cortex API port " + $EmotivCortexPort + " listening 확인") -ForegroundColor Gray
+Write-Host ""
+Write-Host "=== All services healthy ===" -ForegroundColor Green
+Write-Host ""

--- a/scripts/realdevice/start-realdevice-notebook-b.ps1
+++ b/scripts/realdevice/start-realdevice-notebook-b.ps1
@@ -1,0 +1,283 @@
+﻿# Mind Signal Phase 18.1 dual-2pc notebook B starter
+# DE_B 만 기동. BE/Proxy/Redis 는 operator PC 의존 (Tailscale 경유).
+# Idempotent. operator PC start-realdevice-dual-2pc.ps1 GREEN 이후 실행.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-notebook-b.ps1
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-notebook-b.ps1 -OperatorIp 100.117.42.107
+#   powershell -ExecutionPolicy Bypass -File .\start-realdevice-notebook-b.ps1 -SubjectIndex 2 -Production
+#
+# Stop: stop-realdevice-notebook-b.ps1
+#
+# References:
+# - operator PC starter: start-realdevice-dual-2pc.ps1
+# - 2026-05-27 cross-machine Tailscale GREEN [[project_mind_signal_phase18_mcafee_removed_cross_machine_green]]
+# - [[feedback_powershell_start_process_env_inject]] $env: 사전 set 패턴
+
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = "C:\Users\gs071\Team-project",
+    [string]$OperatorIp = "100.117.42.107",
+    [int]$BackendPort = 5000,
+    [int]$DePort = 5002,
+    [int]$ProxyPort = 5050,
+    [string]$CondaEnv = "mind-signal",
+    [string]$EngineSecret = "",
+    [ValidateSet(1, 2)]
+    [int]$SubjectIndex = 2,
+    [string]$DualGroupId = "",
+    [switch]$Production,
+    [int]$HealthcheckTimeoutSec = 60,
+    [int]$ReachabilityTimeoutSec = 10,
+    [int]$EmotivCortexPort = 6868
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step  { param($S,$M) Write-Host "[$S] $M" -ForegroundColor Yellow }
+function Write-OK    { param($M) Write-Host "  $M" -ForegroundColor Green }
+function Write-Warn2 { param($M) Write-Host "  $M" -ForegroundColor DarkYellow }
+function Write-Fail  { param($M) Write-Host "  $M" -ForegroundColor Red }
+
+function Get-NotebookBTailscaleIp {
+    try {
+        $ip = (& "C:\Program Files\Tailscale\tailscale.exe" ip -4 2>$null | Select-Object -First 1).Trim()
+        if ($ip -and $ip -match '^\d+\.\d+\.\d+\.\d+$') { return $ip }
+    } catch { }
+    return ""
+}
+
+function Wait-HttpHealthy {
+    param([string]$Url, [int]$TimeoutSec, [string]$ServiceName)
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    $attempt = 0
+    while ((Get-Date) -lt $deadline) {
+        $attempt++
+        try {
+            $resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 3 -ErrorAction Stop
+            if ($resp.StatusCode -ge 200 -and $resp.StatusCode -lt 400) {
+                Write-OK ("[$ServiceName] healthy after $attempt attempt(s): $Url -> $($resp.StatusCode)")
+                return $true
+            }
+        } catch { }
+        Start-Sleep -Seconds 1
+    }
+    Write-Fail ("[$ServiceName] healthcheck timeout after $TimeoutSec sec: $Url")
+    return $false
+}
+
+function Test-PortInUse {
+    param([int]$Port)
+    $r = Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue
+    return $null -ne $r
+}
+
+function Test-TailscalePing {
+    param([string]$PeerIp, [int]$TimeoutSec)
+    try {
+        $output = & "C:\Program Files\Tailscale\tailscale.exe" ping --timeout="${TimeoutSec}s" --c=1 $PeerIp 2>&1
+        if ($output -match "^pong from") { return $true }
+    } catch { }
+    return $false
+}
+
+# 0. Pre-flight
+Write-Host ""
+Write-Host "=== Mind Signal Realdevice Notebook B Starter (DE_B only) ===" -ForegroundColor Cyan
+Write-Host ("ProjectRoot:    " + $ProjectRoot) -ForegroundColor Gray
+Write-Host ("OperatorIp:     " + $OperatorIp) -ForegroundColor Gray
+Write-Host ("SubjectIndex:   " + $SubjectIndex) -ForegroundColor Gray
+if ($DualGroupId) { Write-Host ("DualGroupId:    " + $DualGroupId + " (즉시 DUAL_2PC 등록 분기)") -ForegroundColor Gray }
+else { Write-Host ("DualGroupId:    (미설정 - pending 분기, /control/assign-group 대기)") -ForegroundColor Gray }
+Write-Host ("Production:     " + $Production) -ForegroundColor Gray
+Write-Host ""
+
+# Resolve ENGINE_SECRET_KEY: param > env var (notebook B has no BE .env.local)
+if (-not $EngineSecret) { $EngineSecret = $env:ENGINE_SECRET_KEY }
+if (-not $EngineSecret) {
+    Write-Host "  ENGINE_SECRET_KEY not found. Pass -EngineSecret or set `$env:ENGINE_SECRET_KEY before running." -ForegroundColor Red
+    exit 2
+}
+
+Write-Step "0/7" "Pre-flight (Tailscale + operator reachability + conda env)"
+
+# 0a. Tailscale running
+$tsService = Get-Service -Name Tailscale -ErrorAction SilentlyContinue
+if (-not $tsService -or $tsService.Status -ne "Running") {
+    Write-Fail "Tailscale service not running. Start Tailscale UI first."
+    exit 2
+}
+Write-OK "Tailscale service Running"
+
+# 0b. Notebook B own Tailscale IP
+$selfIp = Get-NotebookBTailscaleIp
+if (-not $selfIp) {
+    Write-Fail "Notebook B Tailscale IP resolve failed. Login to same tailnet first."
+    exit 2
+}
+Write-OK ("Notebook B Tailscale IP = " + $selfIp)
+
+# 0c. Same tailnet check via ping
+Write-OK "Pinging operator PC via Tailscale..."
+if (-not (Test-TailscalePing -PeerIp $OperatorIp -TimeoutSec $ReachabilityTimeoutSec)) {
+    Write-Fail ("Tailscale ping to " + $OperatorIp + " failed. Same tailnet (account) 확인 필요.")
+    exit 2
+}
+Write-OK ("Tailscale ping " + $OperatorIp + " GREEN")
+
+# 0d. Operator Proxy reachable
+$proxyUrl = "http://${OperatorIp}:$ProxyPort"
+$proxyReachable = Wait-HttpHealthy -Url ($proxyUrl + "/health") -TimeoutSec 5 -ServiceName "OperatorProxy"
+if (-not $proxyReachable) {
+    Write-Fail ("Operator proxy not reachable at " + $proxyUrl + ". start-realdevice-dual-2pc.ps1 GREEN 인지 확인.")
+    exit 2
+}
+
+# 0e. Operator BE reachable (Swagger UI proxy 미사용 시 backup)
+$beUrl = "http://${OperatorIp}:$BackendPort"
+$beReachable = Wait-HttpHealthy -Url ($beUrl + "/api-docs") -TimeoutSec 5 -ServiceName "OperatorBE"
+if (-not $beReachable) {
+    Write-Warn2 ("Operator BE not reachable at " + $beUrl + ". proxy mode 만 검증 됨. BE 직접 호출 시 fail 위험.")
+}
+
+# 0f. Third-party AV check
+$avBlockers = @("mc-fw-host", "mcshield", "norton", "navapsvc", "ahnlab")
+$avFound = Get-Service -ErrorAction SilentlyContinue | Where-Object {
+    $svc = $_
+    $avBlockers | Where-Object { $svc.Name -like "*$_*" -or $svc.DisplayName -like "*$_*" } | Select-Object -First 1
+}
+if ($avFound) {
+    Write-Warn2 "Third-party AV/Firewall detected. May block outbound TCP. See [[feedback_windows_third_party_av_firewall_layer]]"
+    $avFound | ForEach-Object { Write-Warn2 ("  - " + $_.DisplayName + " (" + $_.Status + ")") }
+} else {
+    Write-OK "No third-party AV firewall blockers detected"
+}
+
+# 0g. Conda env
+$condaCandidates = @(
+    "C:\Users\gs071\.conda\envs\$CondaEnv",
+    "C:\Users\gs071\miniconda3\envs\$CondaEnv",
+    "$env:USERPROFILE\.conda\envs\$CondaEnv",
+    "$env:USERPROFILE\miniconda3\envs\$CondaEnv"
+)
+$condaPath = $condaCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $condaPath) {
+    Write-Fail ("Conda env not found in any of: " + ($condaCandidates -join ", "))
+    exit 2
+}
+Write-OK ("Conda env $CondaEnv at " + $condaPath)
+
+# 0h. DE_A project dir
+$deDir = Join-Path $ProjectRoot "mind-signal-data-engine"
+if (-not (Test-Path $deDir)) {
+    Write-Fail ("Data engine directory not found: " + $deDir + ". git clone or update -ProjectRoot")
+    exit 2
+}
+Write-OK ("Data engine dir at " + $deDir)
+
+# 0i. EMOTIV launcher (warn only)
+if (Test-PortInUse -Port $EmotivCortexPort) {
+    Write-OK ("EMOTIV Cortex listening on port " + $EmotivCortexPort)
+} else {
+    Write-Warn2 ("EMOTIV Cortex (port " + $EmotivCortexPort + ") not running. EMOTIV Launcher + 헤드셋 페어링 필요.")
+}
+
+Write-Host ""
+
+# 1. Env injection via $env: (자식 cmd 가 부모 PowerShell env 상속함)
+# 함정 우회: cmd /k 안의 "set X=val && python ..." 패턴은 자식 process 까지 env 전달이 불완전한 사례 박제됨
+# 참고: [[feedback_powershell_start_process_env_inject]]
+Write-Step "1/7" "Inject environment variables (PowerShell scope)"
+$env:ENGINE_SECRET_KEY = $EngineSecret
+$env:LAN_IP = $selfIp
+$env:PROXY_URL = $proxyUrl
+$env:BACKEND_URL = $beUrl
+$env:ALIGNMENT_LOCATION = "proxy"
+$env:REGISTRATION_MODE = "local"
+$env:DUAL_2PC_SUBJECT_INDEX = "$SubjectIndex"
+if ($DualGroupId) { $env:DUAL_2PC_GROUP_ID = $DualGroupId }
+if ($Production) { $env:UVICORN_RELOAD = "false" }
+Write-OK "Injected: ENGINE_SECRET_KEY LAN_IP PROXY_URL BACKEND_URL ALIGNMENT_LOCATION REGISTRATION_MODE DUAL_2PC_SUBJECT_INDEX"
+
+Write-Host ""
+
+# 2. DE_B
+Write-Step "2/7" ("Data Engine B (port " + $DePort + ", subject_index=" + $SubjectIndex + ")")
+if (Test-PortInUse -Port $DePort) {
+    Write-Warn2 ("Port " + $DePort + " already in use. Assuming DE_B already running.")
+} else {
+    $deCmd = "conda activate $CondaEnv && python run_server.py"
+    $deArgs = "/k cd /d `"$deDir`" && $deCmd"
+    Start-Process -FilePath "cmd.exe" -ArgumentList $deArgs -WindowStyle Normal
+    Write-OK "DE_B terminal launched (env inherited from PowerShell scope)"
+}
+
+Write-Host ""
+
+# 3. DE_B local healthcheck
+Write-Step "3/7" "DE_B healthcheck (GET /health)"
+$deHealthy = Wait-HttpHealthy -Url "http://localhost:$DePort/health" -TimeoutSec $HealthcheckTimeoutSec -ServiceName "DE_B"
+if (-not $deHealthy) {
+    Write-Fail "DE_B failed to become healthy. Check DE_B terminal output."
+    exit 5
+}
+
+Write-Host ""
+
+# 4. DE_B Tailscale-side reachability (cross-machine view from operator PC 측 시뮬레이션)
+Write-Step "4/7" "DE_B reachable via Tailscale IP"
+$deTsHealthy = Wait-HttpHealthy -Url "http://${selfIp}:$DePort/health" -TimeoutSec 10 -ServiceName "DE_B-via-Tailscale"
+if (-not $deTsHealthy) {
+    Write-Warn2 "DE_B not reachable via Tailscale IP. Operator PC 측 ingest 시 fail 가능. firewall/listen address 확인 필요."
+} else {
+    Write-OK ("DE_B Tailscale endpoint = http://" + $selfIp + ":" + $DePort + "/health")
+}
+
+Write-Host ""
+
+# 5. Proxy 등록 confirm (proxy mode 분기 DE_B → proxy /register POST)
+# DE_B startup 시 자동 register_to_proxy 호출 (app.py L102+). 등록 결과는 proxy 측 endpoint 로 직접 확인 어려움.
+# 대안: 잠시 대기 후 DE_B stdout 에 "proxy 등록" 메시지 확인 (사용자 위임).
+Write-Step "5/7" "Proxy registration (DE_B auto-registers to operator proxy)"
+Start-Sleep -Seconds 3
+Write-OK ("DE_B 가 " + $proxyUrl + "/register 에 자동 등록 시도함 (retry 3회). DE_B 터미널의 'proxy registration' 로그 확인 필요.")
+
+Write-Host ""
+
+# 6. EMOTIV pairing reminder
+Write-Step "6/7" "EMOTIV pairing check"
+if (Test-PortInUse -Port $EmotivCortexPort) {
+    Write-OK "EMOTIV Cortex 이미 listening. 헤드셋 페어링 상태 확인 필요 (Launcher UI)."
+} else {
+    Write-Warn2 "EMOTIV Cortex 미기동. Launcher 실행 + 노트북 B 측 EMOTIV USB 동글 + 헤드셋 페어링 필요."
+}
+
+Write-Host ""
+
+# 7. Status report
+Write-Step "7/7" "Status report"
+Write-Host ""
+Write-Host "  Notebook B endpoints:" -ForegroundColor Cyan
+Write-Host ("    DE_B (local):    http://localhost:" + $DePort + "/health") -ForegroundColor Gray
+Write-Host ("    DE_B (Tailscale): http://" + $selfIp + ":" + $DePort + "/health") -ForegroundColor Gray
+Write-Host ""
+Write-Host "  Operator PC dependencies (read-only check):" -ForegroundColor Cyan
+Write-Host ("    Operator Proxy:  " + $proxyUrl + "/health") -ForegroundColor Gray
+Write-Host ("    Operator BE:     " + $beUrl + "/api-docs") -ForegroundColor Gray
+Write-Host ""
+Write-Host "  Phase 18 dual-2pc routing:" -ForegroundColor Cyan
+Write-Host ("    DE_B subject_index = " + $SubjectIndex) -ForegroundColor Gray
+Write-Host ("    DE_B registered to: " + $proxyUrl + "/register") -ForegroundColor Gray
+if ($DualGroupId) {
+    Write-Host ("    DUAL_2PC group_id = " + $DualGroupId + " (immediate 분기)") -ForegroundColor Gray
+} else {
+    Write-Host ("    Pending mode: DE_B awaits POST /control/assign-group from operator") -ForegroundColor Gray
+}
+Write-Host ""
+Write-Host "  Next actions (manual):" -ForegroundColor Cyan
+Write-Host ("    1. EMOTIV Launcher 띄움 + 노트북 B 헤드셋 페어링 확인") -ForegroundColor Gray
+Write-Host ("    2. DE_B 터미널의 'proxy registration' 로그 확인 (3 회 retry 안에 GREEN 인지)") -ForegroundColor Gray
+Write-Host ("    3. Operator PC FE 에서 measurement 시작 -> dual-2pc 흐름 검증") -ForegroundColor Gray
+Write-Host ""
+Write-Host "=== Notebook B DE_B healthy ===" -ForegroundColor Green
+Write-Host ""

--- a/scripts/realdevice/stop-realdevice-dual-2pc.ps1
+++ b/scripts/realdevice/stop-realdevice-dual-2pc.ps1
@@ -1,0 +1,60 @@
+﻿# Mind Signal Phase 18.1 dual-2pc stopper (operator PC)
+# Pair with start-realdevice-dual-2pc.ps1
+# Kills processes by port (BE 5000 / DE_A 5002 / Proxy 5050) and optionally Redis container.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\stop-realdevice-dual-2pc.ps1
+#   powershell -ExecutionPolicy Bypass -File .\stop-realdevice-dual-2pc.ps1 -KeepRedis
+#   powershell -ExecutionPolicy Bypass -File .\stop-realdevice-dual-2pc.ps1 -KeepProxy
+
+[CmdletBinding()]
+param(
+    [int]$BackendPort = 5000,
+    [int]$DePort = 5002,
+    [int]$ProxyPort = 5050,
+    [switch]$KeepRedis,
+    [switch]$KeepProxy
+)
+
+function Stop-ByPort {
+    param([int]$Port, [string]$Name)
+    $conns = Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue
+    if (-not $conns) {
+        Write-Host ("  " + $Name + " not listening on " + $Port) -ForegroundColor DarkGray
+        return
+    }
+    foreach ($c in $conns) {
+        try {
+            Stop-Process -Id $c.OwningProcess -Force -ErrorAction Stop
+            Write-Host ("  Killed " + $Name + " (PID " + $c.OwningProcess + " port " + $Port + ")") -ForegroundColor Green
+        } catch {
+            Write-Host ("  Failed to kill PID " + $c.OwningProcess + ": " + $_.Exception.Message) -ForegroundColor Red
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "=== Mind Signal Realdevice Dual-2PC Stopper ===" -ForegroundColor Cyan
+Write-Host ""
+
+Stop-ByPort -Port $BackendPort -Name "Backend"
+Stop-ByPort -Port $DePort -Name "DE_A"
+if (-not $KeepProxy) {
+    Stop-ByPort -Port $ProxyPort -Name "Proxy"
+} else {
+    Write-Host "  Proxy kept (KeepProxy flag)" -ForegroundColor DarkYellow
+}
+
+if (-not $KeepRedis) {
+    docker stop mind-signal-redis 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  Stopped mind-signal-redis container" -ForegroundColor Green
+    } else {
+        Write-Host "  Redis container not running" -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host "  Redis kept (KeepRedis flag)" -ForegroundColor DarkYellow
+}
+
+Write-Host ""
+Write-Host "=== Stop done ===" -ForegroundColor Green

--- a/scripts/realdevice/stop-realdevice-notebook-b.ps1
+++ b/scripts/realdevice/stop-realdevice-notebook-b.ps1
@@ -1,0 +1,56 @@
+﻿# Mind Signal Phase 18.1 dual-2pc notebook B stopper
+# DE_B 만 stop. operator PC 서비스는 별개로 stop.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\stop-realdevice-notebook-b.ps1
+
+[CmdletBinding()]
+param(
+    [int]$DePort = 5002
+)
+
+function Stop-ByPort {
+    param([int]$Port, [string]$Name)
+    $conns = Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue
+    if (-not $conns) {
+        Write-Host ("  " + $Name + " not listening on " + $Port) -ForegroundColor DarkGray
+        return
+    }
+    foreach ($c in $conns) {
+        try {
+            Stop-Process -Id $c.OwningProcess -Force -ErrorAction Stop
+            Write-Host ("  Killed " + $Name + " (PID " + $c.OwningProcess + " port " + $Port + ")") -ForegroundColor Green
+        } catch {
+            Write-Host ("  Failed to kill PID " + $c.OwningProcess + ": " + $_.Exception.Message) -ForegroundColor Red
+        }
+    }
+}
+
+function Stop-PythonRunServer {
+    # uvicorn reload=True 일 때 부모 process kill 후 child python 잔존 사례 우회 (실측 2026-05-27).
+    $procs = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -eq "python.exe" -and $_.CommandLine -match "run_server\.py"
+    }
+    if (-not $procs) {
+        Write-Host "  No residual python run_server.py process" -ForegroundColor DarkGray
+        return
+    }
+    foreach ($p in $procs) {
+        try {
+            Stop-Process -Id $p.ProcessId -Force -ErrorAction Stop
+            Write-Host ("  Killed residual python (PID " + $p.ProcessId + ")") -ForegroundColor Green
+        } catch {
+            Write-Host ("  Failed to kill PID " + $p.ProcessId + ": " + $_.Exception.Message) -ForegroundColor Red
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "=== Mind Signal Realdevice Notebook B Stopper ===" -ForegroundColor Cyan
+Write-Host ""
+
+Stop-ByPort -Port $DePort -Name "DE_B"
+Stop-PythonRunServer
+
+Write-Host ""
+Write-Host "=== Stop done ===" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- `.env.example` Phase 17 ngrok 잔재 cleanup + Phase 18 proxy mode 신규 env 박제
- AGENTS.md 4절에 "Phase migration 환경변수 cleanup 룰" 신설
- paperwork-only, 코드 변경 0건 — 운영자 setup 가이드 가시성 ↑

## Why

5/26 D-0 시연 setup 도중 DE_A `.env.local`의 `REGISTRATION_MODE=ngrok` 잔재 발견 (Phase 17 시점 박제, Phase 18 migration 시 cleanup 누락). proxy mode 환경에서 ngrok URL을 proxy `/register`로 보낼 때 등록 risk 발생. 운영자가 `.env.example` 복사하면 동일 잔재 박제 risk 지속. 본 PR은 `.env.example` amend + AGENTS.md 룰 박제로 미래 phase migration 시점 자동 cross-verify 트리거 박제.

baseline 박제 시점: 옵시디언 [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]] 핵심 발견 6.

## Changes

### `.env.example` (5 amend)

| 위치 | 변경 |
|---|---|
| REGISTRATION_MODE 위 주석 신설 | Phase 18 proxy mode 환경에선 local 의무 + ngrok URL 등록 risk 박제 |
| LAN_IP 주석 amend | operator PC = 127.0.0.1, 노트북 B = 핫스팟 어댑터 IPv4 분기 박제 |
| ALIGNMENT_LOCATION 신규 | Phase 18 proxy mode 트리거, 빈 값 default |
| PROXY_URL 신규 | proxy mode 활성화 시 PROXY_URL 명시. operator PC vs 노트북 B 시점 분기 박제 |
| NGROK_AUTH_TOKEN 주석 amend | Phase 17 잔재 + Phase 18 미사용 권장 박제 |

### `AGENTS.md` 4절

- 신규 절 "Phase migration 환경변수 cleanup 룰" 추가
- 5/26 D-0 사례 3건 박제 (Phase 17 ngrok 잔재, Phase 18 신규 env, LAN_IP override 권장)
- Phase migration PR scope에 `.env.example` 정합 + AGENTS.md amend 의무 박제 (transitive 상속 갭 차단)

## Base 결정

base = `feat/18-engine-proxy-sync` 채택 (R6 정합):

- R6 (3) "로컬 commit + 노트북 B 임시 clone만 허용" 정합. feat/18 자체 진화는 허용 (dev/main 머지 금지 영향 0)
- AGENTS.md가 dev base에 부재 (feat/18 commit `1439737`에서 신규 추가, 미머지). dev base이면 AGENTS.md amend 불가능
- 본 PR 머지 시 feat/18 HEAD 진화 → 시연 재일정 시점에 자동 적용. feat/18 → dev 머지 시점 (시연 종결 후)에 본 amend 자동 dev 포함

## Test plan

- [x] 본 amend는 `.md` only — black/isort/flake8/pytest 코드 영향 0
- [x] pytest 결과 baseline 실패 2건 + 에러 3건 (`test_lifespan_dual_2pc`) 본 PR 무관 — feat/18 HEAD `1439737` baseline 실패 (별도 추적 의무)
- [ ] 운영자가 `.env.example` 복사 시 ALIGNMENT_LOCATION + PROXY_URL 시점 박제 확인 (5/26 D-0 재현 시점)
- [ ] AGENTS.md "Phase migration 환경변수 cleanup 룰" 절을 미래 phase migration PR에서 실제로 참조하는지 검증

## baseline pytest 실패 박제

본 PR과 무관한 baseline 실패 — 별도 추적 의무:

```
FAILED tests/test_lifespan_dual_2pc.py::test_lifespan_dual_env_immediate_register
FAILED tests/test_lifespan_dual_2pc.py::test_lifespan_single_legacy_register
ERROR tests/test_lifespan_dual_2pc.py::test_lifespan_placeholder_secret_warns_but_continues
ERROR tests/test_lifespan_dual_2pc.py::test_lifespan_dual_env_immediate_register
ERROR tests/test_lifespan_dual_2pc.py::test_lifespan_single_legacy_register
```

본 PR 머지 후 baseline 실패 fix 별도 PR 트리거.

## 관련

- 트랙 박제: [[2026-05-26-hotspot-pivot-next-session-handoff]] 트랙 4 (재정의 — `.gitignore` 발견으로 `.env.local` commit 불가능, `.env.example` + AGENTS.md amend로 전환)
- 함정 박제: [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]] 핵심 발견 6
- 트랙 1 governance correction: [[2026-05-26-track-1-doc-governance-correction-done]]

## Co-authored-by 정책 메모

본 commit은 KWONSEOK02 trailer 박제 (global 메모리 `feedback_commit_author` 정합). DE_A `AGENTS.md` L100 + `.agents/rules/commit-conventions.md` L29-L33는 `gs07103` trailer 박제 — BE의 2026-05-16 통일 (`gs07103` → `KWONSEOK02`) 미적용 상태. trailer 정책 통일은 별도 PR scope (본 PR 외).