### PR TITLE
fix(core): 동적 헤드셋 바인딩 + /health subject_index

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -29,8 +29,10 @@ def main():
     group_id = sys.argv[1]
     subject_index = sys.argv[2]
 
-    # subject_index에 매핑된 헤드셋 ID 조회함 (미설정 시 SDK 자동 선택)
-    headset_id = os.getenv(f"HEADSET_ID_{subject_index}", "")
+    # 동적 바인딩: 헤드셋 ID를 고정하지 않음. 빈 문자열을 넘기면 SDK가 이 PC에
+    # 연결된 첫 헤드셋을 자동 선택해 subject_index 스트림으로 값을 주입함.
+    # 헤드셋 ID 하드코딩 제거 — 어떤 헤드셋이 붙어도 동작 (PC당 헤드셋 1대 전제).
+    headset_id = ""
 
     # proxy 연동 설정 로드함 (ALIGNMENT_LOCATION=proxy 시 proxy 모드 활성화)
     alignment_location = os.getenv("ALIGNMENT_LOCATION", "be")
@@ -44,13 +46,9 @@ def main():
     proxy_fail_closed_threshold_ms = int(os.getenv("FAIL_CLOSED_THRESHOLD_MS", "3000"))
 
     print(f"Mind Signal Engine 구동 시작함 (Group: {group_id}, Index: {subject_index})")
-    if headset_id:
-        print(f"지정 헤드셋: {headset_id}")
-    else:
-        print(
-            f"[WARNING] HEADSET_ID_{subject_index} 미설정"
-            " — SDK가 첫 번째 헤드셋을 자동 선택함"
-        )
+    print(
+        f"[INFO] 헤드셋 동적 선택 — Cortex가 보고한 첫 헤드셋을 subject {subject_index}로 사용함"
+    )
 
     # 스트리머 인스턴스 생성 및 실행 수행함
     streamer = MindSignalStreamer(

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter
 
+from server.config import settings
+
 router = APIRouter()
 
 
 @router.get("/health")
 async def health_check():
-    """서버 상태 확인 엔드포인트임"""
-    return {"status": "ok", "service": "mind-signal-data-engine"}
+    """서버 상태 확인 엔드포인트임 (대시보드용 subject_index 포함)"""
+    return {
+        "status": "ok",
+        "service": "mind-signal-data-engine",
+        "subject_index": settings.dual_2pc_subject_index,
+    }

--- a/tests/routes/test_health.py
+++ b/tests/routes/test_health.py
@@ -1,0 +1,13 @@
+"""GET /health 회귀 테스트.
+
+대시보드가 각 DE의 subject_index를 표시할 수 있도록 /health가 이를 노출하는지 검증함.
+"""
+
+
+def test_health_reports_subject_index(test_client):
+    response = test_client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "mind-signal-data-engine"
+    assert "subject_index" in body

--- a/tests/routes/test_health.py
+++ b/tests/routes/test_health.py
@@ -1,13 +1,24 @@
 """GET /health 회귀 테스트.
 
 대시보드가 각 DE의 subject_index를 표시할 수 있도록 /health가 이를 노출하는지 검증함.
+값 바인딩이 끊기거나 상수화돼도 잡도록 settings 값을 sentinel로 패치해 검증함.
 """
 
+from server.config import settings
 
-def test_health_reports_subject_index(test_client):
+
+def test_health_reports_subject_index(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", 2)
     response = test_client.get("/health")
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "ok"
     assert body["service"] == "mind-signal-data-engine"
-    assert "subject_index" in body
+    assert body["subject_index"] == 2
+
+
+def test_health_reports_null_subject_index(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "dual_2pc_subject_index", None)
+    response = test_client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["subject_index"] is None

--- a/tests/test_headset_binding.py
+++ b/tests/test_headset_binding.py
@@ -1,0 +1,43 @@
+"""동적 헤드셋 바인딩 재현/회귀 테스트.
+
+문제 1: core/main.py가 HEADSET_ID_{idx} 환경변수로 헤드셋을 고정 바인딩한다.
+원하는 동작: env를 무시하고 빈 문자열을 넘겨 SDK가 첫 연결 헤드셋을 자동 선택한다
+(어떤 헤드셋이 붙어도 그 PC의 subject로 값 주입).
+
+현재 코드는 env를 읽으므로 이 테스트는 RED여야 한다 (수정 후 GREEN = 회귀 잠금).
+"""
+
+import sys
+
+import core.main as main_module
+
+
+def test_main_ignores_headset_id_env_and_lets_sdk_pick_first(monkeypatch):
+    captured = {}
+
+    class FakeStreamer:
+        def __init__(
+            self,
+            group_id,
+            subject_index,
+            client_id,
+            client_secret,
+            headset_id="",
+            **kwargs,
+        ):
+            captured["headset_id"] = headset_id
+
+        def open(self):
+            captured["opened"] = True
+
+    monkeypatch.setattr(main_module, "MindSignalStreamer", FakeStreamer)
+    monkeypatch.setenv("CLIENT_ID", "test-client")
+    monkeypatch.setenv("CLIENT_SECRET", "test-secret")
+    # 하드코딩 시나리오: 특정 헤드셋 ID가 env에 박혀 있어도
+    monkeypatch.setenv("HEADSET_ID_1", "INSIGHT2-HARDCODED")
+    monkeypatch.setattr(sys, "argv", ["core.main", "group-xyz", "1"])
+
+    main_module.main()
+
+    # 동적 바인딩: env의 하드코딩 ID를 절대 통과시키지 않고 빈 문자열을 넘겨야 한다.
+    assert captured["headset_id"] == ""

--- a/tests/test_headset_binding.py
+++ b/tests/test_headset_binding.py
@@ -4,15 +4,23 @@
 원하는 동작: env를 무시하고 빈 문자열을 넘겨 SDK가 첫 연결 헤드셋을 자동 선택한다
 (어떤 헤드셋이 붙어도 그 PC의 subject로 값 주입).
 
-현재 코드는 env를 읽으므로 이 테스트는 RED여야 한다 (수정 후 GREEN = 회귀 잠금).
+subject_index 1/2를 모두 파라미터화해 양쪽 HEADSET_ID env가 전부 무시되는지 잠근다.
 """
 
 import sys
 
+import pytest
+
 import core.main as main_module
 
 
-def test_main_ignores_headset_id_env_and_lets_sdk_pick_first(monkeypatch):
+@pytest.mark.parametrize(
+    ("subject_index", "env_var"),
+    [("1", "HEADSET_ID_1"), ("2", "HEADSET_ID_2")],
+)
+def test_main_ignores_headset_id_env_and_lets_sdk_pick_first(
+    monkeypatch, subject_index, env_var
+):
     captured = {}
 
     class FakeStreamer:
@@ -33,9 +41,9 @@ def test_main_ignores_headset_id_env_and_lets_sdk_pick_first(monkeypatch):
     monkeypatch.setattr(main_module, "MindSignalStreamer", FakeStreamer)
     monkeypatch.setenv("CLIENT_ID", "test-client")
     monkeypatch.setenv("CLIENT_SECRET", "test-secret")
-    # 하드코딩 시나리오: 특정 헤드셋 ID가 env에 박혀 있어도
-    monkeypatch.setenv("HEADSET_ID_1", "INSIGHT2-HARDCODED")
-    monkeypatch.setattr(sys, "argv", ["core.main", "group-xyz", "1"])
+    # 하드코딩 시나리오: 해당 subject의 헤드셋 ID가 env에 박혀 있어도
+    monkeypatch.setenv(env_var, "INSIGHT2-HARDCODED")
+    monkeypatch.setattr(sys, "argv", ["core.main", "group-xyz", subject_index])
 
     main_module.main()
 


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 목적
어떤 헤드셋이 각 PC에 붙어도 그 PC의 subject로 값이 주입되게 한다(헤드셋 ID 하드코딩 제거). 추가로 대시보드용 /health에 subject_index 노출.

## 변경 (2 커밋)
- `fix(core): 동적 헤드셋 바인딩` — core/main.py가 HEADSET_ID_{idx} env를 무시하고 빈 문자열을 넘겨 SDK 첫-헤드셋 폴백을 항상 사용. ID 불일치 시 0데이터 버그 + .env 중복버그 부류 제거. sdk/ 무수정(Emotiv 원본). 회귀 잠금 test_headset_binding.
- `feat(health): /health subject_index` — 대시보드가 각 DE의 subject_index를 표시하도록 응답에 추가.

## 검증
black/isort/flake8 통과, 신규 테스트 2 green, 전체 pytest 138 passed(실패는 사전결함 test_lifespan_dual_2pc, 본 변경 무관).

## 비고
- 노트북 B도 이 변경 필요(머지 후 dev pull) + .env.local의 HEADSET_ID_1/2 줄 삭제.
- 설계/계획: Team-project/.plans/19-2pc-autoconnect-ops/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 상태 확인 응답(/health)에 대시보드용 `subject_index`가 추가되었습니다.
* **Bug Fixes**
  * 헤드셋 지정 환경 설정에 의존하지 않고, SDK가 첫 헤드셋을 자동 선택하도록 동작이 개선되었습니다.
  * 실행 시작 안내가 “헤드셋 동적 선택” 기준으로 일관되게 출력됩니다.
* **Tests**
  * `/health`에서 `subject_index` 값이 정상/Null 모두 노출되는지 검증하는 회귀 테스트가 추가되었습니다.
  * 헤드셋 자동 선택 동작을 확인하는 회귀 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->