### PR TITLE
fix(engine): LAN_IP 미지정 시 Tailscale IP 자동 광고 + 핫스팟 잔재 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,17 +8,16 @@ REGISTRATION_MODE=local          # local | ngrok
 BACKEND_URL=http://localhost:5000
 # ⚠️ placeholder 값(your-shared-secret-here / change-me-in-production)은 Preflight hard-gate에 의해 lifespan이 abort됨
 ENGINE_SECRET_KEY=your-shared-secret-here
-# LAN_IP — 운영자 시점 명시 override 권장 (5/26 D-0 시연 학습)
-# 분기:
-#   operator PC = proxy 동일 머신 시점 → 127.0.0.1 (loopback)
-#   노트북 B = DE_B 별개 머신 시점 → 핫스팟 어댑터 IPv4 (예: 192.168.137.X)
-# 빈 값 시 socket.gethostbyname 자동 탐지하나 다중 인터페이스 환경에서 부정확 가능
+# LAN_IP — DE가 proxy에 광고할 자기 IP override. Tailscale이 유일 transport라 보통 비워둠.
+# 빈 값 시: 런처가 `tailscale ip -4`로 주입하거나, DE가 Tailscale 대역(100.64.0.0/10)을
+# 자동탐지함. 둘 다 실패해야 socket.gethostbyname 폴백(부정확 가능). 수동 지정 시엔
+# 반드시 이 머신의 Tailscale IP(100.x.y.z)를 넣을 것 — LAN/Wi-Fi IP는 cross-machine 도달 불가.
 LAN_IP=
 
 # Phase 18 proxy mode 전용 env (proxy mode 비사용 시 빈 값 유지)
 # ALIGNMENT_LOCATION=proxy 설정 시 DE_A 또는 DE_B는 측정 데이터를 proxy /ingest로 forward함
 # operator PC = proxy 동일 머신: PROXY_URL=http://127.0.0.1:5050
-# 노트북 B = DE_B 별개 머신: PROXY_URL=http://<operator PC AP IPv4>:5050 (Windows 핫스팟 broadcast 또는 유선 LAN 경로)
+# 노트북 B = DE_B 별개 머신: PROXY_URL=http://<operator Tailscale IP 또는 MagicDNS 이름>:5050 (Tailscale 경유)
 ALIGNMENT_LOCATION=
 PROXY_URL=
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Phase migration 진행 시 `.env.local` 또는 `.env.example`에 박제된 환�
 
 - Phase 17 `REGISTRATION_MODE=ngrok` 잔재 — Phase 18 proxy mode 환경에서 사용 시 `public_url`을 proxy `/register`로 보낼 때 ngrok URL 등록 risk 발생함. proxy mode 환경에선 `REGISTRATION_MODE=local` 의무함.
 - Phase 18 `ALIGNMENT_LOCATION` + `PROXY_URL` 신규 추가 — proxy mode 활성화 트리거. `.env.example`에 빈 값 default 박제로 proxy mode 미사용 시 자연 비활성화 정합함.
-- `LAN_IP` 운영자 명시 override 권장 — 5/26 D-0 학교 Wi-Fi 환경에서 `socket.gethostbyname` 자동 탐지가 다중 인터페이스(학교 Wi-Fi + 핫스팟 broadcast) 시 부정확 발견함. 분기 박제: operator PC = proxy 동일 머신 시 `127.0.0.1`, 노트북 B = DE_B 별개 머신 시 핫스팟 어댑터 IPv4.
+- `LAN_IP` — DE가 proxy에 광고할 자기 IP. **Tailscale이 유일 transport로 pivot**(2026-06-30, 핫스팟/D-0 스크립트 아카이브)한 뒤로는 보통 비워둠. 해석 우선순위: 명시 `LAN_IP`(런처가 `tailscale ip -4`로 주입) > DE 자체 Tailscale 대역(100.64.0.0/10) 자동탐지(`server/app.py` `_detect_tailscale_ip`) > `socket.gethostbyname` 폴백. 과거 `socket.gethostbyname`은 Docker/WSL/Wi-Fi 어댑터를 오선택해 cross-machine 도달 불가 주소를 광고하는 결함이 있었음(노트북 B가 LAN IP `10.26.x`를 등록해 operator assign-group 타임아웃). 수동 지정 시 **반드시 그 머신의 Tailscale IP(100.x)** — LAN/Wi-Fi IP 금지. (핫스팟 primary였던 5/26 전략은 Tailscale primary로 대체됨.)
 
 Phase migration PR scope에 `.env.example` 정합 확인 + AGENTS.md 본 절 amend 의무 (transitive 상속 박제 갭 차단). 옵시디언 [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]] 핵심 발견 6 + [[2026-05-26-track-1-doc-governance-correction-done]] 핵심 발견 2 정합.
 

--- a/scripts/realdevice/start-realdevice-dual-2pc.ps1
+++ b/scripts/realdevice/start-realdevice-dual-2pc.ps1
@@ -12,7 +12,7 @@
 #
 # References:
 # - 2026-05-27 cross-machine Tailscale GREEN [[project_mind_signal_phase18_mcafee_removed_cross_machine_green]]
-# - mind-signal-d0-setup.ps1 (firewall + .env.local 갱신, 별도 책임)
+# - 핫스팟/D-0 셋업 스크립트는 Tailscale 대체로 아카이브됨 (99_archive/). 방화벽은 핫스팟 전용이라 Tailscale 후 무관
 # - [[feedback_start_process_conda_hook]] conda activate hook 안정성
 
 [CmdletBinding()]

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import socket
 from contextlib import asynccontextmanager
 
@@ -30,6 +31,33 @@ PLACEHOLDER_SECRETS = {
     "change-me-in-production",
     "",
 }
+
+# Tailscale CGNAT 대역 — 2PC cross-machine 도달 경로는 Tailscale뿐이라
+# advertise IP는 반드시 이 대역이어야 함
+_TAILSCALE_NET = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _detect_tailscale_ip() -> str | None:
+    """이 머신의 Tailscale IP(100.64.0.0/10 대역) 자동 탐지함.
+
+    LAN_IP 미지정 시 socket.gethostbyname은 기본 어댑터(Docker/WSL/Wi-Fi)를
+    골라 operator가 도달 못 하는 주소를 광고하는 결함이 있어, Tailscale 대역
+    인터페이스를 우선 선택함.
+
+    Returns:
+        Tailscale IPv4 문자열, 없으면 None.
+    """
+    try:
+        _, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    except OSError:
+        return None
+    for ip in ips:
+        try:
+            if ipaddress.ip_address(ip) in _TAILSCALE_NET:
+                return ip
+        except ValueError:
+            continue
+    return None
 
 
 @asynccontextmanager
@@ -65,8 +93,17 @@ async def lifespan(app: FastAPI):
         public_url = tunnel.public_url
         print(f"ngrok 퍼블릭 URL 발급됨: {public_url}", flush=True)
     else:  # local
-        lan_ip = settings.lan_ip or socket.gethostbyname(socket.gethostname())
+        # 우선순위: 명시 LAN_IP(런처가 `tailscale ip -4`로 주입, 또는 수동 override)
+        # > Tailscale 대역 자동탐지 > socket 폴백. Tailscale이 유일 transport라
+        # LAN_IP 미주입 시에도 Tailscale IP를 광고해 cross-machine 도달 보장함
+        # (socket.gethostbyname이 Docker/WSL/Wi-Fi 어댑터 오선택하는 결함 방어).
+        lan_ip = (
+            settings.lan_ip
+            or _detect_tailscale_ip()
+            or socket.gethostbyname(socket.gethostname())
+        )
         public_url = f"http://{lan_ip}:{settings.fastapi_port}"
+        print(f"[INFO] DE advertise URL: {public_url}")
 
     # app.state 초기화 (Phase 17.5) — 모든 분기 공통
     app.state.public_url = public_url

--- a/server/app.py
+++ b/server/app.py
@@ -60,6 +60,33 @@ def _detect_tailscale_ip() -> str | None:
     return None
 
 
+def _resolve_advertise_ip(explicit: str | None) -> str:
+    """DE가 proxy에 광고할 IP 결정함.
+
+    우선순위: 명시 LAN_IP(Tailscale 대역일 때만) > Tailscale 대역 자동탐지 >
+    socket 폴백. Tailscale이 유일 transport라 명시 LAN_IP가 대역 밖(스테일
+    LAN/Wi-Fi 주소)이면 무시하고 자동탐지로 내려 cross-machine 도달 실패를
+    self-heal함 (하드 실패 대신 경고 — 라이브 중단 방지).
+
+    Args:
+        explicit: LAN_IP env 값 (없으면 None).
+
+    Returns:
+        광고할 IPv4 문자열.
+    """
+    if explicit:
+        try:
+            if ipaddress.ip_address(explicit) in _TAILSCALE_NET:
+                return explicit
+        except ValueError:
+            pass
+        print(
+            f"[WARN] LAN_IP={explicit} 이(가) Tailscale 대역(100.64.0.0/10) 밖 — "
+            "무시하고 자동탐지로 대체함 (cross-machine 도달 보장)"
+        )
+    return _detect_tailscale_ip() or socket.gethostbyname(socket.gethostname())
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """서버 시작 시 URL 결정 + 백엔드 등록(모드별 분기) + heartbeat 수행함.
@@ -93,15 +120,7 @@ async def lifespan(app: FastAPI):
         public_url = tunnel.public_url
         print(f"ngrok 퍼블릭 URL 발급됨: {public_url}", flush=True)
     else:  # local
-        # 우선순위: 명시 LAN_IP(런처가 `tailscale ip -4`로 주입, 또는 수동 override)
-        # > Tailscale 대역 자동탐지 > socket 폴백. Tailscale이 유일 transport라
-        # LAN_IP 미주입 시에도 Tailscale IP를 광고해 cross-machine 도달 보장함
-        # (socket.gethostbyname이 Docker/WSL/Wi-Fi 어댑터 오선택하는 결함 방어).
-        lan_ip = (
-            settings.lan_ip
-            or _detect_tailscale_ip()
-            or socket.gethostbyname(socket.gethostname())
-        )
+        lan_ip = _resolve_advertise_ip(settings.lan_ip)
         public_url = f"http://{lan_ip}:{settings.fastapi_port}"
         print(f"[INFO] DE advertise URL: {public_url}")
 

--- a/server/config.py
+++ b/server/config.py
@@ -27,7 +27,9 @@ class Settings(BaseSettings):
     # DUAL_2PC 세션 env (launcher 주입, 비-DUAL_2PC 기동 시 None)
     dual_2pc_group_id: str | None = None
     dual_2pc_subject_index: int | None = None
-    lan_ip: str | None = None  # LAN IP override (없으면 socket 자동 탐지)
+    lan_ip: str | None = (
+        None  # advertise IP override (없으면 Tailscale 자동탐지 후 socket 폴백)
+    )
 
     # Proxy 연동 (engine-proxy-sync Phase 18)
     proxy_url: str | None = None  # env PROXY_URL

--- a/tests/test_advertise_ip.py
+++ b/tests/test_advertise_ip.py
@@ -1,0 +1,25 @@
+"""DE advertise IP 탐지 테스트 — LAN_IP 미지정 시 Tailscale 대역 자동 선택 검증함."""
+
+from server import app as app_mod
+
+
+def test_detect_tailscale_ip_picks_cgnat(monkeypatch):
+    """여러 어댑터 중 100.64.0.0/10 대역(Tailscale)을 선택함."""
+    monkeypatch.setattr(app_mod.socket, "gethostname", lambda: "nb")
+    monkeypatch.setattr(
+        app_mod.socket,
+        "gethostbyname_ex",
+        lambda h: ("nb", [], ["172.17.0.1", "100.86.237.53", "192.168.0.5"]),
+    )
+    assert app_mod._detect_tailscale_ip() == "100.86.237.53"
+
+
+def test_detect_tailscale_ip_none_when_absent(monkeypatch):
+    """Tailscale 대역 IP가 없으면 None 반환함 (기존 폴백으로 위임)."""
+    monkeypatch.setattr(app_mod.socket, "gethostname", lambda: "nb")
+    monkeypatch.setattr(
+        app_mod.socket,
+        "gethostbyname_ex",
+        lambda h: ("nb", [], ["172.17.0.1", "192.168.0.5"]),
+    )
+    assert app_mod._detect_tailscale_ip() is None

--- a/tests/test_advertise_ip.py
+++ b/tests/test_advertise_ip.py
@@ -23,3 +23,22 @@ def test_detect_tailscale_ip_none_when_absent(monkeypatch):
         lambda h: ("nb", [], ["172.17.0.1", "192.168.0.5"]),
     )
     assert app_mod._detect_tailscale_ip() is None
+
+
+def test_resolve_honors_explicit_tailscale_ip(monkeypatch):
+    """명시 LAN_IP가 Tailscale 대역이면 그대로 사용함."""
+    monkeypatch.setattr(app_mod, "_detect_tailscale_ip", lambda: "100.99.99.99")
+    assert app_mod._resolve_advertise_ip("100.86.237.53") == "100.86.237.53"
+
+
+def test_resolve_ignores_stale_non_tailscale_ip(monkeypatch):
+    """명시 LAN_IP가 대역 밖(스테일 LAN/Wi-Fi)이면 무시하고 자동탐지로 대체함 (CodeRabbit)."""
+    monkeypatch.setattr(app_mod, "_detect_tailscale_ip", lambda: "100.86.237.53")
+    # 노트북 B가 등록하던 LAN IP — 이제 무시되고 Tailscale IP로 self-heal됨
+    assert app_mod._resolve_advertise_ip("10.26.140.41") == "100.86.237.53"
+
+
+def test_resolve_none_uses_autodetect(monkeypatch):
+    """LAN_IP 미지정 시 자동탐지 결과 사용함."""
+    monkeypatch.setattr(app_mod, "_detect_tailscale_ip", lambda: "100.86.237.53")
+    assert app_mod._resolve_advertise_ip(None) == "100.86.237.53"


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 원인
노트북 B DE가 proxy에 자기 **LAN IP(10.26.140.41)**를 public_url로 등록 → operator가 그 IP로 도달 못 해(Tailscale 100.86.237.53로만 닿음) assign-group 타임아웃 → subject2 미등록 → 불일치. 근본: `socket.gethostbyname` 폴백이 Docker/WSL/Wi-Fi 어댑터를 오선택.

## 수정
- `server/app.py`: advertise IP 해석에 **Tailscale 대역(100.64.0.0/10) 자동탐지**(`_detect_tailscale_ip`) 추가. 우선순위 = 명시 LAN_IP > Tailscale 자동탐지 > socket 폴백. LAN_IP 미주입 시에도 Tailscale IP 광고 보장.
- **핫스팟 잔재 정리**(Tailscale primary pivot 반영, 2026-06-30 D-0 스크립트 아카이브 정합): `.env.example`(192.168.137.x 예시 제거), `AGENTS.md` LAN_IP 절, 런처 주석, config 주석.

## 검증
- 신규 `_detect_tailscale_ip` 단위 2건 + 전체 pytest 149 통과, flake8 clean.
- operator 실측: `_detect_tailscale_ip` → 100.117.42.107 (정확).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 로컬에서 접속/광고 주소를 더 안정적으로 자동 선택하도록 개선했으며, 설정값이 Tailscale 대역이 아니면 자동으로 대체합니다.
  * 프록시 모드에서 등록 갱신이 백그라운드에서 주기적으로 유지되도록 강화했습니다.
* **Documentation**
  * 환경변수 예시(.env.example)와 운영 규칙(AGENTS.md), 실기기 시작 스크립트 주석을 최신 동작 기준에 맞게 정리했습니다.
* **Tests**
  * 광고 IP 결정 로직에 대한 자동 판별/대체 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->