### PR TITLE
fix(analysis): 자극 윈도우를 절대시각 기준으로 분할한다

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -5,11 +5,13 @@ from contextlib import asynccontextmanager
 
 import httpx
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from server.config import settings
 from server.routes import analyze, control, export, health, logs, stream
 from server.services import logbuffer
+from server.services.analysis import AnalysisContractError
 from server.services.webhook import (
     register_to_backend,
     register_to_backend_dual,
@@ -320,6 +322,19 @@ app = FastAPI(
     version="1.0.0",
     lifespan=lifespan,
 )
+
+
+@app.exception_handler(AnalysisContractError)
+async def analysis_contract_error_handler(
+    request: Request,
+    exc: AnalysisContractError,
+) -> JSONResponse:
+    """분석 계약 오류를 최상위 평면 422 응답으로 변환함"""
+    return JSONResponse(
+        status_code=422,
+        content={"error_code": exc.error_code, "detail": exc.detail},
+    )
+
 
 app.include_router(health.router, tags=["Health"])
 app.include_router(analyze.router, prefix="/api", tags=["Analyze"])

--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from fastapi import APIRouter, Header, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
 from server.config import settings
 from server.services.analysis import compute_session_analysis
@@ -55,11 +55,21 @@ async def analyze(
 class PipelineParams(BaseModel):
     """분석 파이프라인 파라미터임"""
 
-    stimulus_duration_sec: int = 60
-    window_size_sec: int = 10
-    n_stimuli: int = 10
-    baseline_duration_sec: int = 30
-    band_cols: list[str] = ["alpha", "beta", "theta", "gamma"]
+    stimulus_duration_sec: int = Field(default=60, gt=0)
+    window_size_sec: int = Field(default=10, gt=0)
+    n_stimuli: int = Field(default=10, gt=0)
+    baseline_duration_sec: int = Field(default=30, gt=0)
+    band_cols: list[str] = Field(
+        default_factory=lambda: ["alpha", "beta", "theta", "gamma"],
+        min_length=1,
+    )
+
+    @model_validator(mode="after")
+    def validate_window_partition(self) -> "PipelineParams":
+        """자극 길이가 윈도우 크기로 나누어떨어지는지 검증함"""
+        if self.stimulus_duration_sec % self.window_size_sec != 0:
+            raise ValueError("stimulus_duration_sec는 window_size_sec의 배수여야 함")
+        return self
 
 
 class PipelineRequest(BaseModel):
@@ -67,7 +77,7 @@ class PipelineRequest(BaseModel):
 
     group_id: str
     subject_indices: list[int]
-    params: PipelineParams = PipelineParams()
+    params: PipelineParams = Field(default_factory=PipelineParams)
     satisfaction_scores: dict[int, float] | None = None  # {1: 7.5, 2: 6.0}
     include_markdown: bool = False
     mode: Literal["DUAL", "SEQUENTIAL", "BTI", "DUAL_2PC"] = "DUAL"  # 실험 모드 선택

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -1,6 +1,8 @@
 import logging
 import os
 from collections import OrderedDict
+from dataclasses import dataclass
+from math import ceil
 from pathlib import Path
 
 import pandas as pd
@@ -18,6 +20,27 @@ TRIM_END_SECONDS = 15
 
 # 최소 분석 가능 시간 (trimming 후 유효 구간 기준, 임시값 — 교수 확인 후 확정)
 MIN_ANALYSIS_SECONDS = int(os.getenv("MIN_ANALYSIS_SECONDS", 180))
+
+
+class AnalysisContractError(Exception):
+    """분석 입력 계약 위반을 나타내는 예외임"""
+
+    def __init__(self, error_code: str, detail: str) -> None:
+        """구조화된 오류 코드와 설명을 저장함"""
+        super().__init__(detail)
+        self.error_code = error_code
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class WindowSlot:
+    """자극 윈도우의 고정 식별자와 절대시각 구간을 보관함"""
+
+    stim_idx: int
+    win_idx: int
+    window_start: pd.Timestamp
+    window_end: pd.Timestamp
+    data: pd.DataFrame | None
 
 
 def classify_session_tier(total_samples: int) -> str:
@@ -303,43 +326,107 @@ def analyze_pipeline_sequential(
 
 
 def average_by_timestamp(df: pd.DataFrame, band_cols: list[str]) -> pd.DataFrame:
-    """타임스탬프별 뇌파 신호를 평균화하여 노이즈를 감소시킴
+    """정수 초별 뇌파 신호를 평균화하고 절대시각을 보존함
 
-    각 timestamp에서 측정된 원시 뇌파 신호가 여러 샘플인 경우,
-    평균값으로 변환하여 대표값을 설정함.
-    CSV가 이미 1초 1행이면 그대로 반환함.
+    파싱할 수 없는 행은 제외하고 같은 정수 초의 중복 샘플을 평균화함.
+
+    Raises:
+        AnalysisContractError: timestamp 컬럼이 없거나 전 행 파싱 실패한 경우
     """
-    # 'time' 또는 'timestamp' 컬럼 유무 확인
-    time_col = None
-    if "time" in df.columns:
-        time_col = "time"
-    elif "timestamp" in df.columns:
-        time_col = "timestamp"
+    if "timestamp" not in df.columns:
+        raise AnalysisContractError(
+            "TIMESTAMP_COLUMN_MISSING",
+            "CSV에 timestamp 컬럼이 없음",
+        )
 
-    if time_col is None:
-        # 이미 1초 1행 구조로 가정하여 band_cols만 추출하여 반환함
-        available = [c for c in band_cols if c in df.columns]
-        return df[available].reset_index(drop=True)
+    parsed = pd.to_datetime(df["timestamp"], errors="coerce")
+    valid_mask = parsed.notna()
+    if not valid_mask.any():
+        raise AnalysisContractError(
+            "TIMESTAMP_UNPARSABLE",
+            "CSV의 timestamp를 파싱할 수 없음",
+        )
 
-    # 타임스탬프 기준 groupby 후 band_cols의 mean 계산 수행함
     available = [c for c in band_cols if c in df.columns]
-    grouped = df.groupby(time_col)[available].mean().reset_index(drop=True)
-    return grouped
+    normalized = df.loc[valid_mask, available].copy()
+    normalized.insert(0, "timestamp", parsed.loc[valid_mask].dt.floor("s"))
+    normalized = normalized.sort_values("timestamp")
+
+    if not available:
+        return normalized[["timestamp"]].drop_duplicates().reset_index(drop=True)
+
+    return (
+        normalized.groupby("timestamp", as_index=False, sort=True)[available]
+        .mean()
+        .reset_index(drop=True)
+    )
+
+
+def _resolve_origin(
+    df: pd.DataFrame,
+    common_origin: pd.Timestamp | None,
+) -> pd.Timestamp:
+    """명시된 공통 시작시각 또는 DataFrame의 첫 시각을 반환함"""
+    if common_origin is not None:
+        return pd.Timestamp(common_origin)
+    if "timestamp" not in df.columns or df.empty:
+        raise AnalysisContractError(
+            "TIMESTAMP_UNPARSABLE",
+            "분석 가능한 timestamp 행이 없음",
+        )
+    return pd.Timestamp(df["timestamp"].min())
+
+
+def _valid_observation_count(
+    interval_df: pd.DataFrame,
+    band_cols: list[str],
+) -> int:
+    """요청 대역이 모두 존재하고 non-NaN인 고유 관측 초를 계산함"""
+    if "timestamp" not in interval_df.columns:
+        return 0
+    if any(band not in interval_df.columns for band in band_cols):
+        return 0
+    complete = interval_df.loc[
+        interval_df[band_cols].notna().all(axis=1),
+        "timestamp",
+    ]
+    return int(complete.nunique())
 
 
 def compute_baseline(
     df: pd.DataFrame,
     band_cols: list[str],
     baseline_duration_sec: int = 30,
+    common_origin: pd.Timestamp | None = None,
 ) -> dict[str, float]:
-    """Baseline 구간(처음 N초)의 대역별 평균값을 산출함"""
-    # 처음 baseline_duration_sec 행을 baseline 구간으로 사용함 (1행 = 1초 가정)
-    baseline_df = df.iloc[:baseline_duration_sec]
-    result = {}
-    for band in band_cols:
-        if band in baseline_df.columns:
-            result[band] = float(baseline_df[band].mean())
-    return result
+    """공통 시작시각부터 baseline 구간의 대역별 평균값을 산출함
+
+    Raises:
+        AnalysisContractError: baseline 길이가 0 이하이거나 coverage 미달인 경우
+    """
+    if baseline_duration_sec <= 0:
+        raise AnalysisContractError(
+            "BASELINE_COVERAGE_INSUFFICIENT",
+            f"baseline 길이가 양수가 아님: {baseline_duration_sec}",
+        )
+
+    origin = _resolve_origin(df, common_origin)
+    baseline_end = origin + pd.Timedelta(seconds=baseline_duration_sec)
+    baseline_df = df.loc[(df["timestamp"] >= origin) & (df["timestamp"] < baseline_end)]
+    minimum_observations = ceil(baseline_duration_sec * 0.5)
+    observed = _valid_observation_count(baseline_df, band_cols)
+    if observed < minimum_observations:
+        raise AnalysisContractError(
+            "BASELINE_COVERAGE_INSUFFICIENT",
+            (
+                "baseline 관측 초가 최소 coverage에 미달함: "
+                f"{observed}/{minimum_observations}"
+            ),
+        )
+
+    # coverage 판정과 같은 완전 관측 행으로 평균을 산출함
+    complete = baseline_df.loc[baseline_df[band_cols].notna().all(axis=1)]
+    return {band: float(complete[band].mean()) for band in band_cols}
 
 
 def split_stimulus_windows(
@@ -349,42 +436,47 @@ def split_stimulus_windows(
     window_size_sec: int = 10,
     n_stimuli: int = 10,
     baseline_duration_sec: int = 30,
-) -> list[list[pd.DataFrame]]:
-    """Stimulus 구간을 윈도우 단위로 분할함
+    common_origin: pd.Timestamp | None = None,
+) -> list[WindowSlot]:
+    """자극 구간을 절대시각 기반 고정 윈도우 슬롯으로 분할함
 
-    baseline 구간 이후의 데이터를 stimulus별 → window별로 분할함.
-    반환: windows[stimulus_idx][window_idx] = DataFrame (band_cols만 포함)
+    coverage 미달 윈도우도 None 데이터와 원래 식별자를 가진 슬롯으로 유지함.
     """
+    origin = _resolve_origin(df, common_origin)
     n_windows = stimulus_duration_sec // window_size_sec
-    available = [c for c in band_cols if c in df.columns]
-    windows: list[list[pd.DataFrame]] = []
+    slots: list[WindowSlot] = []
+    minimum_observations = ceil(window_size_sec * 0.5)
 
     for stim_idx in range(n_stimuli):
-        # 각 stimulus의 시작 행 인덱스 계산함
-        stimulus_start = baseline_duration_sec + (stim_idx * stimulus_duration_sec)
-        stim_windows: list[pd.DataFrame] = []
+        stimulus_start = origin + pd.Timedelta(
+            seconds=baseline_duration_sec + (stim_idx * stimulus_duration_sec)
+        )
 
         for win_idx in range(n_windows):
-            win_start = stimulus_start + (win_idx * window_size_sec)
-            win_end = win_start + window_size_sec
+            window_start = stimulus_start + pd.Timedelta(
+                seconds=win_idx * window_size_sec
+            )
+            window_end = window_start + pd.Timedelta(seconds=window_size_sec)
+            window_df = df.loc[
+                (df["timestamp"] >= window_start) & (df["timestamp"] < window_end)
+            ].reset_index(drop=True)
+            observed = _valid_observation_count(window_df, band_cols)
+            data = window_df if observed >= minimum_observations else None
+            slots.append(
+                WindowSlot(
+                    stim_idx=stim_idx,
+                    win_idx=win_idx,
+                    window_start=window_start,
+                    window_end=window_end,
+                    data=data,
+                )
+            )
 
-            # 데이터가 부족한 경우 해당 window 건너뜀
-            if win_start >= len(df):
-                break
-
-            window_df = df[available].iloc[win_start:win_end].reset_index(drop=True)
-
-            # 실제 데이터가 존재하는 경우만 추가함
-            if len(window_df) > 0:
-                stim_windows.append(window_df)
-
-        windows.append(stim_windows)
-
-    return windows
+    return slots
 
 
 def extract_features(
-    windows: list[list[pd.DataFrame]],
+    windows: list[WindowSlot],
     band_cols: list[str],
     baseline: dict[str, float] | None = None,
 ) -> dict[str, float]:
@@ -395,22 +487,23 @@ def extract_features(
     """
     features: dict[str, float] = OrderedDict()
 
-    for stim_idx, stim_windows in enumerate(windows):
-        for win_idx, window_df in enumerate(stim_windows):
-            for band in band_cols:
-                if band not in window_df.columns:
-                    continue
-                window_mean = float(window_df[band].mean())
+    for slot in windows:
+        if slot.data is None:
+            continue
+        for band in band_cols:
+            if band not in slot.data.columns:
+                continue
+            window_mean = float(slot.data[band].mean())
 
-                # baseline이 있으면 baseline 대비 변화량으로 계산함
-                if baseline is not None and band in baseline:
-                    feature_val = window_mean - baseline[band]
-                else:
-                    feature_val = window_mean
+            # baseline이 있으면 baseline 대비 변화량으로 계산함
+            if baseline is not None and band in baseline:
+                feature_val = window_mean - baseline[band]
+            else:
+                feature_val = window_mean
 
-                # 1-indexed 키 네이밍 적용함
-                key = f"s{stim_idx + 1}_w{win_idx + 1}_{band}"
-                features[key] = feature_val
+            # 슬롯의 고정 식별자로 1-indexed 키를 생성함
+            key = f"s{slot.stim_idx + 1}_w{slot.win_idx + 1}_{band}"
+            features[key] = feature_val
 
     return features
 
@@ -419,16 +512,19 @@ def build_pair_features(
     features_a: dict[str, float],
     features_b: dict[str, float],
 ) -> dict[str, float]:
-    """두 피실험자의 feature를 결합하여 pair feature를 구성함"""
+    """양쪽에 모두 존재하는 feature만 pair feature로 구성함"""
     pair: dict[str, float] = OrderedDict()
+    common_keys = features_a.keys() & features_b.keys()
 
-    # Subject A feature에 "a_" 접두사 추가함
+    # Subject A의 교집합 feature에 "a_" 접두사 추가함
     for key, val in features_a.items():
-        pair[f"a_{key}"] = val
+        if key in common_keys:
+            pair[f"a_{key}"] = val
 
-    # Subject B feature에 "b_" 접두사 추가함
+    # Subject B의 교집합 feature에 "b_" 접두사 추가함
     for key, val in features_b.items():
-        pair[f"b_{key}"] = val
+        if key in common_keys:
+            pair[f"b_{key}"] = val
 
     return pair
 
@@ -461,48 +557,116 @@ def run_full_pipeline(
     n_windows_per_stimulus = stimulus_duration_sec // window_size_sec
     total_features_per_subject = n_stimuli * n_windows_per_stimulus * len(band_cols)
 
-    subjects_result = []
+    subjects_by_index: dict[int, dict] = {}
     subject_features: dict[int, dict[str, float]] = {}
-    dataframes: dict[int, pd.DataFrame] = {}
+    raw_dataframes: dict[int, pd.DataFrame] = {}
+    normalized_dataframes: dict[int, pd.DataFrame] = {}
 
+    # 1차 pass에서 모든 사용 가능한 CSV를 로드하고 정규화함
     for idx in subject_indices:
-        # [1] CSV 로드 수행함
         csv_files = find_csv_files(group_id, idx)
         if not csv_files:
-            subjects_result.append({"subject_index": idx, "error": "CSV 파일 미발견"})
+            subjects_by_index[idx] = {
+                "subject_index": idx,
+                "error": "CSV 파일 미발견",
+            }
             continue
 
         raw_df = load_session_data(csv_files[0])
-        dataframes[idx] = raw_df
+        raw_dataframes[idx] = raw_df
+        # 한 subject의 계약 위반이 다른 subject 분석까지 막지 않도록 격리함
+        try:
+            normalized_dataframes[idx] = average_by_timestamp(raw_df, band_cols)
+        except AnalysisContractError as exc:
+            subjects_by_index[idx] = {
+                "subject_index": idx,
+                "error": exc.detail,
+                "error_code": exc.error_code,
+            }
 
-        # [2] 타임스탬프별 평균화 수행함
-        averaged_df = average_by_timestamp(raw_df, band_cols)
+    # usable CSV가 없으면 기존 partial 200 계약을 유지함
+    if not normalized_dataframes:
+        return {
+            "group_id": group_id,
+            "subjects": [subjects_by_index[idx] for idx in subject_indices],
+            "pair_features": None,
+            "y_score": None,
+            "synchrony_score": None,
+            "pipeline_params": {
+                "stimulus_duration_sec": stimulus_duration_sec,
+                "window_size_sec": window_size_sec,
+                "n_stimuli": n_stimuli,
+                "baseline_duration_sec": baseline_duration_sec,
+                "band_cols": band_cols,
+                "n_windows_per_stimulus": n_windows_per_stimulus,
+                "total_features_per_subject": total_features_per_subject,
+            },
+            "dataframes": raw_dataframes,
+        }
 
-        # [3] Baseline 산출 수행함
-        baseline = compute_baseline(averaged_df, band_cols, baseline_duration_sec)
-
-        # [4] Stimulus 윈도우 분할 수행함
-        windows = split_stimulus_windows(
-            averaged_df,
-            band_cols,
-            stimulus_duration_sec=stimulus_duration_sec,
-            window_size_sec=window_size_sec,
-            n_stimuli=n_stimuli,
-            baseline_duration_sec=baseline_duration_sec,
+    common_origin = max(df["timestamp"].min() for df in normalized_dataframes.values())
+    common_end = min(
+        df["timestamp"].max() for df in normalized_dataframes.values()
+    ) + pd.Timedelta(seconds=1)
+    common_duration_sec = (common_end - common_origin).total_seconds()
+    if common_duration_sec < baseline_duration_sec:
+        raise AnalysisContractError(
+            "COMMON_WINDOW_TOO_SHORT",
+            (
+                "공통 분석 구간이 baseline보다 짧음: "
+                f"{common_duration_sec:g}/{baseline_duration_sec}초"
+            ),
         )
 
-        # [5] Feature 추출 수행함
-        features = extract_features(windows, band_cols, baseline=baseline)
+    # 2차 pass에서 공통 구간으로 트리밍한 후 feature를 추출함
+    aligned_dataframes: dict[int, pd.DataFrame] = {}
+    for idx, normalized_df in normalized_dataframes.items():
+        aligned_df = normalized_df.loc[
+            (normalized_df["timestamp"] >= common_origin)
+            & (normalized_df["timestamp"] < common_end)
+        ].reset_index(drop=True)
+        aligned_dataframes[idx] = aligned_df
+
+        # subject 단위 계약 위반은 그 subject만 실패 처리하고 나머지를 살림
+        try:
+            # [3] Baseline 산출 수행함
+            baseline = compute_baseline(
+                aligned_df,
+                band_cols,
+                baseline_duration_sec,
+                common_origin=common_origin,
+            )
+
+            # [4] Stimulus 윈도우 분할 수행함
+            windows = split_stimulus_windows(
+                aligned_df,
+                band_cols,
+                stimulus_duration_sec=stimulus_duration_sec,
+                window_size_sec=window_size_sec,
+                n_stimuli=n_stimuli,
+                baseline_duration_sec=baseline_duration_sec,
+                common_origin=common_origin,
+            )
+
+            # [5] Feature 추출 수행함
+            features = extract_features(windows, band_cols, baseline=baseline)
+        except AnalysisContractError as exc:
+            subjects_by_index[idx] = {
+                "subject_index": idx,
+                "error": exc.detail,
+                "error_code": exc.error_code,
+            }
+            continue
 
         subject_features[idx] = features
-        subjects_result.append(
-            {
-                "subject_index": idx,
-                "baseline": baseline,
-                "features": features,
-                "n_features": len(features),
-            }
-        )
+        subjects_by_index[idx] = {
+            "subject_index": idx,
+            "baseline": baseline,
+            "features": features,
+            "n_features": len(features),
+        }
+
+    subjects_result = [subjects_by_index[idx] for idx in subject_indices]
 
     # [7] Pair Feature 구성 (subject 2명일 때만 수행함)
     pair_features = None
@@ -522,9 +686,11 @@ def run_full_pipeline(
 
     # 기존 compute_synchrony를 활용한 synchrony_score 계산 수행함
     synchrony_score = None
-    if len(dataframes) == 2:
-        keys = list(dataframes.keys())
-        synchrony_score = compute_synchrony(dataframes[keys[0]], dataframes[keys[1]])
+    if len(raw_dataframes) == 2:
+        keys = list(raw_dataframes.keys())
+        synchrony_score = compute_synchrony(
+            raw_dataframes[keys[0]], raw_dataframes[keys[1]]
+        )
 
     return {
         "group_id": group_id,
@@ -541,5 +707,5 @@ def run_full_pipeline(
             "n_windows_per_stimulus": n_windows_per_stimulus,
             "total_features_per_subject": total_features_per_subject,
         },
-        "dataframes": dataframes,  # Markdown 변환용
+        "dataframes": raw_dataframes,  # Markdown 변환용 원본 데이터임
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,10 @@ def band_cols():
 
 @pytest.fixture
 def simple_df():
-    """time 컬럼 없이 band_cols만 포함한 100행 DataFrame 반환함"""
+    """1초 간격 timestamp와 band_cols를 포함한 100행 DataFrame 반환함"""
     np.random.seed(42)
     data = {
+        "timestamp": pd.date_range("2026-01-01", periods=100, freq="s"),
         "alpha": np.random.uniform(0.1, 1.0, 100),
         "beta": np.random.uniform(0.1, 1.0, 100),
         "theta": np.random.uniform(0.1, 1.0, 100),
@@ -44,7 +45,10 @@ def timestamped_df():
     """'timestamp' 컬럼 포함 — 동일 timestamp에 복수 행 존재하는 DataFrame 반환함"""
     np.random.seed(42)
     # 각 timestamp에 3개 샘플씩 30개 timestamp = 90행
-    timestamps = np.repeat(np.arange(30), 3)
+    timestamps = np.repeat(
+        pd.date_range("2026-01-01", periods=30, freq="s").values,
+        3,
+    )
     data = {
         "timestamp": timestamps,
         "alpha": np.random.uniform(0.1, 1.0, 90),
@@ -63,6 +67,11 @@ def full_session_df():
     """
     np.random.seed(42)
     data = {
+        "timestamp": pd.date_range(
+            "2026-01-01",
+            periods=FULL_SESSION_ROWS,
+            freq="s",
+        ),
         "alpha": np.random.uniform(0.1, 1.0, FULL_SESSION_ROWS),
         "beta": np.random.uniform(0.1, 1.0, FULL_SESSION_ROWS),
         "theta": np.random.uniform(0.1, 1.0, FULL_SESSION_ROWS),

--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest  # noqa: F401
 
+from server.services.analysis import AnalysisContractError
 from tests.conftest import TEST_GROUP_ID, TEST_SECRET  # noqa: F401
 
 
@@ -174,6 +175,69 @@ class TestAnalyzePipelineEndpoint:
             headers=pipeline_secret_header,
         )
         assert response.status_code == 422
+
+    @pytest.mark.parametrize("mode", ["DUAL", "DUAL_2PC"])
+    @pytest.mark.parametrize(
+        ("error_code", "detail"),
+        # subject 단위 위반(TIMESTAMP_*, BASELINE_*)은 partial 200으로 흡수되므로
+        # 전역 422로 탈출하는 공통 구간 위반만 라우트 계약으로 검증함
+        [("COMMON_WINDOW_TOO_SHORT", "공통 구간 부족")],
+    )
+    @patch("server.services.analysis.run_full_pipeline")
+    def test_analysis_contract_error_returns_flat_422_in_both_dual_paths(
+        self,
+        mock_pipeline,
+        error_code,
+        detail,
+        mode,
+        test_client,
+        pipeline_secret_header,
+    ):
+        """두 DUAL 호출 경로에서 분석 계약 오류를 평면 422로 반환함"""
+        mock_pipeline.side_effect = AnalysisContractError(error_code, detail)
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={
+                "group_id": TEST_GROUP_ID,
+                "subject_indices": [1, 2],
+                "mode": mode,
+            },
+            headers=pipeline_secret_header,
+        )
+        assert response.status_code == 422
+        assert response.json() == {
+            "error_code": error_code,
+            "detail": detail,
+        }
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"window_size_sec": 0},
+            {"baseline_duration_sec": -1},
+            {"band_cols": []},
+            {"stimulus_duration_sec": 61, "window_size_sec": 10},
+        ],
+    )
+    def test_invalid_pipeline_params_use_fastapi_validation_422(
+        self,
+        params,
+        test_client,
+        pipeline_secret_header,
+    ):
+        """비정상 파라미터를 실행 전 FastAPI validation 422로 거부함"""
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={
+                "group_id": TEST_GROUP_ID,
+                "subject_indices": [1, 2],
+                "params": params,
+            },
+            headers=pipeline_secret_header,
+        )
+        assert response.status_code == 422
+        assert "detail" in response.json()
+        assert "error_code" not in response.json()
 
 
 class TestAnalyzePipelineModeField:

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -9,6 +9,9 @@ import pandas as pd
 import pytest
 
 from server.services.analysis import (
+    CSV_BASE_DIR,
+    AnalysisContractError,
+    WindowSlot,
     analyze_pipeline_sequential,
     average_by_timestamp,
     build_pair_features,
@@ -29,51 +32,48 @@ from tests.conftest import (
 
 
 class TestAverageByTimestamp:
-    def test_no_time_col_returns_band_cols_only(self, simple_df, band_cols):
-        """time/timestamp 컬럼 없는 DataFrame → 반환 컬럼이 band_cols와 일치함"""
-        result = average_by_timestamp(simple_df, band_cols)
-        assert list(result.columns) == band_cols
-
-    def test_no_time_col_preserves_row_count(self, simple_df, band_cols):
-        """time 컬럼 없으면 행 수 변화 없음"""
-        result = average_by_timestamp(simple_df, band_cols)
-        assert len(result) == len(simple_df)
-
-    def test_no_time_col_index_reset(self, simple_df, band_cols):
-        """반환 DataFrame의 index가 0부터 연속 정수임"""
-        result = average_by_timestamp(simple_df, band_cols)
-        assert list(result.index) == list(range(len(result)))
+    def test_timestamp_missing_raises_contract_error(self, band_cols):
+        """timestamp 컬럼 누락 시 명시적 계약 오류가 발생함"""
+        df = pd.DataFrame({band: [1.0] for band in band_cols})
+        with pytest.raises(AnalysisContractError) as exc_info:
+            average_by_timestamp(df, band_cols)
+        assert exc_info.value.error_code == "TIMESTAMP_COLUMN_MISSING"
 
     def test_timestamp_col_groups_and_averages(self, timestamped_df, band_cols):
         """timestamp 컬럼 존재 시 동일 timestamp의 값이 평균화되어 행 수 감소함"""
         result = average_by_timestamp(timestamped_df, band_cols)
         # 30개 unique timestamp → 30행으로 축소
         assert len(result) == 30
+        assert list(result.columns) == ["timestamp", *band_cols]
+        assert result["timestamp"].is_monotonic_increasing
 
-    def test_time_col_preferred_over_timestamp(self, band_cols):
-        """'time'과 'timestamp' 동시 존재 시 'time' 우선 사용함"""
-        np.random.seed(42)
+    def test_same_second_samples_are_averaged(self, band_cols):
+        """마이크로초가 다른 같은 초 샘플을 하나로 평균화함"""
         df = pd.DataFrame(
             {
-                "time": [0, 0, 1, 1],
-                "timestamp": [10, 10, 20, 20],
-                "alpha": [1.0, 3.0, 2.0, 4.0],
-                "beta": [0.5, 0.5, 1.5, 1.5],
-                "theta": [0.1, 0.3, 0.2, 0.4],
-                "gamma": [0.2, 0.4, 0.3, 0.5],
+                "timestamp": [
+                    "2026-01-01 00:00:00.100",
+                    "2026-01-01 00:00:00.900",
+                ],
+                **{band: [1.0, 3.0] for band in band_cols},
             }
         )
         result = average_by_timestamp(df, band_cols)
-        # 'time' 기준 2개 그룹 → 2행
-        assert len(result) == 2
+        assert len(result) == 1
+        assert result.loc[0, "alpha"] == 2.0
+        assert result.loc[0, "timestamp"] == pd.Timestamp("2026-01-01")
 
-    def test_partial_band_cols_in_df(self):
-        """DataFrame에 band_cols 일부만 존재할 때 존재하는 것만 반환함"""
-        df = pd.DataFrame({"alpha": [1.0, 2.0], "beta": [3.0, 4.0]})
-        result = average_by_timestamp(df, ["alpha", "beta", "nonexistent"])
-        assert "nonexistent" not in result.columns
-        assert "alpha" in result.columns
-        assert "beta" in result.columns
+    def test_unparsable_timestamp_raises_contract_error(self, band_cols):
+        """전 행 timestamp 파싱 실패 시 명시적 계약 오류가 발생함"""
+        df = pd.DataFrame(
+            {
+                "timestamp": ["invalid", None],
+                **{band: [1.0, 2.0] for band in band_cols},
+            }
+        )
+        with pytest.raises(AnalysisContractError) as exc_info:
+            average_by_timestamp(df, band_cols)
+        assert exc_info.value.error_code == "TIMESTAMP_UNPARSABLE"
 
 
 # ──────────────────────────────────────────────
@@ -87,8 +87,8 @@ class TestComputeBaseline:
         result = compute_baseline(simple_df, band_cols)
         assert set(result.keys()) == set(band_cols)
 
-    def test_mean_of_first_n_rows(self, simple_df, band_cols):
-        """값이 실제 첫 30행의 평균과 일치함"""
+    def test_mean_of_absolute_time_interval(self, simple_df, band_cols):
+        """값이 절대시각 기준 첫 30초의 평균과 일치함"""
         result = compute_baseline(simple_df, band_cols, baseline_duration_sec=30)
         expected_alpha = float(simple_df["alpha"].iloc[:30].mean())
         assert abs(result["alpha"] - expected_alpha) < 1e-10
@@ -100,11 +100,20 @@ class TestComputeBaseline:
         assert abs(result["alpha"] - expected) < 1e-10
 
     def test_missing_band_col_excluded(self):
-        """DataFrame에 없는 band 컬럼은 결과 dict에서 제외됨"""
-        df = pd.DataFrame({"alpha": [1.0, 2.0, 3.0]})
-        result = compute_baseline(df, ["alpha", "nonexistent"], baseline_duration_sec=3)
-        assert "alpha" in result
-        assert "nonexistent" not in result
+        """요청 대역이 누락되면 baseline coverage 오류가 발생함"""
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=3, freq="s"),
+                "alpha": [1.0, 2.0, 3.0],
+            }
+        )
+        with pytest.raises(AnalysisContractError) as exc_info:
+            compute_baseline(
+                df,
+                ["alpha", "nonexistent"],
+                baseline_duration_sec=3,
+            )
+        assert exc_info.value.error_code == "BASELINE_COVERAGE_INSUFFICIENT"
 
     def test_values_are_float(self, simple_df, band_cols):
         """반환 dict의 모든 value가 float 타입임"""
@@ -119,48 +128,55 @@ class TestComputeBaseline:
 
 
 class TestSplitStimulusWindows:
-    def test_returns_nested_list_structure(self, full_session_df, band_cols):
-        """반환값이 list[list[DataFrame]] 구조임"""
+    def test_returns_fixed_window_slots(self, full_session_df, band_cols):
+        """반환값이 고정 식별자를 가진 WindowSlot 목록임"""
         result = split_stimulus_windows(full_session_df, band_cols)
         assert isinstance(result, list)
-        assert isinstance(result[0], list)
-        assert isinstance(result[0][0], pd.DataFrame)
+        assert isinstance(result[0], WindowSlot)
+        assert isinstance(result[0].data, pd.DataFrame)
 
     def test_n_stimuli_length(self, full_session_df, band_cols):
-        """외부 리스트 길이가 n_stimuli와 일치함"""
+        """슬롯 수가 n_stimuli × n_windows와 일치함"""
         result = split_stimulus_windows(full_session_df, band_cols, n_stimuli=10)
-        assert len(result) == 10
+        assert len(result) == 60
 
     def test_n_windows_per_stimulus(self, full_session_df, band_cols):
-        """데이터 충분할 때 각 stimulus의 window 수가 올바름"""
+        """데이터 충분할 때 자극별 고정 window 식별자가 올바름"""
         result = split_stimulus_windows(
             full_session_df, band_cols, stimulus_duration_sec=60, window_size_sec=10
         )
-        # 첫 번째 stimulus는 데이터 충분 → 6개 window
-        assert len(result[0]) == 6
+        assert [(slot.stim_idx, slot.win_idx) for slot in result[:6]] == [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 4),
+            (0, 5),
+        ]
 
     def test_window_row_count(self, full_session_df, band_cols):
         """각 window DataFrame의 행 수가 window_size_sec과 일치함"""
         result = split_stimulus_windows(full_session_df, band_cols, window_size_sec=10)
-        assert len(result[0][0]) == 10
+        assert result[0].data is not None
+        assert len(result[0].data) == 10
 
     def test_baseline_rows_excluded(self, full_session_df, band_cols):
-        """baseline 이전 행이 window에 포함되지 않음"""
+        """첫 윈도우가 공통 시작시각의 baseline 종료 후 시작함"""
         result = split_stimulus_windows(
             full_session_df, band_cols, baseline_duration_sec=30
         )
-        # 첫 window의 첫 행은 df.iloc[30]과 동일해야 함
-        first_win = result[0][0]
-        pd.testing.assert_frame_equal(
-            first_win,
-            full_session_df[band_cols].iloc[30:40].reset_index(drop=True),
-        )
+        assert result[0].window_start == pd.Timestamp("2026-01-01 00:00:30")
+        assert result[0].window_end == pd.Timestamp("2026-01-01 00:00:40")
+        assert result[0].data is not None
+        assert result[0].data["timestamp"].min() == result[0].window_start
 
     def test_short_data_partial_windows(self, band_cols):
-        """데이터가 짧아 일부 stimulus가 비어있을 때 오류 미발생함"""
-        # baseline(30) + 1 stimulus(60) = 90행만 제공, n_stimuli=3 요청
+        """데이터가 짧아도 후속 슬롯 ID가 유지되고 data만 None이 됨"""
         short_df = pd.DataFrame(
-            {col: np.random.uniform(0.1, 1.0, 90) for col in band_cols}
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=90, freq="s"),
+                **{col: np.random.uniform(0.1, 1.0, 90) for col in band_cols},
+            }
         )
         result = split_stimulus_windows(
             short_df,
@@ -170,22 +186,46 @@ class TestSplitStimulusWindows:
             n_stimuli=3,
             baseline_duration_sec=30,
         )
-        assert len(result) == 3
-        assert len(result[0]) == 6  # 첫 stimulus는 완전함
-        # 두 번째, 세 번째 stimulus는 빈 리스트이거나 window 수 부족
-        assert len(result[2]) == 0  # 데이터 부족
+        assert len(result) == 18
+        assert all(slot.data is not None for slot in result[:6])
+        assert all(slot.data is None for slot in result[6:])
+        assert result[-1].stim_idx == 2
+        assert result[-1].win_idx == 5
 
     def test_window_cols_match_band_cols(self, full_session_df, band_cols):
-        """각 window DataFrame의 컬럼이 band_cols와 일치함"""
+        """각 window DataFrame이 timestamp와 band_cols를 보존함"""
         result = split_stimulus_windows(full_session_df, band_cols)
-        assert list(result[0][0].columns) == band_cols
+        assert result[0].data is not None
+        assert list(result[0].data.columns) == ["timestamp", *band_cols]
 
     def test_index_reset_in_each_window(self, full_session_df, band_cols):
         """각 window DataFrame의 index가 0부터 시작함"""
-        result = split_stimulus_windows(full_session_df, band_cols)
-        for stim_windows in result:
-            for win_df in stim_windows:
-                assert win_df.index[0] == 0
+        slots = split_stimulus_windows(full_session_df, band_cols)
+        for slot in slots:
+            assert slot.data is not None
+            assert slot.data.index[0] == 0
+
+    def test_boundary_sample_belongs_to_next_window(self, band_cols):
+        """경계 시각 샘플이 앞이 아니라 다음 반개구간에 포함됨"""
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=50, freq="s"),
+                **{band: np.arange(50, dtype=float) for band in band_cols},
+            }
+        )
+        slots = split_stimulus_windows(
+            df,
+            band_cols,
+            stimulus_duration_sec=20,
+            window_size_sec=10,
+            n_stimuli=1,
+            baseline_duration_sec=30,
+        )
+        assert slots[0].data is not None
+        assert slots[1].data is not None
+        boundary = pd.Timestamp("2026-01-01 00:00:40")
+        assert boundary not in set(slots[0].data["timestamp"])
+        assert boundary in set(slots[1].data["timestamp"])
 
 
 # ──────────────────────────────────────────────
@@ -199,15 +239,30 @@ class TestExtractFeatures:
         if band_cols is None:
             band_cols = DEFAULT_BAND_COLS
         windows = []
+        origin = pd.Timestamp("2026-01-01")
         for s in range(n_stim):
-            stim_wins = []
             for w in range(n_win):
                 data = {
-                    band: [float(s + w + i) * 0.1 for i in range(10)]
-                    for band in band_cols
+                    "timestamp": pd.date_range(
+                        origin + pd.Timedelta(seconds=(s * n_win + w) * 10),
+                        periods=10,
+                        freq="s",
+                    ),
+                    **{
+                        band: [float(s + w + i) * 0.1 for i in range(10)]
+                        for band in band_cols
+                    },
                 }
-                stim_wins.append(pd.DataFrame(data))
-            windows.append(stim_wins)
+                window_start = origin + pd.Timedelta(seconds=(s * n_win + w) * 10)
+                windows.append(
+                    WindowSlot(
+                        stim_idx=s,
+                        win_idx=w,
+                        window_start=window_start,
+                        window_end=window_start + pd.Timedelta(seconds=10),
+                        data=pd.DataFrame(data),
+                    )
+                )
         return windows
 
     def test_key_naming_convention(self, band_cols):
@@ -236,7 +291,8 @@ class TestExtractFeatures:
         """baseline=None 시 feature값이 window 평균과 동일함"""
         windows = self._make_windows(1, 1, band_cols)
         result = extract_features(windows, band_cols, baseline=None)
-        expected = float(windows[0][0]["alpha"].mean())
+        assert windows[0].data is not None
+        expected = float(windows[0].data["alpha"].mean())
         assert abs(result["s1_w1_alpha"] - expected) < 1e-10
 
     def test_baseline_subtraction(self, band_cols):
@@ -244,7 +300,8 @@ class TestExtractFeatures:
         windows = self._make_windows(1, 1, band_cols)
         baseline = {"alpha": 0.5, "beta": 0.5, "theta": 0.5, "gamma": 0.5}
         result = extract_features(windows, band_cols, baseline=baseline)
-        expected = float(windows[0][0]["alpha"].mean()) - 0.5
+        assert windows[0].data is not None
+        expected = float(windows[0].data["alpha"].mean()) - 0.5
         assert abs(result["s1_w1_alpha"] - expected) < 1e-10
 
     def test_returns_ordered_dict(self, band_cols):
@@ -255,10 +312,33 @@ class TestExtractFeatures:
 
     def test_missing_band_in_window_skipped(self):
         """window DataFrame에 없는 band는 feature에서 건너뜀"""
-        windows = [[pd.DataFrame({"alpha": [1.0, 2.0]})]]
+        origin = pd.Timestamp("2026-01-01")
+        windows = [
+            WindowSlot(
+                stim_idx=0,
+                win_idx=0,
+                window_start=origin,
+                window_end=origin + pd.Timedelta(seconds=2),
+                data=pd.DataFrame({"alpha": [1.0, 2.0]}),
+            )
+        ]
         result = extract_features(windows, ["alpha", "nonexistent"])
         assert "s1_w1_alpha" in result
         assert "s1_w1_nonexistent" not in result
+
+    def test_none_slot_keeps_later_window_label(self, band_cols):
+        """중간 결측 슬롯 뒤 feature 라벨이 당겨지지 않음"""
+        windows = self._make_windows(1, 3, band_cols)
+        windows[1] = WindowSlot(
+            stim_idx=0,
+            win_idx=1,
+            window_start=windows[1].window_start,
+            window_end=windows[1].window_end,
+            data=None,
+        )
+        result = extract_features(windows, band_cols)
+        assert "s1_w2_alpha" not in result
+        assert "s1_w3_alpha" in result
 
 
 # ──────────────────────────────────────────────
@@ -268,14 +348,14 @@ class TestExtractFeatures:
 
 class TestBuildPairFeatures:
     def test_a_prefix_applied(self, sample_features):
-        """features_a의 키에 'a_' 접두사가 붙음"""
-        result = build_pair_features(sample_features, {})
+        """교집합 features_a의 키에 'a_' 접두사가 붙음"""
+        result = build_pair_features(sample_features, sample_features)
         for key in sample_features:
             assert f"a_{key}" in result
 
     def test_b_prefix_applied(self, sample_features):
-        """features_b의 키에 'b_' 접두사가 붙음"""
-        result = build_pair_features({}, sample_features)
+        """교집합 features_b의 키에 'b_' 접두사가 붙음"""
+        result = build_pair_features(sample_features, sample_features)
         for key in sample_features:
             assert f"b_{key}" in result
 
@@ -304,6 +384,16 @@ class TestBuildPairFeatures:
         a_end = max(i for i, k in enumerate(keys) if k.startswith("a_"))
         b_start = min(i for i, k in enumerate(keys) if k.startswith("b_"))
         assert a_end < b_start
+
+    def test_one_sided_slot_excluded_from_both_subjects(self):
+        """한쪽에만 있는 슬롯은 pair 양쪽에서 모두 제외됨"""
+        features_a = {"s2_w3_alpha": 0.1, "s2_w4_alpha": 0.2}
+        features_b = {"s2_w4_alpha": 0.3}
+        result = build_pair_features(features_a, features_b)
+        assert "a_s2_w3_alpha" not in result
+        assert "b_s2_w3_alpha" not in result
+        assert "a_s2_w4_alpha" in result
+        assert "b_s2_w4_alpha" in result
 
 
 # ──────────────────────────────────────────────
@@ -427,6 +517,320 @@ class TestRunFullPipeline:
         """MindSignalAnalyzer.calculate_synchrony Mock → 0.75 반환함"""
         result = run_full_pipeline(TEST_GROUP_ID, [1, 2])
         assert result["synchrony_score"] == 0.75
+
+    def test_subjects_with_39_second_offset_use_same_absolute_window(
+        self,
+        monkeypatch,
+    ):
+        """39초 늦게 시작한 subject를 공통 절대시각 윈도우로 정렬함"""
+        absolute_origin = pd.Timestamp("2026-01-01")
+
+        def make_frame(start_second, seconds):
+            timestamps = pd.date_range(
+                absolute_origin + pd.Timedelta(seconds=start_second),
+                periods=seconds,
+                freq="s",
+            )
+            values = (timestamps - absolute_origin).total_seconds().astype(float)
+            return pd.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "alpha": values,
+                }
+            )
+
+        frames = {
+            1: make_frame(39, 101),
+            2: make_frame(0, 140),
+        }
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: frames[1 if "subject_1_" in str(path) else 2].copy(),
+        )
+        result = run_full_pipeline(
+            TEST_GROUP_ID,
+            [1, 2],
+            stimulus_duration_sec=20,
+            window_size_sec=10,
+            n_stimuli=1,
+            baseline_duration_sec=10,
+            band_cols=["alpha"],
+        )
+        subject_a, subject_b = result["subjects"]
+        assert subject_a["features"] == subject_b["features"]
+        assert subject_a["features"]["s1_w1_alpha"] == 10.0
+
+    def test_common_end_trims_later_subject_and_keeps_feature_counts_symmetric(
+        self,
+        monkeypatch,
+    ):
+        """한쪽 조기 종료 시 common_end 이후 양쪽 feature를 생성하지 않음"""
+
+        def make_frame(seconds):
+            return pd.DataFrame(
+                {
+                    "timestamp": pd.date_range(
+                        "2026-01-01",
+                        periods=seconds,
+                        freq="s",
+                    ),
+                    "alpha": np.arange(seconds, dtype=float),
+                }
+            )
+
+        frames = {1: make_frame(70), 2: make_frame(100)}
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: frames[1 if "subject_1_" in str(path) else 2].copy(),
+        )
+        result = run_full_pipeline(
+            TEST_GROUP_ID,
+            [1, 2],
+            stimulus_duration_sec=20,
+            window_size_sec=10,
+            n_stimuli=4,
+            baseline_duration_sec=10,
+            band_cols=["alpha"],
+        )
+        counts = [subject["n_features"] for subject in result["subjects"]]
+        assert counts == [6, 6]
+        assert all(
+            "s4_" not in key
+            for subject in result["subjects"]
+            for key in subject["features"]
+        )
+
+    def test_one_sided_internal_gap_is_excluded_from_pair(
+        self,
+        monkeypatch,
+    ):
+        """한쪽 s2_w3 coverage 미달 시 pair 양쪽 슬롯을 모두 제외함"""
+        timestamps = pd.date_range("2026-01-01", periods=70, freq="s")
+        base = pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "alpha": np.arange(70, dtype=float),
+            }
+        )
+        frames = {
+            1: base.drop(index=range(60, 66)).reset_index(drop=True),
+            2: base,
+        }
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: frames[1 if "subject_1_" in str(path) else 2].copy(),
+        )
+        result = run_full_pipeline(
+            TEST_GROUP_ID,
+            [1, 2],
+            stimulus_duration_sec=30,
+            window_size_sec=10,
+            n_stimuli=2,
+            baseline_duration_sec=10,
+            band_cols=["alpha"],
+        )
+        assert "s2_w3_alpha" not in result["subjects"][0]["features"]
+        assert "s2_w3_alpha" in result["subjects"][1]["features"]
+        assert "a_s2_w3_alpha" not in result["pair_features"]
+        assert "b_s2_w3_alpha" not in result["pair_features"]
+
+    def test_no_usable_csv_preserves_partial_response(self, monkeypatch):
+        """usable CSV 0개면 subject별 오류와 pair None을 반환함"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, idx: [],
+        )
+        result = run_full_pipeline(TEST_GROUP_ID, [1, 2])
+        assert [subject["error"] for subject in result["subjects"]] == [
+            "CSV 파일 미발견",
+            "CSV 파일 미발견",
+        ]
+        assert result["pair_features"] is None
+        assert result["synchrony_score"] is None
+
+    def test_subject_contract_error_is_isolated_to_that_subject(
+        self,
+        monkeypatch,
+    ):
+        """한 subject의 timestamp 계약 위반이 다른 subject 분석을 막지 않음"""
+        healthy = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=30, freq="s"),
+                "alpha": np.ones(30),
+            }
+        )
+        broken = pd.DataFrame({"alpha": np.ones(30)})
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: (
+                broken.copy() if "subject_1_" in str(path) else healthy.copy()
+            ),
+        )
+        result = run_full_pipeline(
+            TEST_GROUP_ID,
+            [1, 2],
+            stimulus_duration_sec=10,
+            window_size_sec=10,
+            n_stimuli=1,
+            baseline_duration_sec=10,
+            band_cols=["alpha"],
+        )
+        failed, healthy_subject = result["subjects"]
+        assert failed["error_code"] == "TIMESTAMP_COLUMN_MISSING"
+        assert healthy_subject["n_features"] == 1
+        assert result["pair_features"] is None
+
+    def test_baseline_mean_uses_complete_observations_only(self):
+        """coverage 판정에서 제외한 불완전 관측 초는 평균에도 포함하지 않음"""
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=10, freq="s"),
+                "alpha": [1.0] * 5 + [100.0] * 5,
+                "beta": [1.0] * 5 + [np.nan] * 5,
+            }
+        )
+        result = compute_baseline(df, ["alpha", "beta"], baseline_duration_sec=10)
+        assert result == {"alpha": 1.0, "beta": 1.0}
+
+    def test_non_positive_baseline_duration_is_rejected(self):
+        """baseline 길이가 0 이하면 계약 오류를 발생시킴"""
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=5, freq="s"),
+                "alpha": np.ones(5),
+            }
+        )
+        with pytest.raises(AnalysisContractError) as exc_info:
+            compute_baseline(df, ["alpha"], baseline_duration_sec=0)
+        assert exc_info.value.error_code == "BASELINE_COVERAGE_INSUFFICIENT"
+
+    def test_one_usable_csv_uses_its_own_time_range(self, monkeypatch):
+        """usable CSV 1개면 해당 파일 시각으로 분석하고 다른 subject 오류를 유지함"""
+        monkeypatch.setattr(
+            "server.services.analysis.find_csv_files",
+            lambda group_id, idx: (
+                [Path(f"/fake/subject_{idx}_{group_id}.csv")] if idx == 1 else []
+            ),
+        )
+        result = run_full_pipeline(
+            TEST_GROUP_ID,
+            [1, 2],
+            stimulus_duration_sec=20,
+            window_size_sec=10,
+            n_stimuli=1,
+            baseline_duration_sec=10,
+            band_cols=["alpha"],
+        )
+        assert result["subjects"][0]["n_features"] == 2
+        assert result["subjects"][1]["error"] == "CSV 파일 미발견"
+        assert result["pair_features"] is None
+
+    def test_exact_baseline_length_is_valid(self, monkeypatch):
+        """마지막 관측 초 + 1초 배타 경계로 정확한 baseline 길이를 인정함"""
+        exact_df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range(
+                    "2026-01-01",
+                    periods=30,
+                    freq="s",
+                ),
+                "alpha": np.ones(30),
+            }
+        )
+        monkeypatch.setattr(
+            "server.services.analysis.load_session_data",
+            lambda path: exact_df.copy(),
+        )
+        result = run_full_pipeline(
+            TEST_GROUP_ID,
+            [1],
+            stimulus_duration_sec=10,
+            window_size_sec=10,
+            n_stimuli=1,
+            baseline_duration_sec=30,
+            band_cols=["alpha"],
+        )
+        assert result["subjects"][0]["baseline"]["alpha"] == 1.0
+        assert result["subjects"][0]["n_features"] == 0
+
+
+class TestCoverageContract:
+    """baseline과 자극 윈도우 coverage 계약을 검증함"""
+
+    @staticmethod
+    def _baseline_frame(observations: int) -> pd.DataFrame:
+        """60초 구간 안에 지정 개수의 완전한 관측 초를 생성함"""
+        return pd.DataFrame(
+            {
+                "timestamp": pd.date_range(
+                    "2026-01-01",
+                    periods=observations,
+                    freq="s",
+                ),
+                "alpha": np.ones(observations),
+                "beta": np.ones(observations),
+            }
+        )
+
+    def test_custom_60_second_baseline_requires_30_observations(self):
+        """가변 60초 baseline의 최소 coverage가 30초로 계산됨"""
+        valid = self._baseline_frame(30)
+        result = compute_baseline(
+            valid,
+            ["alpha", "beta"],
+            baseline_duration_sec=60,
+        )
+        assert result == {"alpha": 1.0, "beta": 1.0}
+
+        invalid = self._baseline_frame(29)
+        with pytest.raises(AnalysisContractError) as exc_info:
+            compute_baseline(
+                invalid,
+                ["alpha", "beta"],
+                baseline_duration_sec=60,
+            )
+        assert exc_info.value.error_code == "BASELINE_COVERAGE_INSUFFICIENT"
+
+    def test_all_requested_bands_must_be_non_nan_in_same_second(self):
+        """한 초의 요청 대역 중 하나가 NaN이면 완전한 관측 초로 세지 않음"""
+        df = self._baseline_frame(30)
+        df.loc[14:, "beta"] = np.nan
+        with pytest.raises(AnalysisContractError) as exc_info:
+            compute_baseline(
+                df,
+                ["alpha", "beta"],
+                baseline_duration_sec=30,
+            )
+        assert exc_info.value.error_code == "BASELINE_COVERAGE_INSUFFICIENT"
+
+
+LIVE_GROUP_ID = "6a508a6b1048b553eea41778"
+LIVE_FILES = [
+    (
+        CSV_BASE_DIR / f"subject_{idx}_{LIVE_GROUP_ID}_20260710_150135.csv"
+        if idx == 1
+        else CSV_BASE_DIR / f"subject_{idx}_{LIVE_GROUP_ID}_20260710_150059.csv"
+    )
+    for idx in (1, 2)
+]
+
+
+@pytest.mark.skipif(
+    not all(path.exists() for path in LIVE_FILES),
+    reason="2026-07-10 라이브 CSV가 로컬에 없음",
+)
+def test_live_csv_regression_uses_symmetric_absolute_window_keys():
+    """라이브 CSV에서 시작시각 차이와 무관하게 양쪽 윈도우 키를 정렬함"""
+    result = run_full_pipeline(LIVE_GROUP_ID, [1, 2])
+    feature_keys = [set(subject["features"].keys()) for subject in result["subjects"]]
+    raw_frames = result["dataframes"]
+    start_gap = abs(
+        pd.to_datetime(raw_frames[1]["timestamp"]).min()
+        - pd.to_datetime(raw_frames[2]["timestamp"]).min()
+    ).total_seconds()
+    assert start_gap > 30
+    assert feature_keys[0] == feature_keys[1]
+    assert len(result["pair_features"]) == len(feature_keys[0]) * 2
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/21-stimulus-window-absolute-alignment` (ANALYSIS-W104)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 문제

baseline과 자극 윈도우를 행 번호로 분할해서, 두 피실험자의 측정 시작 시각이 어긋나면 같은 자극 번호가 서로 다른 절대시각을 가리켰다. 2026-07-10 라이브 측정(groupId 6a508a6b1048b553eea41778)으로 재현한 실측:

| 경계 | subject_1 | subject_2 | 차이 |
|---|---|---|---|
| 첫 샘플 | 15:01:41.0748 | 15:01:02.7772 | 38.2976초 |
| 수정 전 S1W1 | 15:02:11.0305 | 15:01:32.7671 | 38.2634초, 두 구간이 겹치지 않음 |
| 수정 전 S2W1 | 15:03:12.4281 | 15:02:32.7489 | 39.6792초, 진행할수록 커짐 |

오차가 커지는 이유는 subject_1에 2.3783초 스트림 공백이 있어 "1행이 곧 1초" 가정이 실데이터에서 이미 깨져 있었기 때문이다. 파이프라인은 오류 없이 feature 80개 대 228개의 불균형 결과를 반환했고, 기존 테스트가 첫 자극을 iloc[30:40]으로 검증하며 이 동작을 정상 명세로 고정하고 있었다.

## 변경

- `average_by_timestamp`: 정수 초로 floor해 집계하고 timestamp를 보존한다. 기존에는 마이크로초 단위 원본 값으로 그룹화해 사실상 아무것도 줄이지 못했고 집계 후 timestamp를 버렸다.
- `run_full_pipeline`: 2-pass 구조로 바꿔 `common_origin = max(첫 초)`, `common_end = min(마지막 초) + 1초`를 계산하고 두 피실험자를 공통 구간으로 트리밍한다. `+1초`는 배타 경계 보정으로, 없으면 정확히 30초짜리 정상 baseline이 구간 부족으로 잘못 거부된다.
- `compute_baseline`과 `split_stimulus_windows`: iloc 슬라이스를 시간 마스크로 교체한다.
- `split_stimulus_windows` 반환을 고정 슬롯 `WindowSlot(stim_idx, win_idx, window_start, window_end, data)`로 바꾼다. 결측 윈도우도 자리를 유지해 중간 누락 뒤 라벨이 밀리지 않는다.
- `extract_features`: 슬롯의 고정 식별자로 키를 만든다. 기존 enumerate 방식은 빈 항목을 빼면 라벨이 당겨졌다.
- `build_pair_features`: 양쪽 슬롯 교집합만 pair로 만든다. 트리밍만으로는 한쪽 내부 윈도우가 결측일 때 비대칭이 남는다.
- 구간 coverage: 최소 관측 초를 `ceil(구간 길이 곱하기 0.5)`로 둔다. 관측 초는 요청 대역이 전부 존재하고 전부 non-NaN인 초만 센다.
- 입력 계약 위반은 422로 반환한다. `AnalysisContractError`를 두고 `server/app.py`에서 최상위 평면 본문 `{error_code, detail}`로 변환한다. 코드는 TIMESTAMP_COLUMN_MISSING, TIMESTAMP_UNPARSABLE, COMMON_WINDOW_TOO_SHORT, BASELINE_COVERAGE_INSUFFICIENT 네 가지다.
- `PipelineParams`에 양수 제약과 나누어떨어짐 검증을 추가한다. 기존에는 `window_size_sec=0`이 정수 나눗셈에서 500을 냈다.

`raw_dataframes`와 `aligned_dataframes`를 분리해 synchrony 계산과 Markdown 생성은 원본을 쓴다. 이번 회차에서 두 소비자의 동작은 바뀌지 않는다.

## 검증

라이브 CSV 실측(수정 후):

- S1W1이 두 피실험자 모두 15:02:11에서 15:02:21로 동일한 절대시각을 가리킨다.
- feature 수 80 대 80으로 대칭, 키 집합 일치, pair 160개. 수정 전 80 대 228, pair 308이었다.
- synchrony 0.023213227938978627로 변화 없음. 원본 DataFrame 분리가 의도대로 동작했다는 뜻이다.

테스트와 린트:

- pytest 192건 통과. 기존 170건에 신규 22건을 더했다.
- black, isort, flake8 통과.
- 회귀 시뮬레이션: 공통 구간 트리밍을 제거하고 origin을 피실험자별로 되돌리면 2건(공통 구간 트리밍 테스트, 라이브 CSV 회귀 테스트)이 실패하는 것을 확인했다.

행 번호 분할을 명세로 고정하던 기존 테스트는 절대시각 명세로 갱신했다. 회귀 실패가 아니라 의도한 명세 변경이다. fixture에는 timestamp를 부여했다.

## 남은 범위

이번 수정은 두 CSV의 공통 녹화 시작점을 맞추는 것이고, 실제 화면 자극 onset 정렬은 아니다. BE의 stimulus_start는 소켓으로만 발행되고 DB 저장이나 엔진 전달이 없다. PC 간 clock 동기화도 미검증이라 CSV timestamp가 timezone-naive 로컬 시각이라는 전제 위에 서 있다. 둘 다 후속 작업으로 분리했다.

계획서는 `.plans/21-stimulus-window-absolute-alignment/PLAN.md`(rev.4)이며 착수 전 3회 교차검토를 거쳐 PROCEED-WITH-CONDITIONS 조건 5건을 반영했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwAx24ZGNH3sRnpNRCzcP4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 분석 파이프라인이 절대 시각 기준으로 정렬되며, 공통 시간 구간을 바탕으로 윈도우와 피처를 생성합니다.
  - 데이터가 부족한 윈도우는 자동으로 스킵되어 결과 안정성이 높아집니다.
  - 양쪽 데이터에 모두 존재하는 피처만 비교에 사용됩니다.

- **버그 수정**
  - 타임스탬프 누락·파싱 실패, baseline 부족 등 계약 위반 시 명확한 오류 코드와 상세 메시지로 안내합니다.
  - 잘못된 분석 파라미터는 실행 전 유효성 검증으로 422 응답을 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->