### PR TITLE
feat(streamer): EEG 스트림 연속성 계측과 생성층 유한성 방어

### DIFF
--- a/core/streamer.py
+++ b/core/streamer.py
@@ -41,6 +41,154 @@ MET_LABEL_CANDIDATES: dict[str, tuple[str, ...]] = {
 }
 
 
+# Cortex EEG COUNTER는 0부터 127까지 순환하는 샘플 카운터임 (128Hz라 1초에 한 바퀴).
+COUNTER_MODULUS = 128
+# 128Hz 기준 정상 샘플 간격은 약 0.0078초임. 이보다 크게 벌어지면 이벤트 유실이나
+# clock jump로 판정함. 0.5초는 CSV 1행(1초) 절반이라 행 단위 결측 직전에 잡힘.
+TIMESTAMP_JUMP_TOLERANCE_SEC = 0.5
+# 같은 종류의 이상을 무한히 찍지 않기 위한 상한임. 초과분은 개수만 세어 종료 요약에 남김.
+CONTINUITY_LOG_CAP_PER_KIND = 20
+# 매 샘플 발생 가능한 경보의 재발행 최소 간격임. BE도 같은 status 연속 수신을
+# 억제하지만(stream-health.service.ts), Redis에 초당 128건을 던질 이유가 없음.
+HEALTH_REPUBLISH_INTERVAL_SEC = 10
+
+
+class StreamContinuityTracker:
+    """Cortex EEG 이벤트의 연속성 이상을 판정하는 순수 상태기임.
+
+    헤드셋 없이 검증 가능하도록 I/O를 하지 않고 값만 받아 이상 목록을 반환함.
+    호출부(`MindSignalStreamer.on_eeg_data_done`)가 로그 기록을 담당함.
+
+    ponytail: COUNTER가 정확히 modulus 배수만큼(128, 256, ...) 유실되면 카운터가
+    제자리로 돌아와 counter_gap으로는 안 잡힘. 그 경우는 timestamp_jump가 잡음.
+    """
+
+    def __init__(
+        self,
+        modulus: int = COUNTER_MODULUS,
+        jump_tolerance_sec: float = TIMESTAMP_JUMP_TOLERANCE_SEC,
+    ):
+        self.modulus = modulus
+        self.jump_tolerance_sec = jump_tolerance_sec
+        self.prev_counter: int | None = None
+        self.prev_time: float | None = None
+        self.events_seen = 0
+        self.lost_samples = 0
+        self.interpolated_samples = 0
+
+    def observe(
+        self,
+        counter: object,
+        cortex_time: object,
+        interpolated: object = 0,
+    ) -> list[dict]:
+        """EEG 이벤트 1건을 관측하고 발견된 이상 목록 반환함.
+
+        Args:
+            counter - Cortex EEG COUNTER 값임 (0부터 modulus-1까지 순환)
+            cortex_time - Cortex가 보낸 epoch 초임
+            interpolated - Cortex INTERPOLATED 플래그임 (1이면 보간 샘플)
+
+        Returns:
+            이상 dict 리스트 반환. 정상이면 빈 리스트임. 각 dict는 `kind` 키를
+            가지며 종류별로 부가 필드가 붙음.
+        """
+        self.events_seen += 1
+        anomalies: list[dict] = []
+
+        try:
+            counter_int = int(counter)
+        except (TypeError, ValueError):
+            anomalies.append({"kind": "counter_invalid", "value": repr(counter)})
+            counter_int = None
+
+        if counter_int is not None:
+            if self.prev_counter is not None:
+                if counter_int == self.prev_counter:
+                    anomalies.append({"kind": "counter_repeat", "counter": counter_int})
+                else:
+                    missing = (counter_int - self.prev_counter - 1) % self.modulus
+                    if missing:
+                        self.lost_samples += missing
+                        anomalies.append(
+                            {
+                                "kind": "counter_gap",
+                                "prev": self.prev_counter,
+                                "counter": counter_int,
+                                "missing": missing,
+                            }
+                        )
+            self.prev_counter = counter_int
+
+        try:
+            time_float = float(cortex_time)
+        except (TypeError, ValueError):
+            time_float = float("nan")
+        if not np.isfinite(time_float):
+            anomalies.append({"kind": "time_invalid", "value": repr(cortex_time)})
+        else:
+            if self.prev_time is not None:
+                delta = time_float - self.prev_time
+                if delta < 0:
+                    anomalies.append(
+                        {"kind": "timestamp_backwards", "deltaSec": round(delta, 4)}
+                    )
+                elif delta > self.jump_tolerance_sec:
+                    anomalies.append(
+                        {"kind": "timestamp_jump", "deltaSec": round(delta, 4)}
+                    )
+            self.prev_time = time_float
+
+        try:
+            if int(interpolated):
+                self.interpolated_samples += 1
+        except (TypeError, ValueError):
+            pass
+
+        return anomalies
+
+    def summary(self) -> dict:
+        """종료 시점 누적 집계 반환함."""
+        return {
+            "eegEvents": self.events_seen,
+            "lostSamples": self.lost_samples,
+            "interpolatedSamples": self.interpolated_samples,
+        }
+
+
+def coerce_eeg_channels(
+    eeg_row: list, indices: list[int]
+) -> tuple[list[float] | None, str | None]:
+    """EEG 행에서 대상 채널만 float로 변환하고 유효성 검사함.
+
+    PR #38이 분석 단계(하류)에 넣은 유한성 방어를 CSV 생성층까지 이은 것임.
+    비유한 값이 버퍼에 들어가면 128샘플 평균 전체가 오염돼 그 초의 5대역이
+    통째로 무효가 되므로, 샘플 단위에서 걸러냄.
+
+    Args:
+        eeg_row - Cortex가 보낸 EEG 행임 (메타 채널 포함)
+        indices - 추출할 뇌파 채널 인덱스 목록임
+
+    Returns:
+        성공 시 (값 리스트, None), 실패 시 (None, 사유) 반환.
+    """
+    if not indices:
+        return None, "no_channel_mapping"
+    if max(indices) >= len(eeg_row):
+        return None, "row_too_short"
+
+    values: list[float] = []
+    for i in indices:
+        try:
+            value = float(eeg_row[i])
+        except (TypeError, ValueError):
+            return None, "non_numeric"
+        if not np.isfinite(value):
+            return None, "non_finite"
+        values.append(value)
+    return values, None
+
+
 def build_met_map(labels: list[str]) -> dict[str, int]:
     """Cortex met 라벨 배열에서 지표별 인덱스 매핑 생성함.
 
@@ -156,6 +304,19 @@ class MindSignalStreamer(Cortex):
         self.met_map = {}
         self.eeg_channel_indices = []
         self.eeg_buffer = []
+
+        # 스트림 연속성 계측 상태 초기화함 (P0-1). COUNTER와 INTERPOLATED 인덱스는
+        # eeg 라벨 이벤트 수신 시 채워짐.
+        self.counter_index: int | None = None
+        self.interpolated_index: int | None = None
+        self.continuity = StreamContinuityTracker()
+        self.csv_rows_written = 0
+        self.dropped_samples = 0
+        self.dropped_blocks = 0
+        self._continuity_log_counts: dict[str, int] = {}
+        self._health_published_at: dict[str, float] = {}
+        self._eeg_stale = False
+        self._met_stale = False
         self.latest_met = {
             "focus": 0,
             "engagement": 0,
@@ -279,6 +440,19 @@ class MindSignalStreamer(Cortex):
             ]
             print(f"EEG 채널 인덱스 매핑 완료됨: {self.eeg_channel_indices}")
 
+            # 연속성 계측용 메타 채널 인덱스 확보함. 없으면 계측만 비활성되고
+            # 측정 자체는 그대로 진행함.
+            self.counter_index = (
+                labels.index("COUNTER") if "COUNTER" in labels else None
+            )
+            self.interpolated_index = (
+                labels.index("INTERPOLATED") if "INTERPOLATED" in labels else None
+            )
+            if self.counter_index is None:
+                print(
+                    f"[WARN] EEG COUNTER 라벨 미발견 — 연속성 계측 비활성 (labels={labels})"
+                )
+
     def on_create_session_done(self, *args, **kwargs):
         print(f"세션 연결 성공하였음. {self.duration_min}분 측정을 시작함.")
 
@@ -322,29 +496,46 @@ class MindSignalStreamer(Cortex):
         t = threading.Thread(target=_check, daemon=True)
         t.start()
 
+    def _publish_health(
+        self, status: str, elapsed: float = 0, min_interval_sec: float = 0
+    ) -> None:
+        """headset_status 경보를 Redis로 발행함 (watchdog과 불량 블록 공용).
+
+        Args:
+            status - DE 상태 문자열임. BE는 disconnected만 보존하고 나머지를
+                stale로 정규화함 (`stream-health.service.ts`)
+            elapsed - 무신호 경과 초임
+            min_interval_sec - 같은 status 재발행 최소 간격임. 0이면 제한 없음
+                (watchdog 기존 동작 보존). 매 샘플 발생 가능한 경보에만 사용함
+        """
+        if min_interval_sec:
+            last = self._health_published_at.get(status, 0)
+            if time.time() - last < min_interval_sec:
+                return
+            self._health_published_at[status] = time.time()
+
+        try:
+            self.r.publish(
+                self.channel,
+                json.dumps(
+                    {
+                        "type": "headset_status",
+                        "status": status,
+                        "subjectIndex": self.subject_index,
+                        "groupId": self.group_id,
+                        "silentSeconds": round(elapsed),
+                    }
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — 경보 발행 실패가 측정을 깨지 않음
+            # 조용히 삼키면 경보 자체가 사라진 걸 아무도 모름 (CodeRabbit PR #36)
+            logger.warning(
+                f"[WATCHDOG] 상태 발행 실패 ({status}): {exc}"
+                f" (subject {self.subject_index})"
+            )
+
     def _start_watchdog(self):
         """무데이터 감지 watchdog 스레드 시작함"""
-
-        def _publish_status(status: str, elapsed: float) -> None:
-            try:
-                self.r.publish(
-                    self.channel,
-                    json.dumps(
-                        {
-                            "type": "headset_status",
-                            "status": status,
-                            "subjectIndex": self.subject_index,
-                            "groupId": self.group_id,
-                            "silentSeconds": round(elapsed),
-                        }
-                    ),
-                )
-            except Exception as exc:  # noqa: BLE001 — 경보 발행 실패가 측정을 깨지 않음
-                # 조용히 삼키면 경보 자체가 사라진 걸 아무도 모름 (CodeRabbit PR #36)
-                logger.warning(
-                    f"[WATCHDOG] 상태 발행 실패 ({status}): {exc}"
-                    f" (subject {self.subject_index})"
-                )
 
         def _check():
             while self._watchdog_active:
@@ -356,7 +547,13 @@ class MindSignalStreamer(Cortex):
                         f"[WATCHDOG] {eeg_elapsed:.0f}초간 EEG 데이터 미수신"
                         f" (subject {self.subject_index})"
                     )
-                    _publish_status("no_data", eeg_elapsed)
+                    self._publish_health("no_data", eeg_elapsed)
+                    # 정지 시작 1회만 구조화 로그로 남김 (복구는 on_eeg_data_done에서)
+                    if not self._eeg_stale:
+                        self._eeg_stale = True
+                        self._log_continuity(
+                            "eeg_stale_start", {"silentSec": round(eeg_elapsed, 1)}
+                        )
 
                 # MET는 EEG와 별개 스트림임. EEG만 살아 있고 MET가 죽으면
                 # latest_met이 마지막 값을 무한 반복해 CSV에 얼어붙은 지표가
@@ -368,7 +565,12 @@ class MindSignalStreamer(Cortex):
                         f"[WATCHDOG] {met_elapsed:.0f}초간 MET 지표 미수신"
                         f" (subject {self.subject_index})"
                     )
-                    _publish_status("metrics_stale", met_elapsed)
+                    self._publish_health("metrics_stale", met_elapsed)
+                    if not self._met_stale:
+                        self._met_stale = True
+                        self._log_continuity(
+                            "met_stale_start", {"silentSec": round(met_elapsed, 1)}
+                        )
 
                 time.sleep(10)
 
@@ -395,10 +597,39 @@ class MindSignalStreamer(Cortex):
         """수신된 MET 배열에서 매핑된 점수 값만 추출함"""
         data = kwargs.get("data")["met"]
         # MET 전용 watchdog 타임스탬프 갱신함 (EEG와 독립)
-        self.last_met_time = time.time()
+        now = time.time()
+        if self._met_stale:
+            self._met_stale = False
+            self._log_continuity(
+                "met_recovered", {"silentSec": round(now - self.last_met_time, 1)}
+            )
+        self.last_met_time = now
         for key, index in self.met_map.items():
             if index < len(data):
                 self.latest_met[key] = data[index]
+
+    def _log_continuity(self, kind: str, payload: dict) -> None:
+        """연속성 이벤트를 구조화 로그 1행으로 남김 (종류별 상한 적용).
+
+        Args:
+            kind - 이벤트 종류 키임 (counter_gap, timestamp_jump 등)
+            payload - 종류별 부가 필드임
+        """
+        seen = self._continuity_log_counts.get(kind, 0) + 1
+        self._continuity_log_counts[kind] = seen
+        if seen > CONTINUITY_LOG_CAP_PER_KIND:
+            return
+
+        record = {
+            "kind": kind,
+            "groupId": self.group_id,
+            "subjectIndex": self.subject_index,
+            "elapsedSec": round(time.time() - self.start_time, 3),
+            **payload,
+        }
+        if seen == CONTINUITY_LOG_CAP_PER_KIND:
+            record["logCapReached"] = True
+        logger.warning("[CONTINUITY] %s", json.dumps(record))
 
     def on_eeg_data_done(self, *args, **kwargs):
         """EEG 샘플을 버퍼링하고 1초(128샘플) 도달 시 대역 파워 계산 수행함"""
@@ -407,14 +638,45 @@ class MindSignalStreamer(Cortex):
         cortex_time = data["time"]
 
         # watchdog 타임스탬프 갱신함
-        self.last_data_time = time.time()
+        now = time.time()
+        silent_sec = now - self.last_data_time
+        self.last_data_time = now
+
+        # stale 복구 엣지 기록함. watchdog은 정지 시작만 알리고 복구는 알리지
+        # 않아서, 다음 공백의 지속 시간을 사후에 알 수 없었음.
+        if self._eeg_stale:
+            self._eeg_stale = False
+            self._log_continuity("eeg_recovered", {"silentSec": round(silent_sec, 1)})
+
+        # 연속성 관측함 (COUNTER 라벨이 매핑된 경우에만)
+        if self.counter_index is not None and self.counter_index < len(eeg_row):
+            interpolated = 0
+            if self.interpolated_index is not None and self.interpolated_index < len(
+                eeg_row
+            ):
+                interpolated = eeg_row[self.interpolated_index]
+            for anomaly in self.continuity.observe(
+                eeg_row[self.counter_index], cortex_time, interpolated
+            ):
+                self._log_continuity(anomaly.pop("kind"), anomaly)
 
         # 채널 인덱스가 아직 매핑되지 않은 경우 대기함
         if not self.eeg_channel_indices:
             return
 
-        # 메타데이터를 제외한 순수 뇌파 채널 데이터만 추출하여 버퍼에 추가함
-        channel_data = [eeg_row[i] for i in self.eeg_channel_indices]
+        # 메타데이터를 제외한 순수 뇌파 채널 데이터만 추출하여 버퍼에 추가함.
+        # 불량 샘플은 버퍼에 넣지 않고 버림 — 하나만 섞여도 128샘플 평균이
+        # 오염돼 그 초의 5대역이 통째로 무효가 됨.
+        channel_data, reject_reason = coerce_eeg_channels(
+            eeg_row, self.eeg_channel_indices
+        )
+        if reject_reason:
+            self.dropped_samples += 1
+            self._log_continuity("eeg_sample_dropped", {"reason": reject_reason})
+            self._publish_health(
+                "invalid_data", min_interval_sec=HEALTH_REPUBLISH_INTERVAL_SEC
+            )
+            return
         self.eeg_buffer.append(channel_data)
 
         # 버퍼에 1초 분량(128 샘플)의 데이터가 모였을 때 분석 실행함
@@ -427,6 +689,24 @@ class MindSignalStreamer(Cortex):
 
             # 시계열 데이터를 필터에 통과시켜 파워 대역 계산함
             powers = self.analyzer.get_all_powers(mean_eeg_time_series)
+
+            # 필터는 대역별 독립 계산이라 샘플이 전부 유한해도 overflow로 한
+            # 대역만 비유한이 될 수 있음. 그 행은 쓰지 않고 버림 — coverage 계약이
+            # "요청 대역 중 하나라도 비유한이면 그 초 전체 무효"라 어차피 못 씀.
+            if not all(np.isfinite(v) for v in powers.values()):
+                self.dropped_blocks += 1
+                self._log_continuity(
+                    "eeg_block_dropped",
+                    {
+                        "reason": "non_finite_power",
+                        "bands": [k for k, v in powers.items() if not np.isfinite(v)],
+                    },
+                )
+                self._publish_health(
+                    "invalid_data", min_interval_sec=HEALTH_REPUBLISH_INTERVAL_SEC
+                )
+                self.eeg_buffer = []
+                return
 
             # Cortex 타임스탬프를 문자열로 변환함
             formatted_time = datetime.fromtimestamp(cortex_time).strftime(
@@ -451,6 +731,7 @@ class MindSignalStreamer(Cortex):
                 ]
             )
             self.csv_file.flush()
+            self.csv_rows_written += 1
 
             # 2. alignment_location에 따라 proxy 또는 Redis로 샘플 발행함
             if self.alignment_location == "proxy":
@@ -538,6 +819,25 @@ class MindSignalStreamer(Cortex):
     def on_close(self, *args, **kwargs):
         self._watchdog_active = False
         elapsed = time.time() - self.start_time if hasattr(self, "start_time") else 0
+
+        # 총 EEG 이벤트 대비 CSV 행 수를 남김. 128 이벤트당 1행이 정상이라
+        # 비율이 어긋나면 이벤트 유실인지 버퍼 미충족인지 사후 판별 가능함.
+        if hasattr(self, "continuity"):
+            summary = self.continuity.summary()
+            summary.update(
+                {
+                    "kind": "session_summary",
+                    "groupId": self.group_id,
+                    "subjectIndex": self.subject_index,
+                    "elapsedSec": round(elapsed, 1),
+                    "csvRows": self.csv_rows_written,
+                    "droppedSamples": self.dropped_samples,
+                    "droppedBlocks": self.dropped_blocks,
+                    "anomalyCounts": dict(self._continuity_log_counts),
+                }
+            )
+            logger.warning("[CONTINUITY] %s", json.dumps(summary))
+
         if hasattr(self, "csv_file") and not self.csv_file.closed:
             self.csv_file.close()
         # 2-PC 집계 — CSV 닫힌 직후 operator BE로 사본 업로드함 (soft-fail).

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -181,7 +181,10 @@ class StreamContinuityTracker:
             if int(interpolated):
                 self.interpolated_samples += 1
         except (TypeError, ValueError, OverflowError):
-            pass
+            # 조용히 삼키면 보간 집계가 왜 비었는지 사후에 알 수 없음
+            anomalies.append(
+                {"kind": "interpolated_invalid", "value": repr(interpolated)}
+            )
 
         return anomalies
 
@@ -561,10 +564,13 @@ class MindSignalStreamer(Cortex):
                 (watchdog 기존 동작 보존). 매 샘플 발생 가능한 경보에만 사용함
         """
         if min_interval_sec:
-            last = self._health_published_at.get(status, 0)
-            if time.time() - last < min_interval_sec:
+            # 수신 간격과 같은 이유로 monotonic 기준임. wall clock이 뒤로 조정되면
+            # time.time() 차이가 음수가 되어 그 폭만큼 경보가 통째로 억제됨.
+            mono = time.monotonic()
+            last = self._health_published_at.get(status)
+            if last is not None and mono - last < min_interval_sec:
                 return
-            self._health_published_at[status] = time.time()
+            self._health_published_at[status] = mono
 
         try:
             self.r.publish(
@@ -659,14 +665,21 @@ class MindSignalStreamer(Cortex):
         # 비유한 MET 값은 반영하지 않고 직전 정상값을 유지함. 그대로 넣으면
         # CSV와 Redis payload에 NaN이 실려 하류 분석이 통째로 깨짐.
         for key, index in self.met_map.items():
-            if index < len(data):
-                if _is_finite_number(data[index]):
-                    self.latest_met[key] = data[index]
-                else:
-                    self._log_continuity(
-                        "met_value_rejected",
-                        {"metric": key, "value": repr(data[index])},
-                    )
+            # 길이 부족을 무음 스킵하면 그 지표가 직전값으로 얼어붙은 채 계속
+            # 기록돼 라벨 매핑이 어긋났다는 사실을 사후에 알 수 없음
+            if index >= len(data):
+                self._log_continuity(
+                    "met_index_out_of_range",
+                    {"metric": key, "index": index, "length": len(data)},
+                )
+                continue
+            if _is_finite_number(data[index]):
+                self.latest_met[key] = data[index]
+            else:
+                self._log_continuity(
+                    "met_value_rejected",
+                    {"metric": key, "value": repr(data[index])},
+                )
 
     def _log_continuity(self, kind: str, payload: dict) -> None:
         """연속성 이벤트를 구조화 로그 1행으로 남김 (종류별 상한 적용).
@@ -783,13 +796,18 @@ class MindSignalStreamer(Cortex):
             # 필터는 대역별 독립 계산이라 샘플이 전부 유한해도 overflow로 한
             # 대역만 비유한이 될 수 있음. 그 행은 쓰지 않고 버림 — coverage 계약이
             # "요청 대역 중 하나라도 비유한이면 그 초 전체 무효"라 어차피 못 씀.
-            # 시각도 함께 검사함. 비유한 cortex_time은 아래 fromtimestamp()에서
-            # 예외를 내 콜백 자체를 죽임 (이후 이벤트가 전부 유실됨).
+            # 시각도 함께 검사함. 불량 cortex_time은 fromtimestamp()에서 예외를 내
+            # 콜백 자체를 죽임 (이후 이벤트가 전부 유실됨). 유한성만으로는 부족해서
+            # (1e300은 유한하지만 변환 불가) 실제 변환을 시도해 판정함.
             block_reject = None
+            timestamp = None
             if not all(np.isfinite(v) for v in powers.values()):
                 block_reject = "non_finite_power"
-            elif not _is_finite_number(cortex_time):
-                block_reject = "non_finite_time"
+            else:
+                try:
+                    timestamp = datetime.fromtimestamp(cortex_time)
+                except (TypeError, ValueError, OverflowError, OSError):
+                    block_reject = "non_finite_time"
 
             if block_reject:
                 self.dropped_blocks += 1
@@ -806,10 +824,8 @@ class MindSignalStreamer(Cortex):
                 self.eeg_buffer = []
                 return
 
-            # Cortex 타임스탬프를 문자열로 변환함
-            formatted_time = datetime.fromtimestamp(cortex_time).strftime(
-                "%Y-%m-%d %H:%M:%S.%f"
-            )
+            # Cortex 타임스탬프를 문자열로 변환함 (위 검사에서 변환된 값 재사용)
+            formatted_time = timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")
 
             # 1. CSV 기록 수행함
             self.writer.writerow(

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -59,8 +59,19 @@ class StreamContinuityTracker:
     헤드셋 없이 검증 가능하도록 I/O를 하지 않고 값만 받아 이상 목록을 반환함.
     호출부(`MindSignalStreamer.on_eeg_data_done`)가 로그 기록을 담당함.
 
-    ponytail: COUNTER가 정확히 modulus 배수만큼(128, 256, ...) 유실되면 카운터가
-    제자리로 돌아와 counter_gap으로는 안 잡힘. 그 경우는 timestamp_jump가 잡음.
+    판별표 (세 신호의 조합으로 원인을 가름):
+
+    | receive_gap | timestamp_jump | counter_gap | 해석 |
+    |---|---|---|---|
+    | 큼 | 큼 | 있거나 없음 | 스트림 정지 — 이벤트가 실제로 안 옴 |
+    | 정상 | 큼 | 없음 | clock jump — 이벤트는 왔고 시각만 튐 |
+    | 정상 | 정상 | 있음 | 국소 유실 — modulus 미만 샘플 누락 |
+
+    COUNTER는 modulus 순환이라 정확히 128의 배수만큼 유실되면 제자리로 돌아와
+    counter_gap으로 안 잡힘. 128Hz에서 "N초 정지"는 언제나 N*128 샘플이라 이 경우가
+    오히려 대표 시나리오임. 그래서 counter 하나에 의존하지 않고 로컬 수신 간격
+    (receive_gap_sec)을 항상 함께 받아 판별함. counter가 연속인데 수신 간격이나
+    Cortex 시각이 벌어졌으면 full_cycle_loss_suspected로 남김.
     """
 
     def __init__(
@@ -73,7 +84,8 @@ class StreamContinuityTracker:
         self.prev_counter: int | None = None
         self.prev_time: float | None = None
         self.events_seen = 0
-        self.lost_samples = 0
+        # modulus 순환 때문에 확정 유실량이 아니라 하한임 (이름으로 못 박음)
+        self.lost_samples_lower_bound = 0
         self.interpolated_samples = 0
 
     def observe(
@@ -81,6 +93,7 @@ class StreamContinuityTracker:
         counter: object,
         cortex_time: object,
         interpolated: object = 0,
+        receive_gap_sec: float | None = None,
     ) -> list[dict]:
         """EEG 이벤트 1건을 관측하고 발견된 이상 목록 반환함.
 
@@ -88,6 +101,8 @@ class StreamContinuityTracker:
             counter - Cortex EEG COUNTER 값임 (0부터 modulus-1까지 순환)
             cortex_time - Cortex가 보낸 epoch 초임
             interpolated - Cortex INTERPOLATED 플래그임 (1이면 보간 샘플)
+            receive_gap_sec - 직전 이벤트와의 로컬 수신 간격임 (monotonic 기준).
+                None이면 수신 간격 판정을 건너뜀
 
         Returns:
             이상 dict 리스트 반환. 정상이면 빈 리스트임. 각 dict는 `kind` 키를
@@ -95,10 +110,11 @@ class StreamContinuityTracker:
         """
         self.events_seen += 1
         anomalies: list[dict] = []
+        counter_gapped = False
 
         try:
             counter_int = int(counter)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             anomalies.append({"kind": "counter_invalid", "value": repr(counter)})
             counter_int = None
 
@@ -109,21 +125,24 @@ class StreamContinuityTracker:
                 else:
                     missing = (counter_int - self.prev_counter - 1) % self.modulus
                     if missing:
-                        self.lost_samples += missing
+                        counter_gapped = True
+                        self.lost_samples_lower_bound += missing
                         anomalies.append(
                             {
                                 "kind": "counter_gap",
                                 "prev": self.prev_counter,
                                 "counter": counter_int,
-                                "missing": missing,
+                                # 실제 유실량이 아니라 유실량 mod modulus임
+                                "missingModulo": missing,
                             }
                         )
             self.prev_counter = counter_int
 
         try:
             time_float = float(cortex_time)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             time_float = float("nan")
+        time_jumped = False
         if not np.isfinite(time_float):
             anomalies.append({"kind": "time_invalid", "value": repr(cortex_time)})
         else:
@@ -134,15 +153,34 @@ class StreamContinuityTracker:
                         {"kind": "timestamp_backwards", "deltaSec": round(delta, 4)}
                     )
                 elif delta > self.jump_tolerance_sec:
+                    time_jumped = True
                     anomalies.append(
                         {"kind": "timestamp_jump", "deltaSec": round(delta, 4)}
                     )
             self.prev_time = time_float
 
+        receive_gapped = (
+            receive_gap_sec is not None and receive_gap_sec > self.jump_tolerance_sec
+        )
+        if receive_gapped:
+            anomalies.append(
+                {"kind": "receive_gap", "gapSec": round(receive_gap_sec, 4)}
+            )
+
+        # counter는 멀쩡한데 시간이 벌어졌다면 정확히 modulus 배수가 유실된 것임.
+        # 이 조합이 없으면 15초 정지(1920샘플)가 clock jump와 구분되지 않음.
+        if (receive_gapped or time_jumped) and not counter_gapped:
+            anomalies.append(
+                {
+                    "kind": "full_cycle_loss_suspected",
+                    "streamStopped": receive_gapped,
+                }
+            )
+
         try:
             if int(interpolated):
                 self.interpolated_samples += 1
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             pass
 
         return anomalies
@@ -151,9 +189,18 @@ class StreamContinuityTracker:
         """종료 시점 누적 집계 반환함."""
         return {
             "eegEvents": self.events_seen,
-            "lostSamples": self.lost_samples,
+            # 확정값 아님 — modulus 순환분은 세지 못함
+            "lostSamplesLowerBound": self.lost_samples_lower_bound,
             "interpolatedSamples": self.interpolated_samples,
         }
+
+
+def _is_finite_number(value: object) -> bool:
+    """유한한 수치로 변환 가능한 값인지 판정함."""
+    try:
+        return bool(np.isfinite(float(value)))
+    except (TypeError, ValueError, OverflowError):
+        return False
 
 
 def coerce_eeg_channels(
@@ -315,6 +362,7 @@ class MindSignalStreamer(Cortex):
         self.dropped_blocks = 0
         self._continuity_log_counts: dict[str, int] = {}
         self._health_published_at: dict[str, float] = {}
+        self._last_event_monotonic: float | None = None
         self._eeg_stale = False
         self._met_stale = False
         self.latest_met = {
@@ -449,8 +497,12 @@ class MindSignalStreamer(Cortex):
                 labels.index("INTERPOLATED") if "INTERPOLATED" in labels else None
             )
             if self.counter_index is None:
-                print(
-                    f"[WARN] EEG COUNTER 라벨 미발견 — 연속성 계측 비활성 (labels={labels})"
+                # print가 아니라 logger를 씀. Windows 기본 콘솔 인코딩(CP949)에서
+                # print는 UnicodeEncodeError로 콜백을 죽일 수 있고, 그러면
+                # "계측만 끄고 측정은 계속"이라는 이 경로의 의도가 깨짐.
+                logger.warning(
+                    "EEG COUNTER 라벨 미발견으로 연속성 계측 비활성함 "
+                    f"(labels={labels}, subject {self.subject_index})"
                 )
 
     def on_create_session_done(self, *args, **kwargs):
@@ -604,9 +656,17 @@ class MindSignalStreamer(Cortex):
                 "met_recovered", {"silentSec": round(now - self.last_met_time, 1)}
             )
         self.last_met_time = now
+        # 비유한 MET 값은 반영하지 않고 직전 정상값을 유지함. 그대로 넣으면
+        # CSV와 Redis payload에 NaN이 실려 하류 분석이 통째로 깨짐.
         for key, index in self.met_map.items():
             if index < len(data):
-                self.latest_met[key] = data[index]
+                if _is_finite_number(data[index]):
+                    self.latest_met[key] = data[index]
+                else:
+                    self._log_continuity(
+                        "met_value_rejected",
+                        {"metric": key, "value": repr(data[index])},
+                    )
 
     def _log_continuity(self, kind: str, payload: dict) -> None:
         """연속성 이벤트를 구조화 로그 1행으로 남김 (종류별 상한 적용).
@@ -631,6 +691,20 @@ class MindSignalStreamer(Cortex):
             record["logCapReached"] = True
         logger.warning("[CONTINUITY] %s", json.dumps(record))
 
+    def _discard_partial_buffer(self, reason: str) -> None:
+        """모으던 부분 버퍼를 버림 (연속되지 않은 구간의 이어붙임 방지).
+
+        Args:
+            reason - 폐기 사유임 (수신 공백 또는 불량 샘플 사유)
+        """
+        if not self.eeg_buffer:
+            return
+        self._log_continuity(
+            "partial_buffer_discarded",
+            {"reason": reason, "samples": len(self.eeg_buffer)},
+        )
+        self.eeg_buffer = []
+
     def on_eeg_data_done(self, *args, **kwargs):
         """EEG 샘플을 버퍼링하고 1초(128샘플) 도달 시 대역 파워 계산 수행함"""
         data = kwargs.get("data")
@@ -641,6 +715,14 @@ class MindSignalStreamer(Cortex):
         now = time.time()
         silent_sec = now - self.last_data_time
         self.last_data_time = now
+
+        # 로컬 수신 간격은 monotonic으로 잼. wall clock이 조정돼도 흔들리지 않아야
+        # "이벤트가 안 온 것"과 "Cortex 시각만 튄 것"을 가를 수 있음.
+        mono = time.monotonic()
+        receive_gap = None
+        if self._last_event_monotonic is not None:
+            receive_gap = mono - self._last_event_monotonic
+        self._last_event_monotonic = mono
 
         # stale 복구 엣지 기록함. watchdog은 정지 시작만 알리고 복구는 알리지
         # 않아서, 다음 공백의 지속 시간을 사후에 알 수 없었음.
@@ -656,13 +738,19 @@ class MindSignalStreamer(Cortex):
             ):
                 interpolated = eeg_row[self.interpolated_index]
             for anomaly in self.continuity.observe(
-                eeg_row[self.counter_index], cortex_time, interpolated
+                eeg_row[self.counter_index], cortex_time, interpolated, receive_gap
             ):
                 self._log_continuity(anomaly.pop("kind"), anomaly)
 
         # 채널 인덱스가 아직 매핑되지 않은 경우 대기함
         if not self.eeg_channel_indices:
             return
+
+        # 수신이 끊겼다가 재개되면 남은 부분 버퍼를 버림. 그대로 두면 15초 떨어진
+        # 두 구간이 하나의 128샘플 블록으로 이어붙어 연속 신호가 아닌 것을
+        # 연속으로 간주해 FFT를 돌리게 됨.
+        if receive_gap is not None and receive_gap > TIMESTAMP_JUMP_TOLERANCE_SEC:
+            self._discard_partial_buffer("receive_gap")
 
         # 메타데이터를 제외한 순수 뇌파 채널 데이터만 추출하여 버퍼에 추가함.
         # 불량 샘플은 버퍼에 넣지 않고 버림 — 하나만 섞여도 128샘플 평균이
@@ -676,6 +764,8 @@ class MindSignalStreamer(Cortex):
             self._publish_health(
                 "invalid_data", min_interval_sec=HEALTH_REPUBLISH_INTERVAL_SEC
             )
+            # 불량 샘플 전후를 이어붙이지 않도록 부분 버퍼도 함께 버림
+            self._discard_partial_buffer(reject_reason)
             return
         self.eeg_buffer.append(channel_data)
 
@@ -693,12 +783,20 @@ class MindSignalStreamer(Cortex):
             # 필터는 대역별 독립 계산이라 샘플이 전부 유한해도 overflow로 한
             # 대역만 비유한이 될 수 있음. 그 행은 쓰지 않고 버림 — coverage 계약이
             # "요청 대역 중 하나라도 비유한이면 그 초 전체 무효"라 어차피 못 씀.
+            # 시각도 함께 검사함. 비유한 cortex_time은 아래 fromtimestamp()에서
+            # 예외를 내 콜백 자체를 죽임 (이후 이벤트가 전부 유실됨).
+            block_reject = None
             if not all(np.isfinite(v) for v in powers.values()):
+                block_reject = "non_finite_power"
+            elif not _is_finite_number(cortex_time):
+                block_reject = "non_finite_time"
+
+            if block_reject:
                 self.dropped_blocks += 1
                 self._log_continuity(
                     "eeg_block_dropped",
                     {
-                        "reason": "non_finite_power",
+                        "reason": block_reject,
                         "bands": [k for k, v in powers.items() if not np.isfinite(v)],
                     },
                 )

--- a/tests/test_stream_continuity.py
+++ b/tests/test_stream_continuity.py
@@ -1,0 +1,338 @@
+"""스트림 연속성 계측 검증 (.plans/22-stream-continuity-instrumentation P0-1).
+
+배경: CSV 1행은 EEG 128샘플마다 생성되므로 결측은 행 단위로 통째 발생한다.
+EEG가 15초 정지하면 DE watchdog 30초와 BE coverage 게이트 0.8을 둘 다 빠져나가,
+다음 공백이 이벤트 유실인지 clock jump인지 판별할 수단이 없었다.
+
+판정 로직은 헤드셋 없이 검증 가능하도록 순수 상태기로 분리했고, 여기서는
+counter 누락과 timestamp 점프가 서로 다른 진단 코드로 기록되는지 잠근다.
+"""
+
+import json
+import logging
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from core.streamer import (
+    COUNTER_MODULUS,
+    MindSignalStreamer,
+    StreamContinuityTracker,
+    coerce_eeg_channels,
+)
+
+# 128Hz 정상 샘플 간격임
+TICK = 1.0 / 128
+
+
+def _feed(tracker, count, start_counter=0, start_time=1000.0):
+    """정상 연속 샘플을 count개 주입하고 마지막 (counter, time) 반환함."""
+    counter = start_counter
+    now = start_time
+    for _ in range(count):
+        tracker.observe(counter, now)
+        counter = (counter + 1) % COUNTER_MODULUS
+        now += TICK
+    return counter, now
+
+
+def test_normal_stream_reports_nothing():
+    tracker = StreamContinuityTracker()
+    _feed(tracker, 300)
+    assert tracker.lost_samples == 0
+    assert tracker.events_seen == 300
+
+
+def test_counter_gap_reports_missing_sample_count():
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 10)
+
+    # 5샘플 유실 후 재개함
+    anomalies = tracker.observe((counter + 5) % COUNTER_MODULUS, now + TICK)
+
+    kinds = {a["kind"] for a in anomalies}
+    assert kinds == {"counter_gap"}
+    assert anomalies[0]["missing"] == 5
+    assert tracker.lost_samples == 5
+
+
+def test_counter_gap_across_wrap_boundary():
+    """127에서 2로 넘어가면 유실 2개임 (순환 경계에서 음수 gap 방지)."""
+    tracker = StreamContinuityTracker()
+    tracker.observe(127, 1000.0)
+    anomalies = tracker.observe(2, 1000.0 + TICK)
+    assert anomalies[0]["kind"] == "counter_gap"
+    assert anomalies[0]["missing"] == 2
+
+
+def test_repeated_counter_is_distinct_from_gap():
+    tracker = StreamContinuityTracker()
+    tracker.observe(7, 1000.0)
+    anomalies = tracker.observe(7, 1000.0 + TICK)
+    assert [a["kind"] for a in anomalies] == ["counter_repeat"]
+    assert tracker.lost_samples == 0
+
+
+def test_timestamp_jump_reported_without_counter_gap():
+    """카운터는 연속인데 시각만 튀는 경우 — clock jump 판별용."""
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 10)
+
+    anomalies = tracker.observe(counter, now + 3.0)
+
+    assert [a["kind"] for a in anomalies] == ["timestamp_jump"]
+    assert anomalies[0]["deltaSec"] == pytest.approx(3.0, abs=0.01)
+    assert tracker.lost_samples == 0
+
+
+def test_counter_gap_and_timestamp_jump_reported_together():
+    """이벤트 유실이면 둘 다 뜸 — clock jump 단독과 구분되는 서명임."""
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 10)
+
+    anomalies = tracker.observe((counter + 20) % COUNTER_MODULUS, now + 2.0)
+
+    assert {a["kind"] for a in anomalies} == {"counter_gap", "timestamp_jump"}
+
+
+def test_backwards_timestamp_is_distinct_kind():
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 5)
+    anomalies = tracker.observe(counter, now - 1.0)
+    assert [a["kind"] for a in anomalies] == ["timestamp_backwards"]
+
+
+def test_non_finite_and_unparsable_values_do_not_raise():
+    tracker = StreamContinuityTracker()
+    assert [a["kind"] for a in tracker.observe(None, 1000.0)] == ["counter_invalid"]
+    assert "time_invalid" in {a["kind"] for a in tracker.observe(1, float("nan"))}
+    assert "time_invalid" in {a["kind"] for a in tracker.observe(2, "not-a-time")}
+
+
+def test_interpolated_samples_counted():
+    tracker = StreamContinuityTracker()
+    tracker.observe(0, 1000.0, interpolated=1)
+    tracker.observe(1, 1000.0 + TICK, interpolated=0)
+    tracker.observe(2, 1000.0 + 2 * TICK, interpolated=1)
+    assert tracker.summary()["interpolatedSamples"] == 2
+
+
+def _bare_streamer():
+    """Cortex와 Redis 부작용 없이 계측 경로만 돌리기 위한 인스턴스 생성함."""
+    s = MindSignalStreamer.__new__(MindSignalStreamer)
+    s.group_id = "g1"
+    s.subject_index = 1
+    s.start_time = time.time()
+    s.last_data_time = time.time()
+    s.last_met_time = time.time()
+    s.eeg_channel_indices = []
+    # 버퍼링 경로는 128샘플 미만이라 분석까지 가지 않음. 실제 analyzer 대신 fs만 둠
+    s.eeg_buffer = []
+    s.analyzer = SimpleNamespace(fs=128)
+    s.counter_index = None
+    s.interpolated_index = None
+    s.continuity = StreamContinuityTracker()
+    s.csv_rows_written = 0
+    s.dropped_samples = 0
+    s.dropped_blocks = 0
+    s._continuity_log_counts = {}
+    s._health_published_at = {}
+    s._eeg_stale = False
+    s._met_stale = False
+    s.channel = "mind-signal:g1:subject:1"
+    s.r = _FakeRedis()
+    return s
+
+
+class _FakeRedis:
+    """publish 호출만 기록하는 대역임."""
+
+    def __init__(self):
+        self.published = []
+
+    def publish(self, channel, message):
+        self.published.append(json.loads(message))
+
+
+def _continuity_records(caplog):
+    return [
+        json.loads(r.message.split("[CONTINUITY] ", 1)[1])
+        for r in caplog.records
+        if r.message.startswith("[CONTINUITY] ")
+    ]
+
+
+def test_labels_event_maps_counter_and_interpolated_indices():
+    s = _bare_streamer()
+    labels = ["COUNTER", "INTERPOLATED", "AF3", "T7", "Pz", "T8", "AF4"]
+    s.on_new_data_labels(data={"streamName": "eeg", "labels": labels})
+    assert s.counter_index == 0
+    assert s.interpolated_index == 1
+    assert s.eeg_channel_indices == [2, 3, 4, 5, 6]
+
+
+def test_missing_counter_label_disables_instrumentation_without_breaking():
+    s = _bare_streamer()
+    s.on_new_data_labels(data={"streamName": "eeg", "labels": ["AF3", "AF4"]})
+    assert s.counter_index is None
+    # 계측이 꺼져도 EEG 수신 자체는 예외 없이 진행됨
+    s.on_eeg_data_done(data={"eeg": [1.0, 2.0], "time": 1000.0})
+    assert s.continuity.events_seen == 0
+
+
+def test_eeg_event_logs_counter_gap(caplog):
+    s = _bare_streamer()
+    s.on_new_data_labels(
+        data={"streamName": "eeg", "labels": ["COUNTER", "INTERPOLATED", "AF3"]}
+    )
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(data={"eeg": [10, 0, 1.0], "time": 1000.0})
+        s.on_eeg_data_done(data={"eeg": [14, 0, 1.0], "time": 1000.0 + TICK})
+
+    records = _continuity_records(caplog)
+    assert [r["kind"] for r in records] == ["counter_gap"]
+    assert records[0]["missing"] == 3
+    assert records[0]["subjectIndex"] == 1
+
+
+def test_stale_start_and_recovery_are_edge_logged(caplog):
+    s = _bare_streamer()
+    s._eeg_stale = True  # watchdog이 정지를 이미 기록한 상태임
+    s.last_data_time = time.time() - 15.0
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(data={"eeg": [0, 0, 1.0], "time": 1000.0})
+        # 복구 후 정상 수신은 다시 로그하지 않음
+        s.on_eeg_data_done(data={"eeg": [1, 0, 1.0], "time": 1000.0 + TICK})
+
+    records = _continuity_records(caplog)
+    assert [r["kind"] for r in records] == ["eeg_recovered"]
+    assert records[0]["silentSec"] >= 15.0
+    assert s._eeg_stale is False
+
+
+def test_log_cap_limits_flood_but_summary_keeps_full_count(caplog):
+    s = _bare_streamer()
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        for _ in range(50):
+            s._log_continuity("counter_gap", {"missing": 1})
+
+    records = _continuity_records(caplog)
+    assert len(records) == 20
+    assert records[-1]["logCapReached"] is True
+    assert s._continuity_log_counts["counter_gap"] == 50
+
+
+# --- P0-2 생성층 유한성 방어 ---
+
+
+def test_coerce_accepts_normal_row():
+    values, reason = coerce_eeg_channels([0, 0, 1.5, "2.5", 3], [2, 3, 4])
+    assert reason is None
+    assert values == [1.5, 2.5, 3.0]
+
+
+@pytest.mark.parametrize(
+    ("bad", "expected_reason"),
+    [
+        (float("nan"), "non_finite"),
+        (float("inf"), "non_finite"),
+        (float("-inf"), "non_finite"),
+        ("not-a-number", "non_numeric"),
+        (None, "non_numeric"),
+    ],
+)
+def test_coerce_rejects_bad_values(bad, expected_reason):
+    values, reason = coerce_eeg_channels([0, 0, 1.0, bad], [2, 3])
+    assert values is None
+    assert reason == expected_reason
+
+
+def test_coerce_rejects_short_row_and_empty_mapping():
+    assert coerce_eeg_channels([0, 1], [2, 3])[1] == "row_too_short"
+    assert coerce_eeg_channels([0, 1], [])[1] == "no_channel_mapping"
+
+
+def _mapped_streamer():
+    s = _bare_streamer()
+    s.on_new_data_labels(
+        data={
+            "streamName": "eeg",
+            "labels": ["COUNTER", "INTERPOLATED", "AF3", "T7", "Pz", "T8", "AF4"],
+        }
+    )
+    return s
+
+
+def test_non_finite_sample_is_dropped_before_buffer(caplog):
+    """Inf 샘플이 버퍼에 들어가면 128샘플 평균 전체가 오염됨."""
+    s = _mapped_streamer()
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(
+            data={"eeg": [0, 0, 1.0, 1.0, float("inf"), 1.0, 1.0], "time": 1000.0}
+        )
+
+    assert s.eeg_buffer == []
+    assert s.dropped_samples == 1
+    records = _continuity_records(caplog)
+    assert records[0]["kind"] == "eeg_sample_dropped"
+    assert records[0]["reason"] == "non_finite"
+    assert s.r.published[0]["status"] == "invalid_data"
+
+
+def test_valid_sample_still_buffered():
+    s = _mapped_streamer()
+    s.on_eeg_data_done(data={"eeg": [0, 0, 1.0, 2.0, 3.0, 4.0, 5.0], "time": 1000.0})
+    assert s.eeg_buffer == [[1.0, 2.0, 3.0, 4.0, 5.0]]
+    assert s.dropped_samples == 0
+    assert s.r.published == []
+
+
+def test_health_republish_is_throttled():
+    s = _mapped_streamer()
+    for i in range(30):
+        s.on_eeg_data_done(
+            data={
+                "eeg": [i % COUNTER_MODULUS, 0, float("nan"), 1.0, 1.0, 1.0, 1.0],
+                "time": 1000.0 + i * TICK,
+            }
+        )
+    assert s.dropped_samples == 30
+    # 초당 128건을 던지지 않고 10초 간격으로 1건만 발행함
+    assert len(s.r.published) == 1
+
+
+def test_non_finite_power_block_is_not_written_to_csv(caplog):
+    """샘플이 전부 유한해도 필터 overflow로 한 대역만 비유한일 수 있음."""
+    s = _mapped_streamer()
+    s.analyzer = SimpleNamespace(
+        fs=2,
+        get_all_powers=lambda _: {
+            "delta": 1.0,
+            "theta": float("inf"),
+            "alpha": 1.0,
+            "beta": 1.0,
+            "gamma": 1.0,
+        },
+    )
+    s.writer = SimpleNamespace(
+        writerow=lambda row: pytest.fail("불량 블록이 CSV에 기록됨")
+    )
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(
+            data={"eeg": [0, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1000.0}
+        )
+        s.on_eeg_data_done(
+            data={"eeg": [1, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1001.0}
+        )
+
+    assert s.dropped_blocks == 1
+    assert s.csv_rows_written == 0
+    assert s.eeg_buffer == []  # 다음 초가 오염되지 않도록 버퍼 초기화됨
+    dropped = [
+        r for r in _continuity_records(caplog) if r["kind"] == "eeg_block_dropped"
+    ]
+    assert dropped[0]["bands"] == ["theta"]
+    assert s.r.published[0]["status"] == "invalid_data"

--- a/tests/test_stream_continuity.py
+++ b/tests/test_stream_continuity.py
@@ -40,7 +40,7 @@ def _feed(tracker, count, start_counter=0, start_time=1000.0):
 def test_normal_stream_reports_nothing():
     tracker = StreamContinuityTracker()
     _feed(tracker, 300)
-    assert tracker.lost_samples == 0
+    assert tracker.lost_samples_lower_bound == 0
     assert tracker.events_seen == 300
 
 
@@ -53,8 +53,8 @@ def test_counter_gap_reports_missing_sample_count():
 
     kinds = {a["kind"] for a in anomalies}
     assert kinds == {"counter_gap"}
-    assert anomalies[0]["missing"] == 5
-    assert tracker.lost_samples == 5
+    assert anomalies[0]["missingModulo"] == 5
+    assert tracker.lost_samples_lower_bound == 5
 
 
 def test_counter_gap_across_wrap_boundary():
@@ -63,7 +63,7 @@ def test_counter_gap_across_wrap_boundary():
     tracker.observe(127, 1000.0)
     anomalies = tracker.observe(2, 1000.0 + TICK)
     assert anomalies[0]["kind"] == "counter_gap"
-    assert anomalies[0]["missing"] == 2
+    assert anomalies[0]["missingModulo"] == 2
 
 
 def test_repeated_counter_is_distinct_from_gap():
@@ -71,19 +71,61 @@ def test_repeated_counter_is_distinct_from_gap():
     tracker.observe(7, 1000.0)
     anomalies = tracker.observe(7, 1000.0 + TICK)
     assert [a["kind"] for a in anomalies] == ["counter_repeat"]
-    assert tracker.lost_samples == 0
+    assert tracker.lost_samples_lower_bound == 0
 
 
-def test_timestamp_jump_reported_without_counter_gap():
-    """카운터는 연속인데 시각만 튀는 경우 — clock jump 판별용."""
+def test_clock_jump_signature_has_no_receive_gap():
+    """이벤트는 정상 수신인데 Cortex 시각만 튄 경우임 — 스트림 정지가 아님."""
     tracker = StreamContinuityTracker()
     counter, now = _feed(tracker, 10)
 
-    anomalies = tracker.observe(counter, now + 3.0)
+    # _feed는 다음에 올 counter를 돌려주므로 그대로 넣으면 카운터는 연속임
+    anomalies = tracker.observe(counter, now + 3.0, receive_gap_sec=TICK)
 
-    assert [a["kind"] for a in anomalies] == ["timestamp_jump"]
-    assert anomalies[0]["deltaSec"] == pytest.approx(3.0, abs=0.01)
-    assert tracker.lost_samples == 0
+    kinds = {a["kind"] for a in anomalies}
+    assert kinds == {"timestamp_jump", "full_cycle_loss_suspected"}
+    jump = next(a for a in anomalies if a["kind"] == "timestamp_jump")
+    assert jump["deltaSec"] == pytest.approx(3.0, abs=0.01)
+    suspected = next(a for a in anomalies if a["kind"] == "full_cycle_loss_suspected")
+    assert suspected["streamStopped"] is False
+
+
+def test_stream_stop_signature_has_receive_gap():
+    """15초 정지는 정확히 1920샘플이라 counter가 제자리로 돌아옴.
+
+    codex 교차검토 지적(High): counter_gap만 보면 이 시나리오가 clock jump와
+    구분되지 않는다. 로컬 수신 간격이 유일한 판별 신호다.
+    """
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 10)
+
+    # 15초 정지 후 복구 — 유실 1920 = 128 * 15라 counter는 연속으로 보임
+    anomalies = tracker.observe(counter, now + 15.0, receive_gap_sec=15.0)
+
+    kinds = {a["kind"] for a in anomalies}
+    assert kinds == {"timestamp_jump", "receive_gap", "full_cycle_loss_suspected"}
+    suspected = next(a for a in anomalies if a["kind"] == "full_cycle_loss_suspected")
+    assert suspected["streamStopped"] is True
+
+
+@pytest.mark.parametrize("lost", [127, 128, 133, 1920])
+def test_full_cycle_losses_are_never_silently_normal(lost):
+    """유실량이 modulus 배수든 아니든 어떤 이상은 반드시 남음."""
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 10)
+
+    gap_sec = lost * TICK
+    anomalies = tracker.observe(
+        (counter + lost) % COUNTER_MODULUS, now + gap_sec, receive_gap_sec=gap_sec
+    )
+
+    assert anomalies, f"{lost}샘플 유실이 아무 이상도 남기지 않음"
+    kinds = {a["kind"] for a in anomalies}
+    # 어느 경우든 수신 공백이 남아 스트림 정지로 판별 가능함
+    assert "receive_gap" in kinds
+    if lost % COUNTER_MODULUS == 0:
+        assert "counter_gap" not in kinds
+        assert "full_cycle_loss_suspected" in kinds
 
 
 def test_counter_gap_and_timestamp_jump_reported_together():
@@ -93,6 +135,7 @@ def test_counter_gap_and_timestamp_jump_reported_together():
 
     anomalies = tracker.observe((counter + 20) % COUNTER_MODULUS, now + 2.0)
 
+    # counter_gap이 유실을 확정하므로 full_cycle_loss_suspected는 붙지 않음
     assert {a["kind"] for a in anomalies} == {"counter_gap", "timestamp_jump"}
 
 
@@ -138,6 +181,7 @@ def _bare_streamer():
     s.dropped_blocks = 0
     s._continuity_log_counts = {}
     s._health_published_at = {}
+    s._last_event_monotonic = None
     s._eeg_stale = False
     s._met_stale = False
     s.channel = "mind-signal:g1:subject:1"
@@ -192,7 +236,7 @@ def test_eeg_event_logs_counter_gap(caplog):
 
     records = _continuity_records(caplog)
     assert [r["kind"] for r in records] == ["counter_gap"]
-    assert records[0]["missing"] == 3
+    assert records[0]["missingModulo"] == 3
     assert records[0]["subjectIndex"] == 1
 
 
@@ -336,3 +380,89 @@ def test_non_finite_power_block_is_not_written_to_csv(caplog):
     ]
     assert dropped[0]["bands"] == ["theta"]
     assert s.r.published[0]["status"] == "invalid_data"
+
+
+# --- codex 교차검토 반영분 ---
+
+
+def test_bad_sample_discards_partial_buffer(caplog):
+    """불량 샘플 전후가 한 블록으로 이어붙지 않음 (codex Medium 2)."""
+    s = _mapped_streamer()
+    s.on_eeg_data_done(data={"eeg": [0, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1000.0})
+    assert len(s.eeg_buffer) == 1
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(
+            data={"eeg": [1, 0, float("nan"), 1.0, 1.0, 1.0, 1.0], "time": 1000.01}
+        )
+
+    assert s.eeg_buffer == []
+    discarded = [
+        r
+        for r in _continuity_records(caplog)
+        if r["kind"] == "partial_buffer_discarded"
+    ]
+    assert discarded[0]["samples"] == 1
+
+
+def test_receive_gap_discards_partial_buffer(monkeypatch):
+    """수신이 끊겼다 재개되면 떨어진 두 구간을 이어붙이지 않음."""
+    s = _mapped_streamer()
+    clock = [100.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    s.on_eeg_data_done(data={"eeg": [0, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1000.0})
+    s.on_eeg_data_done(data={"eeg": [1, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1000.01})
+    assert len(s.eeg_buffer) == 2
+
+    clock[0] += 15.0  # 15초 수신 공백 후 복구됨
+    s.on_eeg_data_done(data={"eeg": [2, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1015.0})
+
+    # 공백 이전 2샘플은 버려지고 새 구간만 남음
+    assert len(s.eeg_buffer) == 1
+
+
+def test_non_finite_time_does_not_kill_callback(caplog):
+    """비유한 cortex_time은 fromtimestamp에서 콜백을 죽임 (codex Medium 3)."""
+    s = _mapped_streamer()
+    s.analyzer = SimpleNamespace(
+        fs=1,
+        get_all_powers=lambda _: {
+            "delta": 1.0,
+            "theta": 1.0,
+            "alpha": 1.0,
+            "beta": 1.0,
+            "gamma": 1.0,
+        },
+    )
+    s.writer = SimpleNamespace(
+        writerow=lambda row: pytest.fail("비유한 시각 행이 CSV에 기록됨")
+    )
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(
+            data={"eeg": [0, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": float("nan")}
+        )
+
+    assert s.dropped_blocks == 1
+    assert s.csv_rows_written == 0
+    dropped = [
+        r for r in _continuity_records(caplog) if r["kind"] == "eeg_block_dropped"
+    ]
+    assert dropped[0]["reason"] == "non_finite_time"
+
+
+def test_non_finite_met_keeps_last_good_value(caplog):
+    """NaN MET을 그대로 저장하면 CSV와 Redis payload가 오염됨 (codex Medium 3)."""
+    s = _mapped_streamer()
+    s.met_map = {"focus": 0, "stress": 1}
+    s.latest_met = {"focus": 0.4, "stress": 0.2}
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_new_met_data(data={"met": [float("nan"), 0.9]})
+
+    assert s.latest_met == {"focus": 0.4, "stress": 0.9}
+    rejected = [
+        r for r in _continuity_records(caplog) if r["kind"] == "met_value_rejected"
+    ]
+    assert rejected[0]["metric"] == "focus"

--- a/tests/test_stream_continuity.py
+++ b/tests/test_stream_continuity.py
@@ -466,3 +466,84 @@ def test_non_finite_met_keeps_last_good_value(caplog):
         r for r in _continuity_records(caplog) if r["kind"] == "met_value_rejected"
     ]
     assert rejected[0]["metric"] == "focus"
+
+
+# --- CodeRabbit 리뷰 반영분 ---
+
+
+def test_tolerance_boundary_is_exclusive():
+    """정확히 tolerance면 이상 아님, 초과하면 receive_gap임 (부등호 회귀 방지)."""
+    tracker = StreamContinuityTracker()
+    counter, now = _feed(tracker, 5)
+
+    at_edge = tracker.observe(counter, now + TICK, receive_gap_sec=0.5)
+    assert [a["kind"] for a in at_edge] == []
+
+    counter = (counter + 1) % COUNTER_MODULUS
+    over_edge = tracker.observe(counter, now + 2 * TICK, receive_gap_sec=0.5001)
+    assert "receive_gap" in {a["kind"] for a in over_edge}
+
+
+def test_out_of_range_time_is_rejected_before_fromtimestamp(caplog):
+    """유한해도 변환 불가한 시각이 있음 (1e300). 유한성 검사만으로는 못 막음."""
+    s = _mapped_streamer()
+    s.analyzer = SimpleNamespace(
+        fs=1,
+        get_all_powers=lambda _: dict.fromkeys(
+            ("delta", "theta", "alpha", "beta", "gamma"), 1.0
+        ),
+    )
+    s.writer = SimpleNamespace(
+        writerow=lambda row: pytest.fail("변환 불가 시각 행이 CSV에 기록됨")
+    )
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_eeg_data_done(data={"eeg": [0, 0, 1.0, 1.0, 1.0, 1.0, 1.0], "time": 1e300})
+
+    assert s.dropped_blocks == 1
+    dropped = [
+        r for r in _continuity_records(caplog) if r["kind"] == "eeg_block_dropped"
+    ]
+    assert dropped[0]["reason"] == "non_finite_time"
+
+
+def test_met_index_out_of_range_is_logged(caplog):
+    """라벨 매핑이 어긋나 지표가 얼어붙는 것을 무음으로 넘기지 않음."""
+    s = _mapped_streamer()
+    s.met_map = {"focus": 0, "stress": 9}
+    s.latest_met = {"focus": 0.1, "stress": 0.2}
+
+    with caplog.at_level(logging.WARNING, logger="core.streamer"):
+        s.on_new_met_data(data={"met": [0.7]})
+
+    assert s.latest_met == {"focus": 0.7, "stress": 0.2}
+    out_of_range = [
+        r for r in _continuity_records(caplog) if r["kind"] == "met_index_out_of_range"
+    ]
+    assert out_of_range[0]["metric"] == "stress"
+    assert out_of_range[0]["length"] == 1
+
+
+def test_publish_failure_does_not_break_measurement():
+    """Redis 장애로 경보가 못 나가도 샘플 버퍼링은 계속돼야 함."""
+    s = _mapped_streamer()
+
+    def _boom(channel, message):
+        raise RuntimeError("redis down")
+
+    s.r = SimpleNamespace(publish=_boom)
+
+    s.on_eeg_data_done(
+        data={"eeg": [0, 0, float("nan"), 1.0, 1.0, 1.0, 1.0], "time": 1000.0}
+    )
+    s.on_eeg_data_done(data={"eeg": [1, 0, 1.0, 2.0, 3.0, 4.0, 5.0], "time": 1000.01})
+
+    assert s.dropped_samples == 1
+    assert s.eeg_buffer == [[1.0, 2.0, 3.0, 4.0, 5.0]]
+
+
+def test_invalid_interpolated_flag_is_reported():
+    """보간 집계가 왜 비었는지 알 수 있어야 함."""
+    tracker = StreamContinuityTracker()
+    anomalies = tracker.observe(0, 1000.0, interpolated="nope")
+    assert [a["kind"] for a in anomalies] == ["interpolated_invalid"]


### PR DESCRIPTION
> 계획 폴더: `.plans/22-stream-continuity-instrumentation` (EEG-W001, EEG-W002)
> 소급 W-ID 부여 2026-07-31 (DOCS-W002). 정본 `.plans/LEGACY-REGISTRY.md`

## 배경

`.plans/22-stream-continuity-instrumentation/PLAN.md`의 남은 P0 둘을 처리한다.

CSV 1행은 EEG 128샘플마다 생성되므로 결측은 행 단위로 통째 발생한다. EEG가 15초 정지하면 DE watchdog 임계 30초보다 짧고 BE coverage 게이트 0.8에도 걸리지 않아 **현재 모든 장치를 빠져나간다.** 다음 측정에서 "왜 끊겼는가"를 판별할 수단이 없어 계측을 먼저 넣는다.

헤드셋이 없는 회차라 판정 로직은 전부 I/O 없는 순수 함수와 상태기로 분리해 pytest로만 검증했다.

## 변경

### P0-1 연속성 계측

- `StreamContinuityTracker` — Cortex COUNTER 불연속, timestamp 점프, 로컬 수신 간격을 관측해 이상 목록을 반환하는 순수 상태기. 진단 코드: `counter_gap`, `counter_repeat`, `timestamp_jump`, `timestamp_backwards`, `receive_gap`, `full_cycle_loss_suspected`, `counter_invalid`, `time_invalid`
- `on_new_data_labels`가 eeg 라벨에서 `COUNTER`와 `INTERPOLATED` 인덱스를 확보. 없으면 계측만 꺼지고 측정은 그대로 진행
- stale 시작과 복구를 엣지에서 1회씩 기록. watchdog은 정지 시작만 알리고 복구는 알리지 않아 공백 지속 시간을 사후에 알 수 없었다
- 종료 시 `session_summary` — EEG 이벤트 수, CSV 행 수, 유실 하한, 보간 샘플, drop 수, 이상 종류별 카운트

원인 판별표:

| receive_gap | timestamp_jump | counter_gap | 해석 |
|---|---|---|---|
| 큼 | 큼 | 무관 | 스트림 정지, 이벤트가 실제로 안 옴 |
| 정상 | 큼 | 없음 | clock jump, 시각만 튐 |
| 정상 | 정상 | 있음 | 국소 유실, 128 미만 |

### P0-2 생성층 유한성 방어

- `coerce_eeg_channels()` — 채널을 명시적으로 float 변환하고 유한성을 검사. 불량 샘플은 버퍼에 들어가기 전에 버린다. 하나만 섞여도 128샘플 평균이 오염돼 그 초의 5대역이 통째로 무효가 된다
- 블록 단위 방어 — 샘플이 전부 유한해도 필터 overflow로 한 대역만 비유한일 수 있다. 그 행은 CSV에 쓰지 않고 어느 대역이 깨졌는지 남긴다
- `_publish_health()` — watchdog 클로저를 메서드로 승격해 공용화. `invalid_data` 상태 발행. watchdog 기존 발행 빈도와 payload는 그대로이고, 매 샘플 발생 가능한 새 경로에만 10초 throttle을 건다

## codex 교차검토 (gpt-5.6-sol, read-only)

초기 verdict는 REVISE였다. 지적 6건 중 4건을 반영했다.

**High 1건 반영** — `missing`이 실제 유실량이 아니라 유실량 mod 128이었다. 결정적으로 128Hz에서 N초 정지는 언제나 정확히 N 곱하기 128 샘플이라, 이번 계측의 표적인 15초 정지(1920샘플)는 구조적으로 `counter_gap`을 낼 수 없고 clock jump와 같은 서명이 됐다. monotonic 기반 로컬 수신 간격을 항상 함께 관측해 가르고, `lost_samples`를 `lost_samples_lower_bound`로, `missing`을 `missingModulo`로 개명해 하한값임을 이름에 못 박았다.

**Medium 3건 반영**
- 불량 샘플에서 return만 하고 버퍼를 남겨 정상 64샘플, 공백, 정상 64샘플이 연속 신호로 FFT를 타던 경로. 불량 샘플과 수신 공백 양쪽에서 부분 버퍼를 폐기한다
- 비유한 `cortex_time`이 `datetime.fromtimestamp()`에서 예외를 내 콜백 자체를 죽이고 이후 전체 이벤트가 유실되던 경로. 블록 기록 직전 검사로 막는다. MET 비유한 값은 직전 정상값을 유지한다
- Windows 기본 콘솔 인코딩(CP949)에서 신규 `print`가 `UnicodeEncodeError`로 죽어 "계측만 끄고 측정은 계속"이라는 fallback 의도가 깨지던 문제. `logger.warning`으로 교체하고 capture 없이 CP949로 재현 검증했다

**미반영 2건**
- Medium, 128Hz 콜백 안 동기 Redis 발행: 기존 코드도 같은 콜백에서 `brain_sync_all`을 매 블록 동기 publish한다. 새 경로는 10초 throttle이라 초당 최대 0.1회로 기존 부하 대비 무시할 수준이다. 진짜 문제는 Redis 클라이언트의 25회 지수 백오프 설정이고 이번 범위 밖이다
- Low, watchdog과 CSV와 Redis 계약 테스트 부재: watchdog tick을 순수 메서드로 분리하는 리팩터가 필요해 범위를 넘는다. codex도 정적 비교로 발행 주기와 payload와 CSV 헤더와 컬럼 순서에 변경이 없음은 확인했다

## 검증

- `black`, `isort`, `flake8` clean
- pytest **228건 PASS** (기존 194 더하기 신규 34)
- 회귀 시뮬레이션: 두 방어를 `if False:`로 무력화하면 정확히 3건이 fail하는 것을 확인했다 (`test_non_finite_sample_is_dropped_before_buffer`, `test_health_republish_is_throttled`, `test_non_finite_power_block_is_not_written_to_csv`). 통과만 하는 테스트가 아니다
- CP949 stdout 조건에서 capture 없이 34건 통과

## 미검증

라이브 검증은 이번 회차에 불가능했다. 다음 측정에서 통제된 신호 중단으로 다음을 확인해야 한다.

- 2.3783초 공백 당시 COUNTER가 실제로 건너뛰는지, timestamp만 점프하는지
- 비유한 raw EEG가 실제 장비에서 발생하는지
- `receive_gap`과 `timestamp_jump` 조합이 실제 정지 사례를 정확히 가르는지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - EEG 스트림의 연속성(누락/타임스탬프 점프·역행/수신 공백) 이상을 순수 상태 기반으로 판정해 구조화 로그와 세션 요약으로 제공합니다.
  - 잘못된 EEG·MET 값 및 비정상 시간/파워는 차단·드롭하며, 부분 버퍼는 폐기해 분석·CSV 오염을 방지합니다.
  - 상태(헬스) 재발행을 기준 시간으로 제어하고, Redis 발행 실패는 측정 진행을 멈추지 않게 처리합니다.
- **테스트**
  - 연속성 계측, 복구/로그 한도, 유효성 방어, 부분 버퍼 폐기, 발행 실패 내성까지 폭넓게 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->