### PR TITLE
fix(streamer): 헤드셋 자동선택 시 connected 우선으로 subscribe 실패 회피

### DIFF
--- a/core/streamer.py
+++ b/core/streamer.py
@@ -166,8 +166,28 @@ class MindSignalStreamer(Cortex):
         Args:
             result_dic: query headset 응답 리스트 (sdk 부모 메서드와 동일한 인수).
         """
-        # 설정 headset_id가 비어 있으면 부모 자동 선택 로직 위임함
+        # headset_id 미지정 시 connected 헤드셋을 우선 선택함.
+        # SDK 기본 로직(super)은 headset_list[0](목록 첫 번째)를 무조건 골라, 첫 번째가
+        # discovered면 이미 connected된 헤드셋을 두고 connect 루프에 빠짐
+        # (2026-07-02 라이브: 8E9 discovered가 먼저라 connected 5B 미선택 + subscribe 실패).
         if not self.headset_id:
+            connected = [
+                ele["id"] for ele in result_dic if ele.get("status") == "connected"
+            ]
+            # PC당 실사용 헤드셋 1대 전제(2-PC). connected가 정확히 1대일 때만
+            # 우선 지정함. 2대 이상은 오선택 위험이라 자동선택 skip하고 SDK 기본
+            # 선택에 위임함 (codex 5.5 조건). connected 없으면 기존 폴백 유지.
+            if len(connected) == 1:
+                self.headset_id = connected[0]
+                print(
+                    f"[INFO] connected 헤드셋 '{self.headset_id}' 우선 선택함 "
+                    f"(subject {self.subject_index})"
+                )
+            elif len(connected) > 1:
+                print(
+                    f"[WARN] connected 헤드셋 {len(connected)}대 ({connected}) — "
+                    f"자동 우선선택 skip, SDK 기본 선택 위임 (subject {self.subject_index})"
+                )
             super()._handle_query_headset(result_dic)
             return
 

--- a/tests/test_headset_binding.py
+++ b/tests/test_headset_binding.py
@@ -12,6 +12,8 @@ import sys
 import pytest
 
 import core.main as main_module
+from core.streamer import MindSignalStreamer
+from sdk.cortex import Cortex
 
 
 @pytest.mark.parametrize(
@@ -48,4 +50,59 @@ def test_main_ignores_headset_id_env_and_lets_sdk_pick_first(
     main_module.main()
 
     # 동적 바인딩: env의 하드코딩 ID를 절대 통과시키지 않고 빈 문자열을 넘겨야 한다.
+    assert captured["headset_id"] == ""
+
+
+def _make_streamer():
+    """Cortex.__init__ 부작용 없이 _handle_query_headset만 테스트하기 위한 인스턴스 생성함"""
+    s = MindSignalStreamer.__new__(MindSignalStreamer)
+    s.headset_id = ""
+    s.subject_index = 2
+    return s
+
+
+def _capture_super(monkeypatch):
+    """super()._handle_query_headset 호출 시점의 headset_id를 캡처함"""
+    captured = {}
+    monkeypatch.setattr(
+        Cortex,
+        "_handle_query_headset",
+        lambda self, rd: captured.update(headset_id=self.headset_id),
+    )
+    return captured
+
+
+def test_query_headset_prefers_single_connected(monkeypatch):
+    """discovered가 먼저여도 connected 헤드셋을 우선 지정함 (2026-07-02 subscribe 실패 회귀)."""
+    s = _make_streamer()
+    captured = _capture_super(monkeypatch)
+    result = [
+        {"id": "8E9", "status": "discovered", "connectedBy": "bluetooth"},
+        {"id": "5B", "status": "connected", "connectedBy": "bluetooth"},
+    ]
+    s._handle_query_headset(result)
+    assert s.headset_id == "5B"
+    assert captured["headset_id"] == "5B"
+
+
+def test_query_headset_skips_when_multiple_connected(monkeypatch):
+    """connected 2대 이상이면 오선택 방지로 자동 우선선택 skip하고 SDK 위임함."""
+    s = _make_streamer()
+    captured = _capture_super(monkeypatch)
+    result = [
+        {"id": "A", "status": "connected", "connectedBy": "bluetooth"},
+        {"id": "B", "status": "connected", "connectedBy": "bluetooth"},
+    ]
+    s._handle_query_headset(result)
+    assert s.headset_id == ""
+    assert captured["headset_id"] == ""
+
+
+def test_query_headset_no_connected_delegates(monkeypatch):
+    """connected가 없으면 headset_id 미지정 상태로 SDK 기본 폴백에 위임함 (#26 보존)."""
+    s = _make_streamer()
+    captured = _capture_super(monkeypatch)
+    result = [{"id": "8E9", "status": "discovered", "connectedBy": "bluetooth"}]
+    s._handle_query_headset(result)
+    assert s.headset_id == ""
     assert captured["headset_id"] == ""


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/19-2pc-autoconnect-ops` (OPS-W102)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 무엇을
headset_id 미지정 시 core/streamer.py가 connected 상태 헤드셋을 우선 선택하도록 함.

## 왜
SDK(sdk/cortex.py _handle_query_headset)는 headset_id=='' 이면 목록 첫 번째(headset_list[0])를 무조건 wanted headset으로 잡음. 2026-07-02 라이브에서 목록 첫 번째가 discovered(8E9), 두 번째가 connected(5B)라, 이미 연결된 5B를 두고 8E9를 골라 connect_headset 루프에 빠져 create_session/subscribe로 못 감. 결과: 노트북 B subject 2 EEG가 redis로 안 흐름('No handling for response of request 25' 반복은 증상, 원인은 헤드셋 오선택).

## 어떻게
sdk/ 수정 금지 제약에 따라 streamer의 _handle_query_headset 오버라이드에서 처리. connected 헤드셋이 정확히 1대일 때만 우선 지정(PC당 1대 전제, 2-PC). connected 2대 이상은 오선택 위험이라 자동선택 skip 후 SDK 기본 위임. connected 없으면 기존 폴백(#26) 유지. 회귀 테스트 3종 추가(1대 우선/2대 skip/0대 폴백). black/isort/flake8 clean, pytest 5 passed.

## 검토
codex gpt-5.5 PROCEED-WITH-CONDITIONS — connected 2대 이상 오선택 조건 반영(1대 한정 guard). 진단 스크립트는 과설계로 제외, 재측정 로그로 검증.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 헤드셋 자동 선택 동작이 개선되어, 연결된 헤드셋이 정확히 1대일 때 해당 장치를 자동으로 선택합니다.
  * 연결된 헤드셋이 2대 이상인 경우에는 잘못된 자동 선택을 피하고 기본 선택 방식으로 안전하게 위임합니다.
  * 연결된 헤드셋이 없을 때도 기존 폴백 흐름을 유지합니다.

* **Tests**
  * 새 선택 규칙을 검증하는 회귀 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->