### PR TITLE
feat(streamer): 측정 종료 시 subject CSV operator 업로드 (2-PC 집계)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,10 @@ ENGINE_SECRET_KEY=<shared_secret>
 
 Redis 채널은 `core.main`의 인수(groupId, subjectIndex)로 동적 결정 — 환경변수 불필요.
 
+### Cortex TLS 인증서 — `certificates/rootCA.pem` 로컬 필수
+
+`sdk/cortex.py`가 Cortex wss 연결의 TLS CA로 레포 루트의 `certificates/rootCA.pem`을 읽음. 이 파일은 gitignore라 git에 안 올라오므로 **새 머신마다 로컬에 직접 둬야 함**. 누락 시 `core.main`이 `SSL CA certificate loading failed: [Errno 2] No such file or directory` 출력 후 0.0초 만에 returncode 0으로 종료함(헤드셋은 정상 발견돼도 측정 0초). 기존 Emotiv 설치 경로의 인증서를 복사해 채움. 2026-06-28 노트북 B 라이브 연결 검증 중 D8(즉시종료) 근본 원인으로 확인됨.
+
 ### Phase migration 환경변수 cleanup 룰
 
 Phase migration 진행 시 `.env.local` 또는 `.env.example`에 박제된 환경변수 중 이전 Phase 전용으로 남아 있는 값은 cleanup 의무. 5/26 D-0 시연 setup 도중 노출된 사례:

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -16,12 +16,14 @@ from redis.retry import Retry
 
 from core.analyzer import MindSignalAnalyzer
 from sdk.cortex import Cortex
+from server.config import settings
 from server.services.proxy_client import (
     ProxyForwardError,
     ProxyHealthTracker,
     check_health,
     post_sample,
 )
+from server.services.webhook import upload_csv_to_backend
 
 logger = logging.getLogger(__name__)
 
@@ -461,4 +463,10 @@ class MindSignalStreamer(Cortex):
         elapsed = time.time() - self.start_time if hasattr(self, "start_time") else 0
         if hasattr(self, "csv_file") and not self.csv_file.closed:
             self.csv_file.close()
+        # 2-PC 집계 — CSV 닫힌 직후 operator BE로 사본 업로드함 (soft-fail).
+        # 양쪽 DE가 업로드해도 operator 자기 사본은 멱등 overwrite라 무해함.
+        if getattr(self, "csv_path", None):
+            upload_csv_to_backend(
+                settings.backend_url, self.csv_path, self.engine_secret_key
+            )
         print(f"프로그램이 안전하게 종료되었음. (총 측정 시간: {elapsed:.1f}초)")

--- a/server/services/webhook.py
+++ b/server/services/webhook.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import httpx
 
@@ -160,3 +161,47 @@ async def start_heartbeat_dual(
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             # heartbeat transient error 허용함 (log-and-continue)
             print(f"dual heartbeat register failed (non-fatal): {e}")
+
+
+def upload_csv_to_backend(
+    backend_url: str,
+    csv_path: str,
+    secret_key: str,
+    timeout: float = 10.0,
+) -> bool:
+    """측정 종료 시 subject CSV를 operator BE로 업로드함 (2-PC 집계). soft-fail.
+
+    원본 CSV는 각 노트북에 분산 유지하고 분석용 사본만 operator로 전송함.
+    실패해도 raise 안 함 — 측정 종료 흐름을 깨지 않기 위함. streamer가 sync 컨텍스트라
+    sync httpx.Client 사용함.
+
+    Args:
+        backend_url: operator BE 베이스 URL.
+        csv_path: 업로드할 로컬 CSV 절대경로.
+        secret_key: X-Engine-Secret 헤더 공유 시크릿.
+        timeout: HTTP 타임아웃 초.
+
+    Returns:
+        업로드 성공 여부 반환.
+    """
+    filename = os.path.basename(csv_path)
+    try:
+        with open(csv_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(
+                f"{backend_url}/api/engine/csv-upload",
+                params={"filename": filename},
+                headers={
+                    "X-Engine-Secret": secret_key,
+                    "Content-Type": "text/csv",
+                },
+                content=content.encode("utf-8"),
+            )
+            response.raise_for_status()
+        print(f"[csv-upload] {filename} 업로드 완료")
+        return True
+    except (httpx.HTTPError, OSError) as e:
+        # soft-fail: 측정 종료 흐름 보호 — raise 금지
+        print(f"[WARN] csv-upload failed (soft): {e}")
+        return False

--- a/tests/test_upload_csv.py
+++ b/tests/test_upload_csv.py
@@ -1,0 +1,50 @@
+"""upload_csv_to_backend 단위 테스트 (2-PC CSV 집계)
+
+측정 종료 시 노트북 B DE가 자기 subject CSV를 operator BE로 업로드함.
+soft-fail: 업로드 실패해도 측정 종료 흐름을 깨지 않아야 함.
+"""
+
+from pytest_httpx import HTTPXMock
+
+from server.services.webhook import upload_csv_to_backend
+
+MOCK_BACKEND_URL = "http://mock-backend:5000"
+SECRET = "test-secret"
+FILENAME = "subject_2_6a413cef58664859f44ee519_20260629_002612.csv"
+
+
+def test_upload_csv_success(httpx_mock: HTTPXMock, tmp_path) -> None:
+    """200 응답 시 CSV 본문+secret 헤더+filename 쿼리로 POST 호출 + True 반환함"""
+    csv = tmp_path / FILENAME
+    csv.write_text("time,alpha\n2026-06-29 00:26:12,0.3\n", encoding="utf-8")
+
+    httpx_mock.add_response(method="POST", status_code=200, json={"status": "success"})
+
+    ok = upload_csv_to_backend(MOCK_BACKEND_URL, str(csv), SECRET)
+
+    assert ok is True
+    req = httpx_mock.get_request()
+    assert req is not None
+    assert req.method == "POST"
+    assert "/api/engine/csv-upload" in str(req.url)
+    assert f"filename={FILENAME}" in str(req.url)
+    assert req.headers["X-Engine-Secret"] == SECRET
+    assert b"alpha" in req.content
+
+
+def test_upload_csv_soft_fail_on_5xx(httpx_mock: HTTPXMock, tmp_path) -> None:
+    """5xx 응답이어도 raise 안 하고 False 반환함 (측정 종료 흐름 보호)"""
+    csv = tmp_path / FILENAME
+    csv.write_text("x\n", encoding="utf-8")
+
+    httpx_mock.add_response(method="POST", status_code=500)
+
+    ok = upload_csv_to_backend(MOCK_BACKEND_URL, str(csv), SECRET)
+
+    assert ok is False
+
+
+def test_upload_csv_missing_file_soft_fail(tmp_path) -> None:
+    """파일이 없으면 raise 안 하고 False 반환함"""
+    ok = upload_csv_to_backend(MOCK_BACKEND_URL, str(tmp_path / "nope.csv"), SECRET)
+    assert ok is False


### PR DESCRIPTION
## 변경
- 측정 종료(on_close) 시 subject CSV 사본을 operator BE /api/engine/csv-upload로 업로드 (sync httpx, soft-fail — 실패해도 종료 흐름 안 깨짐)
- 원본은 각 노트북 분산 유지, 분석용 사본만 operator에 집계

## 테스트
- pytest test_upload_csv 3건 신규 (성공/5xx soft-fail/파일없음). 변경 전후 lifespan 실패는 사전 결함(무관)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 측정 종료 시 CSV 결과를 백엔드로 자동 업로드하도록 개선되었습니다.
  * 업로드 실패나 파일 누락이 발생해도 앱이 중단되지 않고 종료를 계속합니다.

* **문서**
  * TLS 인증서 준비 방법과 누락 시 동작이 안내에 추가되었습니다.
  * 로컬 인증서 파일이 필요하다는 점과 관련 오류 메시지가 명시되었습니다.

* **테스트**
  * CSV 업로드 성공, 서버 오류, 파일 없음 상황에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->