### PR TITLE
fix(analyze): 한쪽 subject CSV 미발견 시 500 대신 partial 200 반환

### DIFF
--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -75,12 +75,18 @@ class PipelineRequest(BaseModel):
 
 
 class SubjectFeatureResult(BaseModel):
-    """피실험자별 feature 추출 결과 스키마임"""
+    """피실험자별 feature 추출 결과 스키마임
+
+    한쪽 subject의 CSV가 없으면(2-PC에서 원격 subject 미수집 등) feature 필드 없이
+    error만 채워 partial 응답으로 반환함. 이때 500 대신 200으로 내려 FE가 어느
+    subject가 실패했는지 판단하게 함.
+    """
 
     subject_index: int
-    baseline: dict[str, float]
-    features: dict[str, float]
-    n_features: int
+    baseline: dict[str, float] | None = None
+    features: dict[str, float] | None = None
+    n_features: int | None = None
+    error: str | None = None
 
 
 class PipelineResponse(BaseModel):

--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -122,11 +122,15 @@ class TestAnalyzePipelineEndpoint:
         assert data["y_score"] is not None
 
     @patch("server.services.analysis.run_full_pipeline")
-    def test_csv_not_found_in_response(
+    def test_csv_not_found_returns_partial_200(
         self, mock_pipeline, test_client, pipeline_secret_header
     ):
-        """CSV 없는 subject의 응답 처리 검증함"""
-        # subjects에 error가 없는 정상 응답을 반환하되, 최소 구조만 갖춤
+        """한쪽 subject CSV 미발견 시 500 대신 200 + error 담은 partial 응답 반환함.
+
+        2-PC에서 원격 subject가 미수집되면 run_full_pipeline이 그 subject를
+        {subject_index, error}로 담음. SubjectFeatureResult가 feature 필드를 필수로
+        요구하면 여기서 ValidationError로 500이 났음(회귀 방지).
+        """
         mock_pipeline.return_value = {
             "group_id": TEST_GROUP_ID,
             "subjects": [
@@ -135,7 +139,8 @@ class TestAnalyzePipelineEndpoint:
                     "baseline": {"alpha": 0.5},
                     "features": {},
                     "n_features": 0,
-                }
+                },
+                {"subject_index": 2, "error": "CSV 파일 미발견"},
             ],
             "pair_features": None,
             "y_score": None,
@@ -153,10 +158,13 @@ class TestAnalyzePipelineEndpoint:
         }
         response = test_client.post(
             "/api/analyze/pipeline",
-            json={"group_id": TEST_GROUP_ID, "subject_indices": [1]},
+            json={"group_id": TEST_GROUP_ID, "subject_indices": [1, 2]},
             headers=pipeline_secret_header,
         )
         assert response.status_code == 200
+        data = response.json()
+        assert data["subjects"][1]["error"] == "CSV 파일 미발견"
+        assert data["subjects"][1]["features"] is None
 
     def test_invalid_body_missing_group_id(self, test_client, pipeline_secret_header):
         """group_id 미포함 body → 422 validation error 반환함"""


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 무엇을
POST /api/analyze/pipeline이 한쪽 subject의 CSV가 없을 때 500 대신 200 partial 응답을 반환하도록 함.

## 왜
2-PC에서 원격 subject(노트북 B)가 미수집되면 run_full_pipeline이 그 subject를 `{subject_index, error:'CSV 파일 미발견'}`로 담음(이미 partial-safe). 그런데 응답 스키마 `SubjectFeatureResult`가 baseline/features/n_features를 필수로 요구해 error dict에서 ValidationError 500 발생(2026-07-02 라이브 로그로 확인). FE엔 '결과를 가져올 수 없습니다'로 표시됨.

## 어떻게
`SubjectFeatureResult`의 baseline/features/n_features를 optional로 바꾸고 `error` 필드 추가. 서비스 로직(run_full_pipeline)은 이미 pair/y/synchrony를 한쪽 없으면 None으로 안전 처리하므로 스키마만 완화. 기존 우회 테스트(error dict를 안 넣던)를 실제 partial 시나리오 회귀 테스트로 교체. black/isort/flake8 clean, pytest 15 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 일부 항목의 데이터가 없어도 전체 응답은 유지되도록 개선했습니다.
  * 개별 항목의 처리 실패 시 원인 메시지를 함께 반환하며, 해당 항목의 값은 비어 있을 수 있습니다.
  * CSV가 없는 경우에도 200 응답을 유지하면서 부분 실패 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->