### PR TITLE
fix(core): core.main em dash cp949 크래시 핫픽스

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -31,7 +31,7 @@ def main():
 
     # 동적 바인딩: 헤드셋 ID를 고정하지 않음. 빈 문자열을 넘기면 SDK가 이 PC에
     # 연결된 첫 헤드셋을 자동 선택해 subject_index 스트림으로 값을 주입함.
-    # 헤드셋 ID 하드코딩 제거 — 어떤 헤드셋이 붙어도 동작 (PC당 헤드셋 1대 전제).
+    # 헤드셋 ID 하드코딩 제거함. 어떤 헤드셋이 붙어도 동작함 (PC당 헤드셋 1대 전제).
     headset_id = ""
 
     # proxy 연동 설정 로드함 (ALIGNMENT_LOCATION=proxy 시 proxy 모드 활성화)
@@ -47,7 +47,7 @@ def main():
 
     print(f"Mind Signal Engine 구동 시작함 (Group: {group_id}, Index: {subject_index})")
     print(
-        f"[INFO] 헤드셋 동적 선택 — Cortex가 보고한 첫 헤드셋을 subject {subject_index}로 사용함"
+        f"[INFO] 헤드셋 동적 선택: Cortex가 보고한 첫 헤드셋을 subject {subject_index}로 사용함"
     )
 
     # 스트리머 인스턴스 생성 및 실행 수행함


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

#26 print의 em dash(U+2014)가 Windows cp949 콘솔/로그 인코딩 실패로 core.main을 시작 직후 죽여 EEG 0 발생. 평문 치환. 라이브 데모 블로커 핫픽스.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 시작 시 표시되는 안내 메시지 문구가 더 자연스럽게 정리되었습니다.
* **Documentation**
  * 관련 주석 표현이 간단하고 명확하게 다듬어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->