### PR TITLE
fix(analysis): Inf를 결측으로 처리하고 subject error_code를 응답에 싣는다

### DIFF
--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -97,6 +97,8 @@ class SubjectFeatureResult(BaseModel):
     features: dict[str, float] | None = None
     n_features: int | None = None
     error: str | None = None
+    # 소비자가 자유 문장 대신 코드로 분기하도록 계약 위반 식별자를 함께 실음
+    error_code: str | None = None
 
 
 class PipelineResponse(BaseModel):

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -433,8 +433,12 @@ def compute_baseline(
             ),
         )
 
-    # coverage 판정과 같은 마스크로 평균을 산출함
-    complete = baseline_df.loc[_finite_mask(baseline_df, band_cols)]
+    # coverage 판정과 같은 마스크에 더해 판정과 같은 수치 변환값으로 평균을 산출함
+    # (object 컬럼의 숫자 문자열은 마스크를 통과하지만 mean()에서 문자열 연결로 터짐)
+    complete = baseline_df.loc[
+        _finite_mask(baseline_df, band_cols),
+        band_cols,
+    ].apply(pd.to_numeric, errors="coerce")
     return {band: float(complete[band].mean()) for band in band_cols}
 
 

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from math import ceil
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from core.analyzer import MindSignalAnalyzer
@@ -377,19 +378,27 @@ def _resolve_origin(
     return pd.Timestamp(df["timestamp"].min())
 
 
+def _finite_mask(interval_df: pd.DataFrame, band_cols: list[str]) -> pd.Series:
+    """요청 대역이 모두 유한 수치인 행의 불리언 마스크를 반환함
+
+    NaN뿐 아니라 ±Inf와 수치 변환 실패도 결측으로 처리함. Inf를 유효값으로
+    인정하면 baseline이 Inf가 되어 응답 직렬화에서 500으로 이어짐.
+    """
+    if any(band not in interval_df.columns for band in band_cols):
+        return pd.Series(False, index=interval_df.index)
+
+    numeric = interval_df[band_cols].apply(pd.to_numeric, errors="coerce")
+    return numeric.map(np.isfinite).all(axis=1)
+
+
 def _valid_observation_count(
     interval_df: pd.DataFrame,
     band_cols: list[str],
 ) -> int:
-    """요청 대역이 모두 존재하고 non-NaN인 고유 관측 초를 계산함"""
+    """요청 대역이 모두 유한 수치인 고유 관측 초를 계산함"""
     if "timestamp" not in interval_df.columns:
         return 0
-    if any(band not in interval_df.columns for band in band_cols):
-        return 0
-    complete = interval_df.loc[
-        interval_df[band_cols].notna().all(axis=1),
-        "timestamp",
-    ]
+    complete = interval_df.loc[_finite_mask(interval_df, band_cols), "timestamp"]
     return int(complete.nunique())
 
 
@@ -424,8 +433,8 @@ def compute_baseline(
             ),
         )
 
-    # coverage 판정과 같은 완전 관측 행으로 평균을 산출함
-    complete = baseline_df.loc[baseline_df[band_cols].notna().all(axis=1)]
+    # coverage 판정과 같은 마스크로 평균을 산출함
+    complete = baseline_df.loc[_finite_mask(baseline_df, band_cols)]
     return {band: float(complete[band].mean()) for band in band_cols}
 
 

--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -167,6 +167,53 @@ class TestAnalyzePipelineEndpoint:
         assert data["subjects"][1]["error"] == "CSV 파일 미발견"
         assert data["subjects"][1]["features"] is None
 
+    @patch("server.services.analysis.run_full_pipeline")
+    def test_subject_error_code_survives_response_model(
+        self, mock_pipeline, test_client, pipeline_secret_header
+    ):
+        """subject 단위 계약 위반의 error_code가 응답까지 도달함.
+
+        SubjectFeatureResult에 error_code 필드가 없으면 Pydantic이 조용히 버려
+        소비자가 자유 문장으로만 분기해야 했음(회귀 방지).
+        """
+        mock_pipeline.return_value = {
+            "group_id": TEST_GROUP_ID,
+            "subjects": [
+                {
+                    "subject_index": 1,
+                    "baseline": {"alpha": 0.5},
+                    "features": {},
+                    "n_features": 0,
+                },
+                {
+                    "subject_index": 2,
+                    "error": "baseline 관측 초가 최소 coverage에 미달함: 14/15",
+                    "error_code": "BASELINE_COVERAGE_INSUFFICIENT",
+                },
+            ],
+            "pair_features": None,
+            "y_score": None,
+            "synchrony_score": None,
+            "pipeline_params": {
+                "stimulus_duration_sec": 60,
+                "window_size_sec": 10,
+                "n_stimuli": 10,
+                "baseline_duration_sec": 30,
+                "band_cols": ["alpha"],
+                "n_windows_per_stimulus": 6,
+                "total_features_per_subject": 0,
+            },
+            "dataframes": {},
+        }
+        response = test_client.post(
+            "/api/analyze/pipeline",
+            json={"group_id": TEST_GROUP_ID, "subject_indices": [1, 2]},
+            headers=pipeline_secret_header,
+        )
+        assert response.status_code == 200
+        subject = response.json()["subjects"][1]
+        assert subject["error_code"] == "BASELINE_COVERAGE_INSUFFICIENT"
+
     def test_invalid_body_missing_group_id(self, test_client, pipeline_secret_header):
         """group_id 미포함 body → 422 validation error 반환함"""
         response = test_client.post(

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -713,6 +713,21 @@ class TestRunFullPipeline:
             compute_baseline(df, ["alpha"], baseline_duration_sec=30)
         assert exc_info.value.error_code == "BASELINE_COVERAGE_INSUFFICIENT"
 
+    def test_numeric_string_band_values_are_averaged_not_concatenated(self):
+        """변환 가능한 숫자 문자열은 수치로 평균함
+
+        마스크는 통과하지만 object Series의 mean()이 문자열을 이어붙여
+        TypeError로 500이 나던 경로임(회귀 방지).
+        """
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=30, freq="s"),
+                "alpha": ["1.0"] * 15 + [3.0] * 15,
+            }
+        )
+        result = compute_baseline(df, ["alpha"], baseline_duration_sec=30)
+        assert result["alpha"] == 2.0
+
     def test_non_positive_baseline_duration_is_rejected(self):
         """baseline 길이가 0 이하면 계약 오류를 발생시킴"""
         df = pd.DataFrame(

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -692,6 +692,27 @@ class TestRunFullPipeline:
         result = compute_baseline(df, ["alpha", "beta"], baseline_duration_sec=10)
         assert result == {"alpha": 1.0, "beta": 1.0}
 
+    @pytest.mark.parametrize("bad_value", [np.inf, -np.inf, "n/a"])
+    def test_non_finite_band_value_is_not_a_valid_observation(self, bad_value):
+        """Inf와 수치 변환 실패는 결측으로 처리해 baseline에 섞이지 않음"""
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=30, freq="s"),
+                "alpha": [1.0] * 30,
+            }
+        )
+        df["alpha"] = df["alpha"].astype(object)
+        df.loc[0, "alpha"] = bad_value
+
+        result = compute_baseline(df, ["alpha"], baseline_duration_sec=30)
+        assert result["alpha"] == 1.0
+
+        # 유효 관측이 임계 아래로 떨어지면 계약 오류로 거부함
+        df.loc[1:, "alpha"] = bad_value
+        with pytest.raises(AnalysisContractError) as exc_info:
+            compute_baseline(df, ["alpha"], baseline_duration_sec=30)
+        assert exc_info.value.error_code == "BASELINE_COVERAGE_INSUFFICIENT"
+
     def test_non_positive_baseline_duration_is_rejected(self):
         """baseline 길이가 0 이하면 계약 오류를 발생시킴"""
         df = pd.DataFrame(


### PR DESCRIPTION
> 계획 폴더: `.plans/_archive/legacy/21-stimulus-window-absolute-alignment` (ANALYSIS-W104)
> 계획 폴더: `.plans/22-stream-continuity-instrumentation` (EEG-W001, EEG-W002)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

PR #37 후속. 조사 중 드러난 결함 2건을 고친다. 둘 다 재현 검증했다.

## 결함 1 — Inf가 유효 관측으로 통과해 500을 유발

`_valid_observation_count`가 `notna()`로 판정하는데 numpy에서 `inf`는 NaN이 아니라 유효값으로 통과한다. 수정 전 실측:

```
compute_baseline(df, ['alpha','beta'], 30)  →  {'alpha': inf, 'beta': 1.0}
```

이 값이 응답까지 가면 어떻게 되는지도 확인했다. FastAPI의 실제 인코딩 경로에서 터진다:

```
ValueError: Out of range float values are not JSON compliant
```

즉 데이터가 나쁠 때 식별 가능한 partial 200을 주자던 PR #37의 취지와 반대로 500이 난다. 참고로 pydantic의 `model_dump_json`은 Inf를 `null`로 바꾸지만 FastAPI가 쓰는 경로는 `jsonable_encoder`와 `JSONResponse`라 예외가 난다.

`_finite_mask` 헬퍼를 도입해 NaN, ±Inf, 수치 변환 실패를 모두 결측으로 처리한다. coverage 판정과 baseline 평균이 같은 마스크를 쓰도록 묶었다. 두 곳이 서로 다른 기준을 보던 것이 PR #37에서 고친 결함의 원인이었으므로, 이번에는 기준을 한 함수로 모아 재발 경로를 없앤다.

## 결함 2 — subject 단위 error_code가 응답 모델에서 소실

PR #37에서 subject 단위 계약 위반에 `error_code`를 실었는데, `SubjectFeatureResult`에 해당 필드가 없어 Pydantic이 조용히 버리고 있었다. 수정 전 실측:

```
model_dump: {'subject_index': 2, 'baseline': None, 'features': None, 'n_features': None, 'error': '...'}
```

`error_code`가 없다. 백엔드는 한국어 자유 문장으로만 분기해야 했다. PR #37이 의도한 계약이 API 경계에서 절반만 전달되던 셈이라 필드를 추가한다.

## 검증

- pytest 193건 통과. 신규 4건 추가(Inf, -Inf, 수치 변환 실패 3종 + 응답 모델 계약 1종).
- 회귀 시뮬레이션: 테스트는 그대로 두고 `server/` 변경만 되돌리면 신규 4건이 정확히 실패한다. 테스트가 두 결함을 실제로 잡는 것을 확인했다.
- black, isort, flake8 통과.
- 라이브 CSV 재실측 불변: feature 80 대 80, pair 160, synchrony 0.023213.

## 범위 밖

50퍼센트 coverage 임계값 정책은 이번 범위가 아니다. 조사에서 함께 드러난 두 가지 미확정 지점이 있다. 30초 중 연속된 앞 15초만 유효해도 통과한다는 점과, 두 피실험자가 서로 겹치지 않는 15초씩으로 각각 통과할 수 있다는 점이다. 후자는 절대시각 정렬을 해놓고 정작 baseline 평균에 쓰인 초의 교집합이 0일 수 있다는 뜻이다. 판단에 필요한 수치 근거가 아직 없어 라이브 데이터가 더 쌓인 뒤로 미룬다. 2026-07-10 CSV에는 5개 대역 전부 NaN이 0개였고, 이 결함들이 실제 측정에 영향을 준 적은 아직 없다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 피실험자별 분석 결과에 오류 코드(`error_code`)를 함께 제공해, 화면에서 오류 유형을 코드 기반으로 일관되게 분기할 수 있습니다.
  - 기준선 및 관측값 산출 시 숫자로 변환되지 않는 값과 무한대(±Inf)를 유효 값에서 제외합니다.
  - 기준선 커버리지가 부족해 분석이 불가능한 경우, 명확한 기준선 커버리지 오류 코드가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->