### PR TITLE
feat(engine): 2PC idle-rebind 자동복구 + 진단/로그 엔드포인트 + SSL 자가치유

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -7,7 +7,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 
 from server.config import settings
-from server.routes import analyze, control, export, health, stream
+from server.routes import analyze, control, export, health, logs, stream
+from server.services import logbuffer
 from server.services.webhook import (
     register_to_backend,
     register_to_backend_dual,
@@ -269,3 +270,7 @@ app.include_router(analyze.router, prefix="/api", tags=["Analyze"])
 app.include_router(export.router, prefix="/api", tags=["Export"])
 app.include_router(stream.router, prefix="/api", tags=["Stream"])
 app.include_router(control.router, tags=["Control"])
+app.include_router(logs.router, tags=["Logs"])
+
+# 서버 로그를 링버퍼에 캡처해 대시보드에서 원격 조회 가능하게 함 (멱등)
+logbuffer.install()

--- a/server/config.py
+++ b/server/config.py
@@ -1,6 +1,16 @@
+import os
 from typing import Literal
 
+import certifi
 from pydantic_settings import BaseSettings
+
+# SSL_CERT_FILE이 존재하지 않는 경로를 가리키면 certifi 번들로 교정함.
+# conda base 활성화가 심는 stale 값(miniconda3/ssl/cacert.pem 부재)으로 httpx가
+# FileNotFoundError로 죽는 것을 방어함. config는 httpx 사용 모듈 대부분이 import하므로
+# 여기서 교정하면 런타임+테스트 전 경로에서 유효함.
+_ssl_cert = os.environ.get("SSL_CERT_FILE")
+if _ssl_cert and not os.path.exists(_ssl_cert):
+    os.environ["SSL_CERT_FILE"] = certifi.where()
 
 
 class Settings(BaseSettings):

--- a/server/routes/control.py
+++ b/server/routes/control.py
@@ -28,6 +28,7 @@ class ReleaseRequest(BaseModel):
 
     group_id: str | None = Field(
         None,
+        min_length=1,
         description="해제 대상 groupId. 미지정 시 현재 바인딩 무조건 해제함 (비상 전체해제)",
     )
 
@@ -52,9 +53,10 @@ def _stop_streams_for(group_id: str) -> list[str]:
         try:
             stop_stream(gid, int(sidx))
             stopped.append(key)
-        except (KeyError, ValueError):
-            # 이미 정리됐거나 key 파싱 실패 — 무시함
-            pass
+        except (KeyError, ValueError) as exc:
+            # 이미 정리됐거나 key 파싱 실패 — 비상 release는 나머지 스트림도 계속
+            # 정지해야 하므로 중단하지 않고 경고만 남김 (가시성 확보)
+            print(f"[WARN] release stream stop skipped for {key}: {exc}")
     return stopped
 
 
@@ -182,7 +184,7 @@ async def release_group(
 
     async with app.state.assign_lock:
         current = app.state.registered_group_id
-        target = body.group_id or current
+        target = current if body.group_id is None else body.group_id
 
         stopped: list[str] = []
         if target:

--- a/server/routes/control.py
+++ b/server/routes/control.py
@@ -1,4 +1,4 @@
-"""Control 라우터 — DUAL_2PC runtime groupId 주입 엔드포인트 제공함 (Phase 17.5)"""
+"""Control 라우터 — DUAL_2PC runtime groupId 주입 + idle-rebind 자동복구 제공함 (Phase 17.5 + 19)"""
 
 import asyncio
 
@@ -6,6 +6,7 @@ import httpx
 from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from server.services.stream import get_all_status, stop_stream
 from server.services.webhook import (
     register_to_backend_dual,
     start_heartbeat_dual,
@@ -22,6 +23,50 @@ class AssignGroupRequest(BaseModel):
     )
 
 
+class ReleaseRequest(BaseModel):
+    """/control/release 요청 바디 스키마임 (비상 해제 / BE supersede)"""
+
+    group_id: str | None = Field(
+        None,
+        description="해제 대상 groupId. 미지정 시 현재 바인딩 무조건 해제함 (비상 전체해제)",
+    )
+
+
+def _is_streaming_for(group_id: str) -> bool:
+    """해당 group_id로 실행 중인 스트리밍 프로세스 존재 여부 반환함 (측정중 판정)."""
+    for s in get_all_status():
+        key = s.get("key", "")
+        if s.get("running") and key.startswith(f"{group_id}:"):
+            return True
+    return False
+
+
+def _stop_streams_for(group_id: str) -> list[str]:
+    """해당 group_id의 실행 중 스트림 전부 정지함 — orphan core.main 방지. 정지된 key 반환."""
+    stopped: list[str] = []
+    for s in get_all_status():
+        key = s.get("key", "")
+        if not (s.get("running") and key.startswith(f"{group_id}:")):
+            continue
+        gid, _, sidx = key.partition(":")
+        try:
+            stop_stream(gid, int(sidx))
+            stopped.append(key)
+        except (KeyError, ValueError):
+            # 이미 정리됐거나 key 파싱 실패 — 무시함
+            pass
+    return stopped
+
+
+def _release_binding(app) -> None:
+    """현재 그룹 바인딩 해제함 — registered_group_id 초기화 + heartbeat 취소함."""
+    task = getattr(app.state, "heartbeat_task", None)
+    if task is not None:
+        task.cancel()
+        app.state.heartbeat_task = None
+    app.state.registered_group_id = None
+
+
 @router.post("/control/assign-group")
 async def assign_group(
     body: AssignGroupRequest,
@@ -30,14 +75,15 @@ async def assign_group(
 ):
     """DUAL_2PC groupId 런타임 주입 + BE /register-dual 트리거 처리함.
 
-    멱등 계약:
-    - pending → register-dual 호출 후 200 registered + heartbeat 시작함
-    - same group_id 재호출 → 200 already_registered (register 재호출 금지, heartbeat 재생성 금지)
-    - different group_id → 409 group_id_conflict 반환함
-    - secret mismatch → 401 invalid_secret 반환함
-    - BE 실패 → 502 backend_register_failed 반환함 + state는 pending 유지(재시도 가능)
+    멱등 + idle-rebind 계약 (Phase 19 자동복구):
+    - pending(null) → register-dual 후 200 registered + heartbeat 시작함
+    - same group_id 재호출 → 200 already_registered (register/heartbeat 재생성 금지)
+    - different group_id + **측정중 아님** → 옛 바인딩 supersede(해제) 후 새 그룹 등록 → 200 registered
+    - different group_id + **측정중** → 409 group_id_conflict (라이브 측정 보호, DE가 최종 거부권)
+    - secret mismatch → 401 invalid_secret
+    - BE 실패 → 502 backend_register_failed + state pending 유지(재시도 가능)
 
-    asyncio.Lock으로 race 방지함 — 동시 2건 요청 시 직렬화 처리함.
+    asyncio.Lock으로 race 방지함 — 동시 요청 직렬화 처리함.
     """
     app = request.app
 
@@ -63,12 +109,22 @@ async def assign_group(
         if current == body.group_id:
             return {"status": "already_registered", "groupId": body.group_id}
 
-        # 다른 groupId 이미 등록됨 → 409
+        superseded: str | None = None
+        # 다른 groupId 이미 등록됨 — idle-rebind 자동복구 (Phase 19)
         if current is not None:
-            raise HTTPException(
-                status_code=409,
-                detail={"error": "group_id_conflict", "current": current},
-            )
+            # 측정중이면 라이브 보호 — 409 유지 (DE가 최종 거부권 소유)
+            if _is_streaming_for(current):
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error": "group_id_conflict",
+                        "current": current,
+                        "reason": "measuring",
+                    },
+                )
+            # idle 바인딩 → supersede(해제) 후 아래 신규 등록 경로로 진행함
+            _release_binding(app)
+            superseded = current
 
         # 신규 등록 경로: BE /register-dual 호출함
         try:
@@ -96,4 +152,45 @@ async def assign_group(
             )
         )
 
-        return {"status": "registered", "groupId": body.group_id}
+        return {
+            "status": "registered",
+            "groupId": body.group_id,
+            "superseded": superseded,
+        }
+
+
+@router.post("/control/release")
+async def release_group(
+    body: ReleaseRequest,
+    request: Request,
+    x_engine_secret: str = Header(alias="X-Engine-Secret"),
+):
+    """그룹 바인딩 강제 해제함 — 비상 전체해제 / BE supersede 용.
+
+    - group_id 미지정 → 현재 바인딩 무조건 해제 + 해당 그룹 스트림 정지함 (비상)
+    - group_id 지정 + current 일치 → 해제 + 스트림 정지함
+    - group_id 지정 + current 불일치 → no-op (released=false)
+
+    측정중이어도 해제함 — 비상 도구이므로 orphan core.main도 함께 정지함.
+
+    Raises:
+        HTTPException 401 — secret 불일치 시.
+    """
+    app = request.app
+    if x_engine_secret != app.state.secret_key:
+        raise HTTPException(status_code=401, detail={"error": "invalid_secret"})
+
+    async with app.state.assign_lock:
+        current = app.state.registered_group_id
+        target = body.group_id or current
+
+        stopped: list[str] = []
+        if target:
+            stopped = _stop_streams_for(target)
+
+        released = False
+        if current is not None and (body.group_id is None or body.group_id == current):
+            _release_binding(app)
+            released = True
+
+        return {"released": released, "previous": current, "stopped": stopped}

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,15 +1,21 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from server.config import settings
+from server.services.stream import get_all_status
 
 router = APIRouter()
 
 
 @router.get("/health")
-async def health_check():
-    """서버 상태 확인 엔드포인트임 (대시보드용 subject_index 포함)"""
+async def health_check(request: Request):
+    """서버 상태 확인 엔드포인트임 (대시보드 groupId 일치확인 + 측정중 노출)"""
+    registered_group_id = getattr(request.app.state, "registered_group_id", None)
+    # 실행 중인 스트리밍 프로세스 존재 여부 계산함 (측정중 판정)
+    streaming = any(s.get("running") for s in get_all_status())
     return {
         "status": "ok",
         "service": "mind-signal-data-engine",
         "subject_index": settings.dual_2pc_subject_index,
+        "registered_group_id": registered_group_id,
+        "streaming": streaming,
     }

--- a/server/routes/logs.py
+++ b/server/routes/logs.py
@@ -1,0 +1,33 @@
+"""로그 조회 라우터 — 대시보드에서 원격 DE 서버 로그를 가져오기 위한 엔드포인트임."""
+
+from fastapi import APIRouter, Header, HTTPException, Query, Request
+
+from server.services.logbuffer import tail
+
+router = APIRouter()
+
+
+@router.get("/logs")
+async def get_logs(
+    request: Request,
+    n: int = Query(200, alias="tail", ge=1, le=1000),
+    x_engine_secret: str = Header(alias="X-Engine-Secret"),
+):
+    """최근 서버 로그 라인 반환함 (secret 검증).
+
+    Args:
+        n: 반환할 최근 라인 수 (기본 200, tail 쿼리 파라미터).
+
+    Returns:
+        lines 배열 + subject_index를 담은 dict.
+
+    Raises:
+        HTTPException 401 — secret 불일치 시.
+    """
+    if x_engine_secret != request.app.state.secret_key:
+        raise HTTPException(status_code=401, detail={"error": "invalid_secret"})
+    return {
+        "subject_index": getattr(request.app.state, "subject_index", None),
+        "registered_group_id": getattr(request.app.state, "registered_group_id", None),
+        "lines": tail(n),
+    }

--- a/server/routes/logs.py
+++ b/server/routes/logs.py
@@ -11,7 +11,7 @@ router = APIRouter()
 async def get_logs(
     request: Request,
     n: int = Query(200, alias="tail", ge=1, le=1000),
-    x_engine_secret: str = Header(alias="X-Engine-Secret"),
+    x_engine_secret: str | None = Header(default=None, alias="X-Engine-Secret"),
 ):
     """최근 서버 로그 라인 반환함 (secret 검증).
 
@@ -22,7 +22,7 @@ async def get_logs(
         lines 배열 + subject_index를 담은 dict.
 
     Raises:
-        HTTPException 401 — secret 불일치 시.
+        HTTPException 401 — secret 누락/불일치 시 (누락도 401로 통일).
     """
     if x_engine_secret != request.app.state.secret_key:
         raise HTTPException(status_code=401, detail={"error": "invalid_secret"})

--- a/server/services/logbuffer.py
+++ b/server/services/logbuffer.py
@@ -1,0 +1,46 @@
+"""DE 서버 로그 인메모리 링버퍼 — 대시보드 로그 조회용임 (원격 노트북 B 진단)."""
+
+import sys
+from collections import deque
+from typing import IO
+
+# 최근 서버 로그 라인 보관 링버퍼 — 최대 1000줄 유지함
+_BUFFER: deque[str] = deque(maxlen=1000)
+
+
+class _Tee:
+    """원본 스트림에 그대로 쓰면서 링버퍼에도 라인 캡처하는 래퍼임."""
+
+    def __init__(self, original: IO[str]) -> None:
+        self._original = original
+
+    def write(self, data: str) -> int:
+        # 원본 콘솔 출력 보존함
+        n = self._original.write(data)
+        text = data.strip()
+        if text:
+            _BUFFER.append(text)
+        return n
+
+    def flush(self) -> None:
+        self._original.flush()
+
+    def __getattr__(self, name: str):
+        # isatty 등 기타 속성은 원본으로 위임함
+        return getattr(self._original, name)
+
+
+def install() -> None:
+    """sys.stdout/stderr에 tee 설치해 서버 print 로그를 링버퍼에 캡처함 (멱등)."""
+    if not isinstance(sys.stdout, _Tee):
+        sys.stdout = _Tee(sys.stdout)
+    if not isinstance(sys.stderr, _Tee):
+        sys.stderr = _Tee(sys.stderr)
+
+
+def tail(n: int = 200) -> list[str]:
+    """최근 n개 로그 라인 반환함 (n<=0 이면 전체)."""
+    lines = list(_BUFFER)
+    if n <= 0:
+        return lines
+    return lines[-n:]

--- a/server/services/logbuffer.py
+++ b/server/services/logbuffer.py
@@ -9,17 +9,24 @@ _BUFFER: deque[str] = deque(maxlen=1000)
 
 
 class _Tee:
-    """원본 스트림에 그대로 쓰면서 링버퍼에도 라인 캡처하는 래퍼임."""
+    """원본 스트림에 그대로 쓰면서 링버퍼에 개행 기준 라인 캡처하는 래퍼임."""
 
     def __init__(self, original: IO[str]) -> None:
         self._original = original
+        # 개행 없이 끊긴 부분 라인 잔여분 — 다음 write까지 보관함 (tail N 정확도)
+        self._remainder = ""
 
     def write(self, data: str) -> int:
         # 원본 콘솔 출력 보존함
         n = self._original.write(data)
-        text = data.strip()
-        if text:
-            _BUFFER.append(text)
+        combined = self._remainder + data
+        parts = combined.split("\n")
+        # 마지막 조각은 개행으로 끝나지 않은 부분 라인 — 잔여분으로 보관함
+        self._remainder = parts.pop()
+        for line in parts:
+            line = line.rstrip("\r")
+            if line.strip():
+                _BUFFER.append(line)
         return n
 
     def flush(self) -> None:

--- a/tests/routes/test_control.py
+++ b/tests/routes/test_control.py
@@ -212,6 +212,17 @@ def test_release_bad_secret_returns_401(pending_app: FastAPI):
     assert resp.status_code == 401
 
 
+def test_release_empty_group_id_returns_422(pending_app: FastAPI):
+    """release group_id 빈 문자열 → 422 (부분 teardown 방지, CodeRabbit)"""
+    client = TestClient(pending_app)
+    resp = client.post(
+        "/control/release",
+        json={"group_id": ""},
+        headers={"X-Engine-Secret": TEST_SECRET},
+    )
+    assert resp.status_code == 422
+
+
 def test_assign_group_invalid_body_returns_422(pending_app: FastAPI):
     """잘못된 body → FastAPI validation 422 확인함 (pydantic 기본)"""
     client = TestClient(pending_app)

--- a/tests/routes/test_control.py
+++ b/tests/routes/test_control.py
@@ -143,20 +143,73 @@ def test_assign_group_concurrent_requests_serialized(
     assert len(requests) == 1
 
 
-def test_assign_group_different_group_returns_409(
+def test_assign_group_different_group_idle_rebinds_200(
     pending_app: FastAPI, httpx_mock: HTTPXMock
 ):
-    """X 등록됨 + Y 호출 → 409 group_id_conflict 확인함"""
+    """X 등록됨(측정중 아님) + Y 호출 → idle-rebind 200 + supersede 확인함 (Phase 19)"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
     httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
     client = TestClient(pending_app)
 
     _assign(client, TEST_GROUP_ID)
     resp = _assign(client, ANOTHER_GROUP_ID)
 
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "registered"
+    assert body["groupId"] == ANOTHER_GROUP_ID
+    assert body["superseded"] == TEST_GROUP_ID
+    assert pending_app.state.registered_group_id == ANOTHER_GROUP_ID
+
+
+def test_assign_group_different_group_measuring_returns_409(
+    pending_app: FastAPI, httpx_mock: HTTPXMock, monkeypatch
+):
+    """X 등록됨 + 측정중 + Y 호출 → 409 group_id_conflict(라이브 보호) 확인함 (Phase 19)"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    _assign(client, TEST_GROUP_ID)
+
+    # TEST_GROUP_ID로 실행 중인 스트림 존재하도록 mock함 (측정중 판정)
+    monkeypatch.setattr(
+        control,
+        "get_all_status",
+        lambda: [{"key": f"{TEST_GROUP_ID}:1", "pid": 1, "running": True}],
+    )
+    resp = _assign(client, ANOTHER_GROUP_ID)
+
     assert resp.status_code == 409
     body = resp.json()
     assert body["detail"]["error"] == "group_id_conflict"
     assert body["detail"]["current"] == TEST_GROUP_ID
+    assert body["detail"]["reason"] == "measuring"
+
+
+def test_release_clears_binding(pending_app: FastAPI, httpx_mock: HTTPXMock):
+    """register 후 release → 바인딩 해제 + released=true 확인함 (Phase 19)"""
+    httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
+    client = TestClient(pending_app)
+
+    _assign(client, TEST_GROUP_ID)
+    resp = client.post(
+        "/control/release", json={}, headers={"X-Engine-Secret": TEST_SECRET}
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["released"] is True
+    assert body["previous"] == TEST_GROUP_ID
+    assert pending_app.state.registered_group_id is None
+
+
+def test_release_bad_secret_returns_401(pending_app: FastAPI):
+    """release secret mismatch → 401 확인함 (Phase 19)"""
+    client = TestClient(pending_app)
+    resp = client.post(
+        "/control/release", json={}, headers={"X-Engine-Secret": "wrong"}
+    )
+    assert resp.status_code == 401
 
 
 def test_assign_group_invalid_body_returns_422(pending_app: FastAPI):

--- a/tests/services/test_logbuffer.py
+++ b/tests/services/test_logbuffer.py
@@ -1,0 +1,24 @@
+"""logbuffer 라인 버퍼링 테스트 — write 청크를 개행 기준 라인으로 적재하는지 검증함."""
+
+import io
+
+from server.services.logbuffer import _BUFFER, _Tee
+
+
+def test_tee_splits_on_newlines_and_buffers_partial():
+    """개행 기준 분리 + 부분 라인 잔여분 보관 확인함 (CodeRabbit)."""
+    _BUFFER.clear()
+    sink = io.StringIO()
+    tee = _Tee(sink)
+
+    tee.write("a\nb\n")
+    assert list(_BUFFER)[-2:] == ["a", "b"]
+
+    tee.write("c")  # 개행 없는 부분 라인 — 아직 미적재
+    assert list(_BUFFER)[-1] == "b"
+
+    tee.write("d\n")  # 이전 잔여분과 합쳐 "cd" 완성
+    assert list(_BUFFER)[-1] == "cd"
+
+    # 원본 스트림에는 전량 그대로 보존함
+    assert sink.getvalue() == "a\nb\ncd\n"

--- a/tests/test_lifespan_dual_2pc.py
+++ b/tests/test_lifespan_dual_2pc.py
@@ -42,6 +42,8 @@ async def test_lifespan_placeholder_secret_warns_but_continues(
     monkeypatch.setattr(settings, "dual_2pc_subject_index", None)
     monkeypatch.setattr(settings, "registration_mode", "local")
     monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+    # .env.local의 ALIGNMENT_LOCATION=proxy 오염 차단 — be-mode 경로 명시적 검증함
+    monkeypatch.setattr(settings, "alignment_location", "be")
 
     # SEQUENTIAL register 모의함
     httpx_mock.add_response(url=BACKEND_URL, method="POST", status_code=200)
@@ -65,6 +67,8 @@ async def test_lifespan_dual_env_immediate_register(monkeypatch, httpx_mock):
     monkeypatch.setattr(settings, "dual_2pc_subject_index", 1)
     monkeypatch.setattr(settings, "registration_mode", "local")
     monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+    # .env.local의 ALIGNMENT_LOCATION=proxy 오염 차단 — be-mode 경로 명시적 검증함
+    monkeypatch.setattr(settings, "alignment_location", "be")
 
     httpx_mock.add_response(url=BACKEND_DUAL_URL, method="POST", status_code=200)
 
@@ -85,6 +89,8 @@ async def test_lifespan_pending_no_register_no_heartbeat(monkeypatch):
     monkeypatch.setattr(settings, "dual_2pc_subject_index", 2)
     monkeypatch.setattr(settings, "registration_mode", "local")
     monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+    # .env.local의 ALIGNMENT_LOCATION=proxy 오염 차단 — be-mode 경로 명시적 검증함
+    monkeypatch.setattr(settings, "alignment_location", "be")
 
     mod = _import_fresh_app()
     async with _run_lifespan(mod.app):
@@ -103,6 +109,8 @@ async def test_lifespan_pending_shutdown_no_crash(monkeypatch):
     monkeypatch.setattr(settings, "dual_2pc_subject_index", 1)
     monkeypatch.setattr(settings, "registration_mode", "local")
     monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+    # .env.local의 ALIGNMENT_LOCATION=proxy 오염 차단 — be-mode 경로 명시적 검증함
+    monkeypatch.setattr(settings, "alignment_location", "be")
 
     mod = _import_fresh_app()
     # shutdown 시 heartbeat_task가 None이어도 AttributeError/UnboundLocalError 없이 종료해야 함
@@ -120,6 +128,8 @@ async def test_lifespan_empty_string_group_id_treated_as_pending(monkeypatch):
     monkeypatch.setattr(settings, "dual_2pc_subject_index", 1)
     monkeypatch.setattr(settings, "registration_mode", "local")
     monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+    # .env.local의 ALIGNMENT_LOCATION=proxy 오염 차단 — be-mode 경로 명시적 검증함
+    monkeypatch.setattr(settings, "alignment_location", "be")
 
     mod = _import_fresh_app()
     async with _run_lifespan(mod.app):
@@ -137,6 +147,8 @@ async def test_lifespan_single_legacy_register(monkeypatch, httpx_mock):
     monkeypatch.setattr(settings, "dual_2pc_subject_index", None)
     monkeypatch.setattr(settings, "registration_mode", "local")
     monkeypatch.setattr(settings, "lan_ip", "127.0.0.1")
+    # .env.local의 ALIGNMENT_LOCATION=proxy 오염 차단 — be-mode 경로 명시적 검증함
+    monkeypatch.setattr(settings, "alignment_location", "be")
 
     httpx_mock.add_response(url=BACKEND_URL, method="POST", status_code=200)
 


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 변경
- **idle-rebind 자동복구**: DE가 측정중 아니면 다른 groupId assign 시 옛 바인딩 해제 후 재바인딩(200), 측정중이면 409 유지(라이브 보호). group_id_conflict 시 수동 DE 재기동 불필요.
- **진단 엔드포인트**: `/health`에 registered_group_id·streaming, `/logs?tail=N`(서버 로그 링버퍼), `/control/release`(비상 해제) 추가.
- **fix: SSL_CERT_FILE 자가치유**: conda base stale 값(부재 경로)으로 httpx가 startup 크래시하던 것 config.py에서 certifi로 교정.
- **test: lifespan 격리**: alignment_location=be 고정으로 .env.local proxy 오염 사전 실패 수정.

## 검증
- pytest 145 passed (SSL export 없이도), flake8/black/isort clean.
- control 테스트 12건(rebind/measuring-409/release 포함) 통과.

codex gpt-5.5 평가로 idle-rebind(A) 방식 채택(기대효과 9·위험관리 8). 측정중 보호 가드는 DE 소유.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `/health` 응답에 현재 등록된 그룹 ID와 스트리밍 실행 여부를 추가했습니다.
  * `GET /logs` 엔드포인트를 추가해 최근 서버 로그를 조회할 수 있게 했습니다.
  * 제어 기능에 그룹 해제(`/control/release`)를 추가하고 그룹 할당 동작을 상태에 따라 확장했습니다.
* **Bug Fixes**
  * SSL 인증서 경로가 유효하지 않을 때 안전한 기본 경로로 자동 보정되도록 개선했습니다.
* **Tests**
  * 로그 버퍼 및 제어 라우트 동작에 대한 테스트를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->