### PR TITLE
fix(scripts): realdevice DE 기동을 절대 conda python으로 (conda activate 미동작 우회)

### DIFF
--- a/scripts/realdevice/start-realdevice-dual-2pc.ps1
+++ b/scripts/realdevice/start-realdevice-dual-2pc.ps1
@@ -226,7 +226,8 @@ if (Test-PortInUse -Port $DePort) {
     Write-Warn2 ("Port " + $DePort + " already in use. Assuming DE_A already running.")
 } else {
     $deDir = Join-Path $ProjectRoot "mind-signal-data-engine"
-    $deCmd = "conda activate $CondaEnv && python run_server.py"
+    # 절대 conda python 경로로 직접 기동함 (cmd 자식에서 conda activate 미동작 사례 우회, AGENTS _start-de-test.bat 패턴).
+    $deCmd = "`"$condaPath\python.exe`" run_server.py"
     $deArgs = "/k cd /d `"$deDir`" && $deCmd"
     Start-Process -FilePath "cmd.exe" -ArgumentList $deArgs -WindowStyle Normal
     Write-OK "DE_A terminal launched (env inherited from PowerShell scope)"

--- a/scripts/realdevice/start-realdevice-notebook-b.ps1
+++ b/scripts/realdevice/start-realdevice-notebook-b.ps1
@@ -227,7 +227,8 @@ Write-Step "2/7" ("Data Engine B (port " + $DePort + ", subject_index=" + $Subje
 if (Test-PortInUse -Port $DePort) {
     Write-Warn2 ("Port " + $DePort + " already in use. Assuming DE_B already running.")
 } else {
-    $deCmd = "conda activate $CondaEnv && python run_server.py"
+    # 절대 conda python 경로로 직접 기동함 (cmd 자식에서 conda activate 미동작 사례 우회, AGENTS _start-de-test.bat 패턴).
+    $deCmd = "`"$condaPath\python.exe`" run_server.py"
     $deArgs = "/k cd /d `"$deDir`" && $deCmd"
     Start-Process -FilePath "cmd.exe" -ArgumentList $deArgs -WindowStyle Normal
     Write-OK "DE_B terminal launched (env inherited from PowerShell scope)"


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 문제
operator 라이브 기동 중 발견: 런처가 DE를 `Start-Process cmd /k ... conda activate mind-signal && python run_server.py`로 띄우는데, 자식 cmd에서 **conda activate가 실패**해 python이 안 뜨고 DE_A가 60초 health 타임아웃(exit 5). conda는 PATH 미등록(RegisterPython=0/AddToPath=0)이라 cmd 자식이 conda 훅을 못 받는 경우 발생.

## 수정
DE_A·DE_B 기동을 이미 resolve된 `$condaPath\python.exe` 절대경로로 직접 호출. conda activate 의존 제거(AGENTS `_start-de-test.bat` 절대경로 패턴 정합).

## 검증 (라이브)
- 재현: conda activate 방식 → DE_A 60초 타임아웃, python 프로세스 부재 확인
- 수정 후: 같은 런처로 DE_A **2시도만에 healthy(200)**, 자체 창에서 정상 기동. operator 풀스택 green(redis/BE/DE_A/proxy/FE) + 대시보드 /health 집계 동작 확인

## 비고
- DE_B(notebook-b 런처)도 동일 수정 — 노트북 B는 머지 후 pull 권장.
- 코드 자체는 무변경(run_server.py 정상). 기동 방식만 robust화.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 일부 실장치 실행 환경에서 서버 시작 방식이 개선되어, conda 활성화 문제로 인한 실행 실패를 줄였습니다.
  * 데이터 엔진 시작 시 Python 경로를 더 안정적으로 찾도록 변경해, 실행 성공률을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->