### PR TITLE
fix(stream): subject CSV 검색 경로를 streamer 저장 경로에 맞춤

### DIFF
--- a/server/services/stream.py
+++ b/server/services/stream.py
@@ -13,6 +13,12 @@ _ENGINE_ROOT = str(Path(__file__).resolve().parent.parent.parent)
 # core.main 자식 로그 디렉토리 (D7: stdout/stderr를 PIPE 대신 파일로 redirect함)
 _LOG_DIR = Path(_ENGINE_ROOT) / "logs"
 
+# CSV 저장 루트 — core/streamer.py의 base_path(레포 부모의 csv/)와 일치시킴.
+# streamer.py는 core/ 아래, 이 파일은 server/services/ 아래라 동일한 parent×3이 서로
+# 다른 폴더를 가리킴. 여기서 _ENGINE_ROOT(레포 루트)/csv 대신 그 부모/csv를 봐야
+# core.main이 실제로 쓴 원격 subject CSV를 찾음 (경로 불일치로 업로드 skip되던 것 정합).
+_CSV_DIR = str(Path(_ENGINE_ROOT).parent / "csv")
+
 # 실행 중인 스트리밍 프로세스 추적 dict — key: "{group_id}:{subject_index}"
 _processes: dict[str, subprocess.Popen] = {}
 
@@ -48,17 +54,14 @@ def _upload_subject_csv(group_id: str, subject_index: int) -> None:
 
     # group_id는 glob.escape로 감싸 *,?,[ 메타문자 오매칭 방지함 (CodeRabbit)
     pattern = os.path.join(
-        _ENGINE_ROOT,
-        "csv",
+        _CSV_DIR,
         f"subject_{subject_index}_{glob.escape(group_id)}_*.csv",
     )
     matches = sorted(glob.glob(pattern), key=os.path.getmtime)
     if not matches:
         print(f"[stop_stream] subject CSV 미발견, 업로드 skip: {pattern}")
         return
-    upload_csv_to_backend(
-        settings.backend_url, matches[-1], settings.engine_secret_key
-    )
+    upload_csv_to_backend(settings.backend_url, matches[-1], settings.engine_secret_key)
 
 
 def start_stream(group_id: str, subject_index: int) -> dict[str, Any]:

--- a/tests/services/test_stream_csv_upload.py
+++ b/tests/services/test_stream_csv_upload.py
@@ -6,6 +6,19 @@ import server.services.stream as stream_mod
 import server.services.webhook as webhook_mod
 
 
+def test_csv_dir_is_repo_parent_not_engine_root():
+    """CSV 검색 루트는 _ENGINE_ROOT/csv가 아니라 그 부모/csv여야 함.
+
+    core/streamer.py의 base_path(레포 부모/csv)에 실제 CSV가 저장되는데,
+    stream.py는 server/services/ 아래라 동일한 parent×3이 레포 루트를 가리켜
+    _ENGINE_ROOT/csv를 보면 원격 subject CSV를 못 찾고 업로드 skip됐음(경로 불일치 회귀).
+    """
+    assert stream_mod._CSV_DIR == os.path.join(
+        os.path.dirname(stream_mod._ENGINE_ROOT), "csv"
+    )
+    assert stream_mod._CSV_DIR != os.path.join(stream_mod._ENGINE_ROOT, "csv")
+
+
 def test_upload_subject_csv_uploads_latest(monkeypatch, tmp_path):
     """csv/ 에서 해당 group/subject의 최신 CSV를 골라 업로드함."""
     csv_dir = tmp_path / "csv"
@@ -17,7 +30,7 @@ def test_upload_subject_csv_uploads_latest(monkeypatch, tmp_path):
     os.utime(old, (1, 1))
     os.utime(new, (2, 2))  # new가 더 최근
 
-    monkeypatch.setattr(stream_mod, "_ENGINE_ROOT", str(tmp_path))
+    monkeypatch.setattr(stream_mod, "_CSV_DIR", str(csv_dir))
     captured = {}
     monkeypatch.setattr(
         webhook_mod,
@@ -36,7 +49,7 @@ def test_upload_subject_csv_escapes_glob_metachars(monkeypatch, tmp_path):
     target = csv_dir / "subject_2_G[1]_20260101_000000.csv"
     target.write_text("x")
 
-    monkeypatch.setattr(stream_mod, "_ENGINE_ROOT", str(tmp_path))
+    monkeypatch.setattr(stream_mod, "_CSV_DIR", str(csv_dir))
     captured = {}
     monkeypatch.setattr(
         webhook_mod,
@@ -50,8 +63,9 @@ def test_upload_subject_csv_escapes_glob_metachars(monkeypatch, tmp_path):
 
 def test_upload_subject_csv_skip_when_none(monkeypatch, tmp_path):
     """해당 CSV가 없으면 업로드 skip함 (호출 0)."""
-    (tmp_path / "csv").mkdir()
-    monkeypatch.setattr(stream_mod, "_ENGINE_ROOT", str(tmp_path))
+    csv_dir = tmp_path / "csv"
+    csv_dir.mkdir()
+    monkeypatch.setattr(stream_mod, "_CSV_DIR", str(csv_dir))
     called = []
     monkeypatch.setattr(
         webhook_mod,


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 무엇을
수동 중지 시 원격 subject CSV를 operator로 업로드하는 stop_stream fallback(`_upload_subject_csv`)의 검색 경로를 실제 저장 경로에 맞춤.

## 왜
core.main(`core/streamer.py`)은 CSV를 레포 부모의 `csv/`(base_path)에 저장하는데, `server/services/stream.py`는 `_ENGINE_ROOT`(레포 루트)/csv를 봤음. 두 파일이 레포 안에서 깊이가 달라 동일한 parent×3이 서로 다른 폴더를 가리킴. 그 결과 노트북 B에서 `subject CSV 미발견, 업로드 skip` 발생(2026-07-02 라이브 로그로 확인).

## 어떻게
`_CSV_DIR = Path(_ENGINE_ROOT).parent / 'csv'` 상수로 통일. `_ENGINE_ROOT`는 logs/cwd에 그대로 쓰이므로 csv 경로만 국소 수정. 경로 불일치 회귀 방지 테스트 추가(`test_csv_dir_is_repo_parent_not_engine_root`). black/isort/flake8 clean, pytest 4 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV 업로드 시 파일을 찾는 기준 경로를 조정해, 경로 불일치로 업로드가 건너뛰어지던 문제를 수정했습니다.
  * 최신 수정 시각의 CSV 1개만 업로드되며, 파일이 없으면 기존처럼 건너뜁니다.

* **Tests**
  * CSV 업로드 경로 기준이 올바른지 확인하는 회귀 테스트를 추가했습니다.
  * 관련 테스트 설정을 새 경로 기준에 맞게 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->