### PR TITLE
fix(stream): 수동 중지 시 subject CSV 업로드 (Windows 하드킬 대응)

### DIFF
--- a/server/services/stream.py
+++ b/server/services/stream.py
@@ -1,5 +1,6 @@
 """EEG 스트리밍 프로세스 관리 서비스임"""
 
+import glob
 import os
 import subprocess
 import sys
@@ -32,6 +33,29 @@ def _close_log(key: str) -> None:
             handle.close()
         except OSError:
             pass
+
+
+def _upload_subject_csv(group_id: str, subject_index: int) -> None:
+    """종료된 subject의 CSV를 operator BE로 업로드함 (2-PC 집계).
+
+    Windows에서 proc.terminate()는 TerminateProcess(하드 킬)이라 core.main의
+    SIGTERM/on_close 업로드가 실행되지 않음. DE 서버가 종료 직후 직접 업로드해
+    수동 중지에도 subject CSV가 operator csv/에 집계되게 함. upload는 멱등 overwrite라
+    auto-stop의 on_close 업로드와 중복돼도 무해함.
+    """
+    from server.config import settings
+    from server.services.webhook import upload_csv_to_backend
+
+    pattern = os.path.join(
+        _ENGINE_ROOT, "csv", f"subject_{subject_index}_{group_id}_*.csv"
+    )
+    matches = sorted(glob.glob(pattern), key=os.path.getmtime)
+    if not matches:
+        print(f"[stop_stream] subject CSV 미발견, 업로드 skip: {pattern}")
+        return
+    upload_csv_to_backend(
+        settings.backend_url, matches[-1], settings.engine_secret_key
+    )
 
 
 def start_stream(group_id: str, subject_index: int) -> dict[str, Any]:
@@ -93,6 +117,11 @@ def stop_stream(group_id: str, subject_index: int) -> dict[str, Any]:
 
     del _processes[key]
     _close_log(key)
+    # Windows 하드킬로 core.main on_close 업로드가 스킵되므로 DE 서버가 직접 업로드함
+    try:
+        _upload_subject_csv(group_id, subject_index)
+    except Exception as e:  # noqa: BLE001 — 업로드 실패는 stop 흐름 안 깸(soft)
+        print(f"[stop_stream] CSV 업로드 오류(무시): {e}")
     return {"status": "stopped", "key": key}
 
 

--- a/server/services/stream.py
+++ b/server/services/stream.py
@@ -46,8 +46,11 @@ def _upload_subject_csv(group_id: str, subject_index: int) -> None:
     from server.config import settings
     from server.services.webhook import upload_csv_to_backend
 
+    # group_id는 glob.escape로 감싸 *,?,[ 메타문자 오매칭 방지함 (CodeRabbit)
     pattern = os.path.join(
-        _ENGINE_ROOT, "csv", f"subject_{subject_index}_{group_id}_*.csv"
+        _ENGINE_ROOT,
+        "csv",
+        f"subject_{subject_index}_{glob.escape(group_id)}_*.csv",
     )
     matches = sorted(glob.glob(pattern), key=os.path.getmtime)
     if not matches:

--- a/tests/services/test_stream_csv_upload.py
+++ b/tests/services/test_stream_csv_upload.py
@@ -29,6 +29,25 @@ def test_upload_subject_csv_uploads_latest(monkeypatch, tmp_path):
     assert captured["path"] == str(new)
 
 
+def test_upload_subject_csv_escapes_glob_metachars(monkeypatch, tmp_path):
+    """group_id에 glob 메타문자([)가 있어도 리터럴 매칭함 (CodeRabbit)."""
+    csv_dir = tmp_path / "csv"
+    csv_dir.mkdir()
+    target = csv_dir / "subject_2_G[1]_20260101_000000.csv"
+    target.write_text("x")
+
+    monkeypatch.setattr(stream_mod, "_ENGINE_ROOT", str(tmp_path))
+    captured = {}
+    monkeypatch.setattr(
+        webhook_mod,
+        "upload_csv_to_backend",
+        lambda backend, path, secret: captured.update(path=path),
+    )
+
+    stream_mod._upload_subject_csv("G[1]", 2)
+    assert captured.get("path") == str(target)
+
+
 def test_upload_subject_csv_skip_when_none(monkeypatch, tmp_path):
     """해당 CSV가 없으면 업로드 skip함 (호출 0)."""
     (tmp_path / "csv").mkdir()

--- a/tests/services/test_stream_csv_upload.py
+++ b/tests/services/test_stream_csv_upload.py
@@ -1,0 +1,44 @@
+"""stop_stream의 subject CSV 업로드 테스트 — Windows 하드킬로 on_close가 안 돌 때 대비."""
+
+import os
+
+import server.services.stream as stream_mod
+import server.services.webhook as webhook_mod
+
+
+def test_upload_subject_csv_uploads_latest(monkeypatch, tmp_path):
+    """csv/ 에서 해당 group/subject의 최신 CSV를 골라 업로드함."""
+    csv_dir = tmp_path / "csv"
+    csv_dir.mkdir()
+    old = csv_dir / "subject_2_G_20260101_000000.csv"
+    old.write_text("old")
+    new = csv_dir / "subject_2_G_20260101_000001.csv"
+    new.write_text("new")
+    os.utime(old, (1, 1))
+    os.utime(new, (2, 2))  # new가 더 최근
+
+    monkeypatch.setattr(stream_mod, "_ENGINE_ROOT", str(tmp_path))
+    captured = {}
+    monkeypatch.setattr(
+        webhook_mod,
+        "upload_csv_to_backend",
+        lambda backend, path, secret: captured.update(path=path),
+    )
+
+    stream_mod._upload_subject_csv("G", 2)
+    assert captured["path"] == str(new)
+
+
+def test_upload_subject_csv_skip_when_none(monkeypatch, tmp_path):
+    """해당 CSV가 없으면 업로드 skip함 (호출 0)."""
+    (tmp_path / "csv").mkdir()
+    monkeypatch.setattr(stream_mod, "_ENGINE_ROOT", str(tmp_path))
+    called = []
+    monkeypatch.setattr(
+        webhook_mod,
+        "upload_csv_to_backend",
+        lambda *a, **k: called.append(1),
+    )
+
+    stream_mod._upload_subject_csv("G", 2)
+    assert called == []


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 원인
Windows `proc.terminate()`는 `TerminateProcess`(하드 킬)이라 수동 중지(실험 중지) 시 core.main이 즉사 → SIGTERM 핸들러/`on_close`의 CSV 업로드가 실행 안 됨. auto-stop(600초)만 정상 업로드됐음. 결과: subject_2 CSV가 operator `csv/`에 안 와 분석 타임아웃("결과를 가져올 수 없습니다").

## 수정
`stop_stream`이 core.main 종료 직후 **DE 서버가 직접** 해당 group/subject의 최신 CSV를 operator BE `/api/engine/csv-upload`로 업로드(`_upload_subject_csv`). 크로스플랫폼 + DE 서버의 검증된 backend_url 사용(prod 오전송 방지). 멱등 overwrite라 auto-stop의 on_close 업로드와 중복돼도 무해.

## 검증
- 신규 테스트 2건(최신 CSV 선택 업로드 / CSV 없으면 skip) + 전체 pytest 154 통과, flake8 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 종료된 subject의 최신 CSV를 자동으로 찾아 operator backend로 업로드합니다.
  * 업로드 대상은 지정된 패턴에 맞는 파일 중 수정시간 기준 최신 파일로 선택됩니다.
* **Bug Fixes**
  * 업로드 중 오류가 발생해도 stream 종료 및 정리 흐름이 중단되지 않도록 개선했습니다.
* **Tests**
  * 최신 CSV 선택, 특수 문자 포함 여부, CSV 미존재 시 업로드 호출 여부를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->