### PR TITLE
fix: focus 라벨 매핑, 동조율 절대시각 정렬, metrics 전달, MET watchdog 분리

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,6 +1,6 @@
 ---
 name: "🔧 TASK"
-about: ".plans/에서 생성된 개발 작업 (dispatch 실행용)"
+about: "Team-project/.plans/에서 생성된 개발 작업 (dispatch 실행용)"
 title: ""
 labels: "task"
 assignees: ""
@@ -13,7 +13,7 @@ assignees: ""
 
 ## 관련 Phase
 - Phase: ``
-- Plan: `.plans//PLAN.md`
+- Plan: `Team-project/.plans/{NN}-{기능명}/PLAN.md`
 
 ## 할 일 (변경 파일 + diff 명세)
 - [ ] `src/path/file` — 신규/수정: 설명

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,3 +225,15 @@ Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>
 - **Python 경로**: conda 활성화 미선행 시 시스템 Python(3.13/3.9) 잡혀 의존성 깨짐 — 반드시 `conda activate mind-signal` 먼저
 
 상세: `.agents/rules/troubleshooting.md`.
+
+---
+
+## 계획 산출물 위치 (2026-07-10 표준화)
+
+mind-signal은 3레포 멀티레포 제품이므로 계획 산출물 `.plans/`는 **제품 단위 1개**로 상위 워크스페이스 `Team-project/.plans/`에 둔다. 레포 로컬 `.plans/`에는 세션 로그(`_logs/`)와 임시 조사(`_quick/`)만 남긴다 — 작업 폴더(`{NN}-{기능명}`)를 여기에 새로 만들지 말 것.
+
+- 세션 핸드오프 정본: `Team-project/.plans/HANDOFF.md` (구 `_next-session-handoff.md`, 2026-07-10 고정명화)
+- 작업 폴더: `Team-project/.plans/{NN}-{기능명}` (예: `19-2pc-autoconnect-ops`)
+- 상태: `Team-project/.plans/STATE.md`
+- 아카이브: `Team-project/.plans/_archive/HANDOFF-YYYYMMDD.md`
+- docs/는 외부 전달물 전용

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -263,7 +263,10 @@ class MindSignalStreamer(Cortex):
         labels = data["labels"]
 
         if stream_name == "met":
-            self.met_map.update(build_met_map(labels))
+            # 라벨 이벤트가 재수신되면 매핑을 통째로 교체함. update()로 병합하면
+            # 이전 이벤트의 키와 인덱스가 남아 누락 경고가 무력화되고
+            # on_new_met_data가 옛 인덱스로 엉뚱한 값을 읽음 (CodeRabbit PR #36).
+            self.met_map = build_met_map(labels)
             missing = [k for k in MET_LABEL_CANDIDATES if k not in self.met_map]
             print(f"MET 인덱스 매핑 완료됨: {self.met_map}")
             if missing:
@@ -336,8 +339,12 @@ class MindSignalStreamer(Cortex):
                         }
                     ),
                 )
-            except Exception:
-                pass
+            except Exception as exc:  # noqa: BLE001 — 경보 발행 실패가 측정을 깨지 않음
+                # 조용히 삼키면 경보 자체가 사라진 걸 아무도 모름 (CodeRabbit PR #36)
+                logger.warning(
+                    f"[WATCHDOG] 상태 발행 실패 ({status}): {exc}"
+                    f" (subject {self.subject_index})"
+                )
 
         def _check():
             while self._watchdog_active:

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -27,6 +27,38 @@ from server.services.webhook import upload_csv_to_backend
 
 logger = logging.getLogger(__name__)
 
+# Cortex met 스트림의 지표별 라벨 후보임. 헤드셋 세대마다 라벨명이 달라
+# 후보를 순서대로 탐색해 처음 발견된 것을 채택함.
+# Insight2는 focus를 'attention'으로 보냄 (2026-07-10 라이브 로그 실측).
+# 기존 코드가 'foc'만 찾아 focus가 전 구간 0으로 기록되던 결함을 수정함.
+MET_LABEL_CANDIDATES: dict[str, tuple[str, ...]] = {
+    "focus": ("attention", "foc"),
+    "engagement": ("eng",),
+    "interest": ("int",),
+    "excitement": ("exc",),
+    "stress": ("str",),
+    "relaxation": ("rel",),
+}
+
+
+def build_met_map(labels: list[str]) -> dict[str, int]:
+    """Cortex met 라벨 배열에서 지표별 인덱스 매핑 생성함.
+
+    Args:
+        labels - Cortex가 보낸 met 스트림 라벨 배열임
+
+    Returns:
+        지표명을 라벨 인덱스로 매핑한 dict 반환. 후보 라벨을 하나도
+        찾지 못한 지표는 키 자체가 빠짐(호출부가 미발견을 감지 가능함).
+    """
+    met_map: dict[str, int] = {}
+    for met_key, candidates in MET_LABEL_CANDIDATES.items():
+        for label in candidates:
+            if label in labels:
+                met_map[met_key] = labels.index(label)
+                break
+    return met_map
+
 
 class MindSignalStreamer(Cortex):
     """
@@ -136,6 +168,8 @@ class MindSignalStreamer(Cortex):
         # 5. 측정 시작 시간 및 watchdog 상태 초기화함
         self.start_time = time.time()
         self.last_data_time = time.time()
+        # MET 스트림은 EEG와 별개 수신 시각을 추적함 (한쪽만 죽는 경우 감지용)
+        self.last_met_time = time.time()
         self._watchdog_active = False
         self._watchdog_interval = 30  # 무데이터 감지 임계값(초)
 
@@ -229,18 +263,11 @@ class MindSignalStreamer(Cortex):
         labels = data["labels"]
 
         if stream_name == "met":
-            target_metrics = {
-                "foc": "focus",
-                "eng": "engagement",
-                "int": "interest",
-                "exc": "excitement",
-                "str": "stress",
-                "rel": "relaxation",
-            }
-            for label_key, met_key in target_metrics.items():
-                if label_key in labels:
-                    self.met_map[met_key] = labels.index(label_key)
+            self.met_map.update(build_met_map(labels))
+            missing = [k for k in MET_LABEL_CANDIDATES if k not in self.met_map]
             print(f"MET 인덱스 매핑 완료됨: {self.met_map}")
+            if missing:
+                print(f"[WARN] MET 라벨 미발견: {missing} (labels={labels})")
 
         elif stream_name == "eeg":
             target_eeg_channels = ["AF3", "T7", "Pz", "T8", "AF4"]
@@ -295,27 +322,47 @@ class MindSignalStreamer(Cortex):
     def _start_watchdog(self):
         """무데이터 감지 watchdog 스레드 시작함"""
 
+        def _publish_status(status: str, elapsed: float) -> None:
+            try:
+                self.r.publish(
+                    self.channel,
+                    json.dumps(
+                        {
+                            "type": "headset_status",
+                            "status": status,
+                            "subjectIndex": self.subject_index,
+                            "groupId": self.group_id,
+                            "silentSeconds": round(elapsed),
+                        }
+                    ),
+                )
+            except Exception:
+                pass
+
         def _check():
             while self._watchdog_active:
-                elapsed = time.time() - self.last_data_time
-                if elapsed > self._watchdog_interval:
+                now = time.time()
+
+                eeg_elapsed = now - self.last_data_time
+                if eeg_elapsed > self._watchdog_interval:
                     logger.warning(
-                        f"[WATCHDOG] {elapsed:.0f}초간 EEG 데이터 미수신"
+                        f"[WATCHDOG] {eeg_elapsed:.0f}초간 EEG 데이터 미수신"
                         f" (subject {self.subject_index})"
                     )
-                    try:
-                        status_msg = json.dumps(
-                            {
-                                "type": "headset_status",
-                                "status": "no_data",
-                                "subjectIndex": self.subject_index,
-                                "groupId": self.group_id,
-                                "silentSeconds": round(elapsed),
-                            }
-                        )
-                        self.r.publish(self.channel, status_msg)
-                    except Exception:
-                        pass
+                    _publish_status("no_data", eeg_elapsed)
+
+                # MET는 EEG와 별개 스트림임. EEG만 살아 있고 MET가 죽으면
+                # latest_met이 마지막 값을 무한 반복해 CSV에 얼어붙은 지표가
+                # 기록되는데, EEG 기준 watchdog만으로는 감지되지 않음
+                # (2026-07-10 교차검토에서 식별함).
+                met_elapsed = now - self.last_met_time
+                if met_elapsed > self._watchdog_interval:
+                    logger.warning(
+                        f"[WATCHDOG] {met_elapsed:.0f}초간 MET 지표 미수신"
+                        f" (subject {self.subject_index})"
+                    )
+                    _publish_status("metrics_stale", met_elapsed)
+
                 time.sleep(10)
 
         t = threading.Thread(target=_check, daemon=True)
@@ -340,6 +387,8 @@ class MindSignalStreamer(Cortex):
     def on_new_met_data(self, *args, **kwargs):
         """수신된 MET 배열에서 매핑된 점수 값만 추출함"""
         data = kwargs.get("data")["met"]
+        # MET 전용 watchdog 타임스탬프 갱신함 (EEG와 독립)
+        self.last_met_time = time.time()
         for key, index in self.met_map.items():
             if index < len(data):
                 self.latest_met[key] = data[index]
@@ -408,6 +457,7 @@ class MindSignalStreamer(Cortex):
                         subject_idx=self.subject_index,
                         seq=self.seq,
                         payload=powers,
+                        metrics=dict(self.latest_met),
                         sync_meta={"de_clock_domain": "monotonic_ns"},
                         max_retries=self.max_proxy_post_retries,
                     )

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import OrderedDict
 from pathlib import Path
@@ -5,6 +6,8 @@ from pathlib import Path
 import pandas as pd
 
 from core.analyzer import MindSignalAnalyzer
+
+logger = logging.getLogger(__name__)
 
 # CSV 저장 기본 경로 (streamer.py와 동일한 위치)
 CSV_BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "csv"
@@ -124,24 +127,73 @@ def compute_subject_summary(df: pd.DataFrame) -> dict:
     return summary
 
 
+def align_on_second(
+    df1: pd.DataFrame, df2: pd.DataFrame, column: str
+) -> pd.DataFrame | None:
+    """두 피실험자 시계열을 공통 절대시각(정수 초) 격자에서 정렬함.
+
+    각 timestamp를 초 단위로 내림한 뒤 같은 초끼리 평균 집계하고 교집합만 남김.
+    merge_asof 최근접 매칭을 쓰지 않는 이유: 두 스트림의 초 경계 위상차와
+    행 간격 드리프트 때문에 경계 부근에서 최근접 이웃이 뒤집혀 상관값이
+    pandas 버전과 부동소수에 민감해짐 (2026-07-10 교차검토).
+
+    Args:
+        df1 - subject 1 시계열, timestamp 컬럼 필요함
+        df2 - subject 2 시계열, timestamp 컬럼 필요함
+        column - 정렬 대상 값 컬럼명임
+
+    Returns:
+        `sec`, `{column}_1`, `{column}_2` 컬럼을 가진 DataFrame 반환.
+        timestamp 컬럼이 없으면 None 반환(호출부가 폴백 판단함).
+    """
+    if "timestamp" not in df1.columns or "timestamp" not in df2.columns:
+        return None
+
+    frames = []
+    for df in (df1, df2):
+        sec = pd.to_datetime(df["timestamp"]).dt.floor("s")
+        frames.append(
+            pd.DataFrame({"sec": sec, column: df[column].values})
+            .groupby("sec", as_index=False)[column]
+            .mean()
+        )
+
+    return frames[0].merge(frames[1], on="sec", how="inner", suffixes=("_1", "_2"))
+
+
 def compute_synchrony(df1: pd.DataFrame, df2: pd.DataFrame) -> float | None:
-    """두 피실험자 간 뇌파 동기화 점수를 계산함 (trimming 적용)"""
+    """두 피실험자 간 뇌파 동기화 점수를 계산함 (trimming 적용).
+
+    각 피실험자의 진정 구간을 먼저 제거한 뒤 공통 절대시각 구간만 비교함.
+    측정 시작 시각이 어긋나도(2026-07-10 라이브: 38.3초 차이) 같은 시각끼리
+    맞대므로 시차가 상관에 섞이지 않음.
+    """
     analyzer = MindSignalAnalyzer()
 
     # trimming 적용 — 진정 구간 제외한 유효 구간만 사용함
     trimmed1, _ = trim_dataframe(df1)
     trimmed2, _ = trim_dataframe(df2)
 
-    # 공통 길이로 맞춤
-    min_len = min(len(trimmed1), len(trimmed2))
-    if min_len < 10:
+    aligned = align_on_second(trimmed1, trimmed2, "alpha")
+
+    if aligned is None:
+        # timestamp 부재 시 구 위치 정렬로 폴백함 (합성 픽스처 호환)
+        logger.warning("timestamp 컬럼 부재로 위치 기반 정렬 폴백함")
+        min_len = min(len(trimmed1), len(trimmed2))
+        if min_len < 10:
+            return None
+        alpha1 = trimmed1["alpha"].values[:min_len]
+        alpha2 = trimmed2["alpha"].values[:min_len]
+        return float(analyzer.calculate_synchrony(alpha1, alpha2))
+
+    if len(aligned) < 10:
         return None
 
-    # alpha 대역 기준 동기화 계산 수행함
-    alpha1 = trimmed1["alpha"].values[:min_len]
-    alpha2 = trimmed2["alpha"].values[:min_len]
-
-    return float(analyzer.calculate_synchrony(alpha1, alpha2))
+    return float(
+        analyzer.calculate_synchrony(
+            aligned["alpha_1"].values, aligned["alpha_2"].values
+        )
+    )
 
 
 def compute_session_analysis(group_id: str, subject_indices: list[int]) -> dict:

--- a/server/services/proxy_client.py
+++ b/server/services/proxy_client.py
@@ -82,6 +82,7 @@ def post_sample(
     seq: int,
     payload: dict,
     sync_meta: dict,
+    metrics: dict | None = None,
     max_retries: int = 2,
     backoffs_sec: tuple[float, ...] = (0.1, 0.2),
 ) -> None:
@@ -95,6 +96,9 @@ def post_sample(
         seq: 엔진 단위 단조 증가 시퀀스 번호.
         payload: 5대역 파워 dict (delta/theta/alpha/beta/gamma).
         sync_meta: 동기화 메타 dict (de_clock_domain 포함).
+        metrics: EMOTIV 지표 6종 dict. None이면 envelope에서 생략함
+            (구버전 proxy 호환). 생략 시 FE 차트가 대역 파워를 지표로
+            오표시하던 결함이 재발하므로 라이브 경로에서는 항상 전달함.
         max_retries: 재시도 최대 횟수 (총 시도 = 1 + max_retries).
         backoffs_sec: 각 retry 전 대기 시간 (초) 순서 튜플.
 
@@ -113,6 +117,8 @@ def post_sample(
         "payload": payload,
         "sync_meta": sync_meta,
     }
+    if metrics is not None:
+        body["metrics"] = metrics
 
     last_exc: Exception | None = None
 

--- a/tests/test_met_label_map.py
+++ b/tests/test_met_label_map.py
@@ -64,3 +64,16 @@ def test_missing_label_omits_key_instead_of_defaulting():
     met_map = build_met_map(["eng", "exc"])
     assert "focus" not in met_map
     assert met_map["engagement"] == 0
+
+
+def test_relabel_replaces_map_without_stale_keys():
+    """라벨 재수신 시 이전 매핑이 남지 않음 (CodeRabbit PR #36).
+
+    update()로 병합하면 이전 이벤트의 focus 인덱스가 남아, 새 라벨에
+    focus가 없는데도 on_new_met_data가 옛 인덱스로 값을 읽는다.
+    """
+    first = build_met_map(INSIGHT2_LABELS)
+    assert first["focus"] == 1
+
+    second = build_met_map(["eng", "exc", "str", "rel", "int"])
+    assert "focus" not in second

--- a/tests/test_met_label_map.py
+++ b/tests/test_met_label_map.py
@@ -1,0 +1,66 @@
+"""build_met_map 회귀 검증.
+
+회귀 배경(2026-07-10 라이브 측정, groupId 6a508a6b1048b553eea41778):
+    core/streamer.py가 met 라벨 'foc'만 탐색했으나 Insight2 Cortex는
+    'attention'을 보냄. focus 키가 매핑에서 빠져 CSV의 focus 컬럼이
+    827행 전 구간 0.000으로 기록됨.
+    로그 24행 실측: {'engagement':3,'interest':12,'excitement':5,'stress':8,'relaxation':10}
+"""
+
+from core.streamer import build_met_map
+
+# 2026-07-10 operator core 로그 23행에서 그대로 옮긴 Cortex Insight2 met 라벨임
+INSIGHT2_LABELS = [
+    "attention.isActive",
+    "attention",
+    "eng.isActive",
+    "eng",
+    "exc.isActive",
+    "exc",
+    "lex",
+    "str.isActive",
+    "str",
+    "rel.isActive",
+    "rel",
+    "int.isActive",
+    "int",
+]
+
+
+def test_insight2_attention_maps_to_focus():
+    """Insight2의 attention 라벨이 focus로 매핑됨 (수정 전 실패하던 케이스)."""
+    met_map = build_met_map(INSIGHT2_LABELS)
+    assert met_map["focus"] == 1
+
+
+def test_insight2_all_six_metrics_mapped():
+    """6개 지표 전부 매핑되고 인덱스가 라이브 로그 실측과 일치함."""
+    met_map = build_met_map(INSIGHT2_LABELS)
+    assert met_map == {
+        "focus": 1,
+        "engagement": 3,
+        "interest": 12,
+        "excitement": 5,
+        "stress": 8,
+        "relaxation": 10,
+    }
+
+
+def test_legacy_foc_label_still_supported():
+    """foc 라벨을 쓰는 구세대 헤드셋도 회귀 없이 매핑됨."""
+    labels = ["foc", "eng", "exc", "str", "rel", "int"]
+    met_map = build_met_map(labels)
+    assert met_map["focus"] == 0
+
+
+def test_attention_preferred_over_foc_when_both_present():
+    """두 라벨이 함께 있으면 후보 순서대로 attention을 채택함."""
+    labels = ["foc", "attention", "eng", "exc", "str", "rel", "int"]
+    assert build_met_map(labels)["focus"] == 1
+
+
+def test_missing_label_omits_key_instead_of_defaulting():
+    """미발견 지표는 키를 만들지 않아 호출부가 누락을 감지함."""
+    met_map = build_met_map(["eng", "exc"])
+    assert "focus" not in met_map
+    assert met_map["engagement"] == 0

--- a/tests/test_synchrony_alignment.py
+++ b/tests/test_synchrony_alignment.py
@@ -1,0 +1,109 @@
+"""compute_synchrony 시간축 정렬 회귀 검증.
+
+회귀 배경(2026-07-10 라이브 측정, groupId 6a508a6b1048b553eea41778):
+    compute_synchrony가 CSV의 timestamp 컬럼을 무시하고 각 스트림의 0번 행끼리
+    맞대어(.values[:min_len]) 상관을 계산함. 두 피실험자의 측정 시작이 38.3초
+    어긋나 고정 시차가 그대로 상관에 섞임.
+    실측: 위치 정렬 r=-0.12738, 시간축 정렬 r=+0.05943 (부호까지 뒤집힘).
+
+라이브 CSV의 정확한 float를 박제하지 않음. 이유:
+    (1) 레포 밖 Team-project/csv/ 파일 의존이라 CI에서 부재
+    (2) pandas 버전과 부동소수에 민감
+    대신 합성 픽스처로 정렬 로직을 결정적으로 검증하고, 부호와 범위만 단언함.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from server.services.analysis import (
+    TRIM_END_SECONDS,
+    TRIM_START_SECONDS,
+    align_on_second,
+    compute_synchrony,
+)
+
+
+def _make_df(start: str, n: int, alpha: np.ndarray) -> pd.DataFrame:
+    """초당 1행, 지정 시각부터 시작하는 시계열 생성함"""
+    ts = pd.date_range(start=start, periods=n, freq="1s")
+    return pd.DataFrame({"timestamp": ts, "alpha": alpha})
+
+
+def test_align_on_second_removes_start_offset():
+    """시작 시각이 어긋나도 같은 절대시각끼리 정렬됨."""
+    wave = np.sin(np.linspace(0, 8 * np.pi, 100))
+    a = _make_df("2026-07-10 15:00:00", 100, wave)
+    # b는 30초 늦게 시작하지만 같은 절대시각에는 같은 값을 가짐
+    b = _make_df("2026-07-10 15:00:30", 70, wave[30:])
+
+    aligned = align_on_second(a, b, "alpha")
+
+    assert len(aligned) == 70
+    # 같은 시각의 값이 정확히 일치해야 함
+    np.testing.assert_allclose(aligned["alpha_1"], aligned["alpha_2"])
+
+
+def test_align_on_second_returns_none_without_timestamp():
+    """timestamp 컬럼이 없으면 None 반환해 호출부가 폴백하게 함."""
+    a = pd.DataFrame({"alpha": [1.0, 2.0, 3.0]})
+    b = pd.DataFrame({"alpha": [1.0, 2.0, 3.0]})
+    assert align_on_second(a, b, "alpha") is None
+
+
+def test_positional_alignment_would_report_spurious_correlation():
+    """위치 정렬(구 동작)은 시차를 상관으로 오인함 — 회귀 재현.
+
+    동일 신호를 시간축에서 30초 밀면 진짜 상관은 1.0이어야 하나,
+    행 인덱스로 맞대면 위상이 어긋나 1.0이 아님.
+    """
+    wave = np.sin(np.linspace(0, 8 * np.pi, 130))
+    a = _make_df("2026-07-10 15:00:00", 130, wave)
+    b = _make_df("2026-07-10 15:00:30", 100, wave[30:])
+
+    trim = TRIM_START_SECONDS + TRIM_END_SECONDS
+    assert len(b) - trim >= 10  # 픽스처가 유효 구간을 남기는지 확인함
+
+    # 수정 후: 절대시각 정렬이라 완전 상관
+    assert compute_synchrony(a, b) == pytest.approx(1.0, abs=1e-9)
+
+    # 구 동작(위치 정렬)을 직접 재현하면 1.0이 아님
+    t1 = a.iloc[TRIM_START_SECONDS : len(a) - TRIM_END_SECONDS].reset_index(drop=True)
+    t2 = b.iloc[TRIM_START_SECONDS : len(b) - TRIM_END_SECONDS].reset_index(drop=True)
+    n = min(len(t1), len(t2))
+    positional = np.corrcoef(t1["alpha"].values[:n], t2["alpha"].values[:n])[0, 1]
+    assert abs(positional - 1.0) > 0.1
+
+
+def test_returns_none_when_overlap_too_short():
+    """겹치는 구간이 10초 미만이면 None 반환함."""
+    wave = np.random.default_rng(0).normal(size=60)
+    a = _make_df("2026-07-10 15:00:00", 60, wave)
+    b = _make_df("2026-07-10 15:10:00", 60, wave)  # 겹침 없음
+    assert compute_synchrony(a, b) is None
+
+
+def test_duplicate_seconds_are_averaged_not_duplicated():
+    """같은 초에 여러 행이 오면 평균 집계해 1:1 정렬 유지함."""
+    ts = pd.to_datetime(
+        [
+            "2026-07-10 15:00:00.100",
+            "2026-07-10 15:00:00.600",
+            "2026-07-10 15:00:01.200",
+        ]
+    )
+    a = pd.DataFrame({"timestamp": ts, "alpha": [1.0, 3.0, 5.0]})
+    b = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                ["2026-07-10 15:00:00.000", "2026-07-10 15:00:01.000"]
+            ),
+            "alpha": [10.0, 20.0],
+        }
+    )
+
+    aligned = align_on_second(a, b, "alpha")
+
+    assert len(aligned) == 2
+    # 15:00:00 초에 1.0과 3.0이 있었으므로 평균 2.0
+    assert aligned.loc[aligned["sec"].dt.second == 0, "alpha_1"].iloc[0] == 2.0


### PR DESCRIPTION
> 계획 폴더: `.plans/20-live-measurement-integrity-fixes` (ANALYSIS-W103)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 배경

2026-07-10 라이브 2-PC 측정(groupId `6a508a6b1048b553eea41778`)에서 결함 4건을 실측으로 확인했다. Fable과 codex gpt-5.6-sol 병렬 교차검토로 검증했다.

## 변경

### focus 라벨 매핑 (`core/streamer.py`)

Cortex Insight2가 보내는 met 라벨은 `attention`인데 코드는 `foc`만 탐색했다. 그래서 focus 키가 매핑에서 통째로 빠지고 CSV의 focus 컬럼이 **827행 전 구간 0.000**으로 기록됐다.

operator core 로그 실측:

```
labels: ['attention.isActive','attention','eng.isActive','eng',...]
MET 인덱스 매핑 완료됨: {'engagement':3,'interest':12,'excitement':5,'stress':8,'relaxation':10}
```

`build_met_map()`으로 후보 라벨을 순서대로 탐색하게 바꿨다. 구세대 `foc`도 계속 지원한다.

### 동조율 절대시각 정렬 (`server/services/analysis.py`)

`compute_synchrony`가 CSV의 timestamp 컬럼을 무시하고 각 스트림의 0번 행끼리 맞대어(`.values[:min_len]`) 상관을 냈다. 두 피실험자의 측정 시작이 38.3초 어긋나 그 시차가 그대로 상관에 섞였다.

라이브 CSV 실측:

| 방식 | n | r |
|---|---|---|
| 현행 (trim 후 위치 정렬) | 197 | **-0.12738** |
| 수정 후 (정수 초 격자 조인) | 197 | **+0.02321** |

부호까지 뒤집힌다. merge_asof 최근접 매칭은 채택하지 않았다. 두 스트림의 초 경계 위상차가 298ms인데 행 간격 드리프트가 5.8ms/초라, 경계 부근에서 최근접 이웃이 뒤집혀 상관값이 pandas 버전과 부동소수에 민감해진다.

### proxy로 metrics 전달 (`core/streamer.py`, `server/services/proxy_client.py`)

proxy 모드가 `payload=powers`만 보내 EMOTIV 지표 6종이 소실됐다. 하류 FE 차트가 `stress`에 `delta`를 표시하던 원인의 최상류다.

### MET watchdog 분리 (`core/streamer.py`)

`last_data_time`이 EEG 핸들러에서만 갱신돼, EEG는 살아 있고 MET만 죽으면 watchdog이 침묵했다. `latest_met`이 마지막 값을 무한 반복하며 CSV에 얼어붙은 지표가 기록된다. `last_met_time`을 분리하고 `metrics_stale` 상태를 별도 발행한다.

## 검증

- `pytest` 169건 PASS (신규 10건 포함)
- `black`, `isort`, `flake8` clean
- 회귀 테스트는 오늘 로그의 **실제 Cortex 라벨 배열**과 합성 픽스처를 사용한다. 라이브 CSV의 float는 박제하지 않았다 — 정렬 방식에 따라 값이 갈리고(0.023 / 0.059 / 0.086) n이 약 197이라 표준오차가 약 0.071이므로 셋 다 0과 구분되지 않는다.

## 알려진 잔여

`run_full_pipeline`의 baseline 30행과 자극 윈도우가 여전히 행 번호 기준이라, 시작 시각이 어긋나면 같은 자극 번호가 서로 다른 절대시각을 가리킨다. 동조율은 고쳤으나 자극별 feature 정렬은 다음 회차 과제다.

## 관련 PR

계약이 4레포를 관통한다. proxy PR #4와 함께 머지해야 한다.

계획서: `Team-project/.plans/20-live-measurement-integrity-fixes/PLAN.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 다양한 지표 라벨을 자동 매핑해 집중도·참여도·스트레스·이완도 등 주요 지표를 안정적으로 제공합니다.
  * 샘플 전송 시 측정 지표를 함께 포함해 전달합니다.

* **버그 수정**
  * 공통 시간 기준으로 동기화 계산을 정렬해 결과 신뢰성을 개선했습니다.
  * 지표 수신 지연/정체를 별도로 감지하고 상태를 더 정확히 반영합니다.

* **문서**
  * 계획 산출물 및 세션 기록 관리 기준을 표준화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->