### PR TITLE
fix(proxy-client): 공용 httpx.Client 재사용으로 수신 백로그 해소 (#43)

### DIFF
--- a/server/services/proxy_client.py
+++ b/server/services/proxy_client.py
@@ -4,9 +4,38 @@ Emotiv Cortex SDK 콜백(동기 스레드)에서 직접 호출되므로 httpx.Cl
 AsyncClient 사용 금지 — 동기 스레드에서 이벤트 루프 없이 호출됨.
 """
 
+import threading
 import time
 
 import httpx
+
+_client_lock = threading.Lock()
+_shared_client: httpx.Client | None = None
+
+
+def get_shared_client() -> httpx.Client:
+    """모듈 공용 httpx.Client 반환함 (미생성 시 생성).
+
+    호출마다 Client를 새로 만들면 그때마다 SSL 컨텍스트를 새로 구성하며
+    certifi CA 번들 약 271KB를 다시 파싱함. PC A 실측 약 690ms 소요됨.
+    이 비용이 128샘플 블록당 1초 예산을 잠식해 수신 백로그가 초당 약 0.2초씩
+    누적됐음 (EEG-W003, 10분 측정에 약 100초 지연). 재사용 시 같은 POST가
+    약 5ms로 떨어짐.
+    """
+    global _shared_client
+    with _client_lock:
+        if _shared_client is None or _shared_client.is_closed:
+            _shared_client = httpx.Client(timeout=10)
+        return _shared_client
+
+
+def close_shared_client() -> None:
+    """공용 Client 해제함 (프로세스 종료와 테스트 격리용)"""
+    global _shared_client
+    with _client_lock:
+        if _shared_client is not None:
+            _shared_client.close()
+            _shared_client = None
 
 
 class ProxyForwardError(Exception):
@@ -26,9 +55,8 @@ def check_health(proxy_url: str, timeout: float = 5.0) -> bool:
         HTTP 200 응답 시 True, 그 외(503/비200/네트워크 오류) False 반환함.
     """
     try:
-        with httpx.Client(timeout=timeout) as client:
-            response = client.get(f"{proxy_url}/health")
-            return response.status_code == 200
+        response = get_shared_client().get(f"{proxy_url}/health", timeout=timeout)
+        return response.status_code == 200
     except httpx.RequestError:
         return False
 
@@ -135,19 +163,20 @@ def post_sample(
             time.sleep(wait_sec)
 
         try:
-            with httpx.Client(timeout=10) as client:
-                response = client.post(
-                    f"{proxy_url}/ingest/sample",
-                    headers={
-                        "X-Engine-Secret": secret_key,
-                        "Content-Type": "application/json",
-                    },
-                    json=body,
-                )
-                # 4xx/5xx 응답 시 HTTPStatusError raise함
-                response.raise_for_status()
-                # 전송 성공 — 즉시 반환함
-                return
+            # 공용 Client 재사용함 — 호출마다 생성하면 SSL 컨텍스트 재구성으로
+            # 블록당 예산을 잠식함 (get_shared_client docstring 참조)
+            response = get_shared_client().post(
+                f"{proxy_url}/ingest/sample",
+                headers={
+                    "X-Engine-Secret": secret_key,
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+            # 4xx/5xx 응답 시 HTTPStatusError raise함
+            response.raise_for_status()
+            # 전송 성공 — 즉시 반환함
+            return
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
             # 네트워크 오류 또는 상태 코드 오류 — retry 대상임
             last_exc = exc

--- a/tests/services/test_proxy_client.py
+++ b/tests/services/test_proxy_client.py
@@ -2,6 +2,8 @@
 
 import inspect
 import json
+import threading
+from typing import Any, Generator
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -310,7 +312,7 @@ def test_tracker_healthy_after_trip_resets_to_false() -> None:
 # 아래 테스트는 "호출 횟수와 무관하게 Client 생성은 1회"를 잠금.
 # ──────────────────────────────────────────────
 @pytest.fixture(autouse=True)
-def _reset_shared_client():
+def _reset_shared_client() -> Generator[None, None, None]:
     """테스트 간 공용 Client 격리함 — mock transport가 새 Client에 적용되게 함.
 
     getattr 폴백은 공용 Client가 없는 구현에서도 나머지 테스트가 정상 실행되어
@@ -324,7 +326,7 @@ def _reset_shared_client():
     reset()
 
 
-def _count_client_constructions(monkeypatch) -> list[int]:
+def _count_client_constructions(monkeypatch: pytest.MonkeyPatch) -> list[int]:
     """httpx.Client 생성 횟수를 세는 카운터 설치하고 리스트로 반환함"""
     import httpx
 
@@ -333,7 +335,7 @@ def _count_client_constructions(monkeypatch) -> list[int]:
     calls = [0]
     real_client = httpx.Client
 
-    def counting_client(*args, **kwargs):
+    def counting_client(*args: Any, **kwargs: Any) -> httpx.Client:
         calls[0] += 1
         return real_client(*args, **kwargs)
 
@@ -392,6 +394,53 @@ def test_check_health_reuses_same_client_as_post_sample(
     )
 
     assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 두 경로가 공유해야 함"
+
+
+def test_concurrent_get_shared_client_constructs_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """여러 스레드가 동시에 진입해도 Client는 1개만 생성됨을 확인함.
+
+    get_shared_client가 락 없이 None 검사와 대입을 하면 첫 호출들이 겹칠 때
+    각자 Client를 만들고 마지막 하나만 남아 나머지가 누수됨. Barrier로 동시
+    진입을 강제해 그 경합을 재현함.
+    """
+    from server.services import proxy_client
+
+    # 실물 Client 대신 더미를 세움 — 실물 생성은 CA 번들을 읽어 파일시스템에
+    # 의존하고, 이 테스트는 HTTP가 아니라 생성 횟수와 동일성만 검증함
+    calls = [0]
+
+    class _DummyClient:
+        is_closed = False
+
+        def close(self) -> None:
+            pass
+
+    def counting_client(*args: Any, **kwargs: Any) -> Any:
+        calls[0] += 1
+        return _DummyClient()
+
+    monkeypatch.setattr(proxy_client.httpx, "Client", counting_client)
+
+    thread_count = 8
+    barrier = threading.Barrier(thread_count)
+    results: list[object] = [None] * thread_count
+
+    def worker(idx: int) -> None:
+        barrier.wait()
+        results[idx] = proxy_client.get_shared_client()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert all(
+        result is results[0] for result in results
+    ), "스레드마다 다른 Client 반환됨"
+    assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 동시 진입에도 1회여야 함"
 
 
 def test_close_shared_client_allows_recreation() -> None:

--- a/tests/services/test_proxy_client.py
+++ b/tests/services/test_proxy_client.py
@@ -298,3 +298,111 @@ def test_tracker_healthy_after_trip_resets_to_false() -> None:
     assert tracker.record(False, 5.0) is False  # 첫 fail — threshold 미도달
     assert tracker.record(False, 7.999) is False  # 2999ms 미도달
     assert tracker.record(False, 8.0) is True  # 3000ms 도달 — True
+
+
+# ──────────────────────────────────────────────
+# T-PC-8: Client 재사용 회귀 (EEG-W003)
+#
+# 결함: post_sample이 호출마다 httpx.Client를 새로 만들어 매번 SSL 컨텍스트를
+# 재구성했고, PC A 실측 약 690ms가 소요됐음. 128샘플 블록당 1초 예산을 잠식해
+# Cortex 수신 백로그가 초당 약 0.2초씩 누적됐음(10분 측정에 약 100초 지연).
+# 실측 근거: httpx.Client() 생성만 694ms, 재사용 시 POST 왕복 5.3ms.
+# 아래 테스트는 "호출 횟수와 무관하게 Client 생성은 1회"를 잠금.
+# ──────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _reset_shared_client():
+    """테스트 간 공용 Client 격리함 — mock transport가 새 Client에 적용되게 함.
+
+    getattr 폴백은 공용 Client가 없는 구현에서도 나머지 테스트가 정상 실행되어
+    본 회귀 테스트가 AttributeError가 아니라 생성 횟수로 실패하게 하려는 것임.
+    """
+    from server.services import proxy_client
+
+    reset = getattr(proxy_client, "close_shared_client", lambda: None)
+    reset()
+    yield
+    reset()
+
+
+def _count_client_constructions(monkeypatch) -> list[int]:
+    """httpx.Client 생성 횟수를 세는 카운터 설치하고 리스트로 반환함"""
+    import httpx
+
+    from server.services import proxy_client
+
+    calls = [0]
+    real_client = httpx.Client
+
+    def counting_client(*args, **kwargs):
+        calls[0] += 1
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(proxy_client.httpx, "Client", counting_client)
+    return calls
+
+
+def test_post_sample_reuses_single_client(httpx_mock: HTTPXMock, monkeypatch) -> None:
+    """post_sample 3회 호출 시 httpx.Client 생성은 1회뿐임을 확인함"""
+    from server.services import proxy_client
+
+    monkeypatch.setattr(proxy_client.time, "monotonic_ns", lambda: FIXED_TS_NS)
+    calls = _count_client_constructions(monkeypatch)
+
+    for _ in range(3):
+        httpx_mock.add_response(url=INGEST_SAMPLE_URL, method="POST", status_code=200)
+
+    for seq in range(3):
+        proxy_client.post_sample(
+            proxy_url=MOCK_PROXY_URL,
+            secret_key=MOCK_SECRET_KEY,
+            group_id=MOCK_GROUP_ID,
+            subject_idx=MOCK_SUBJECT_IDX,
+            seq=seq,
+            payload=MOCK_PAYLOAD,
+            sync_meta=MOCK_SYNC_META,
+        )
+
+    assert len(httpx_mock.get_requests(url=INGEST_SAMPLE_URL)) == 3
+    assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 호출마다 생성하면 안 됨"
+
+
+def test_check_health_reuses_same_client_as_post_sample(
+    httpx_mock: HTTPXMock, monkeypatch
+) -> None:
+    """check_health와 post_sample이 같은 Client를 공유함을 확인함"""
+    from server.services import proxy_client
+
+    monkeypatch.setattr(proxy_client.time, "monotonic_ns", lambda: FIXED_TS_NS)
+    calls = _count_client_constructions(monkeypatch)
+
+    httpx_mock.add_response(
+        url=f"{MOCK_PROXY_URL}/health", method="GET", status_code=200
+    )
+    httpx_mock.add_response(url=INGEST_SAMPLE_URL, method="POST", status_code=200)
+
+    assert proxy_client.check_health(MOCK_PROXY_URL) is True
+    proxy_client.post_sample(
+        proxy_url=MOCK_PROXY_URL,
+        secret_key=MOCK_SECRET_KEY,
+        group_id=MOCK_GROUP_ID,
+        subject_idx=MOCK_SUBJECT_IDX,
+        seq=MOCK_SEQ,
+        payload=MOCK_PAYLOAD,
+        sync_meta=MOCK_SYNC_META,
+    )
+
+    assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 두 경로가 공유해야 함"
+
+
+def test_close_shared_client_allows_recreation() -> None:
+    """close 후 재요청 시 새 Client가 생성되어 재사용 가능함을 확인함"""
+    from server.services import proxy_client
+
+    first = proxy_client.get_shared_client()
+    assert proxy_client.get_shared_client() is first
+
+    proxy_client.close_shared_client()
+
+    second = proxy_client.get_shared_client()
+    assert second is not first
+    assert second.is_closed is False

--- a/tests/services/test_proxy_client.py
+++ b/tests/services/test_proxy_client.py
@@ -426,10 +426,14 @@ def test_concurrent_get_shared_client_constructs_once(
     thread_count = 8
     barrier = threading.Barrier(thread_count)
     results: list[object] = [None] * thread_count
+    errors: list[tuple[int, BaseException]] = []
 
     def worker(idx: int) -> None:
-        barrier.wait()
-        results[idx] = proxy_client.get_shared_client()
+        try:
+            barrier.wait()
+            results[idx] = proxy_client.get_shared_client()
+        except BaseException as exc:  # 진단 목적으로 캡처함
+            errors.append((idx, exc))
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(thread_count)]
     for thread in threads:
@@ -437,6 +441,7 @@ def test_concurrent_get_shared_client_constructs_once(
     for thread in threads:
         thread.join()
 
+    assert not errors, f"워커 스레드에서 예외 발생: {errors}"
     assert all(
         result is results[0] for result in results
     ), "스레드마다 다른 Client 반환됨"


### PR DESCRIPTION
## 원인

`post_sample`과 `check_health`가 호출마다 `httpx.Client`를 새로 만들었다. Client 생성은 SSL 컨텍스트를 새로 구성하고 certifi CA 번들 약 271KB를 다시 파싱한다. 평문 HTTP로 로컬 프록시에 보내면서 쓰지도 않을 신뢰 저장소를 매번 읽고 있었다.

PC A 실측 분해:

| 항목 | 중앙값 |
|---|---|
| `httpx.Client()` 생성만 (요청 없음) | 694 밀리초 |
| `ssl.create_default_context()` | 688 밀리초 |
| `httpx.Client(verify=False)` 생성 | 0.8 밀리초 |
| Client 재사용 더하기 POST | 5.3 밀리초 |

`post_sample`은 128샘플 블록당 1회, `check_health`는 초당 1회 돈다. 즉 초당 두 번 SSL 컨텍스트를 만들면서 블록당 1초 예산을 잠식했고, 수신 백로그가 초당 약 0.2초씩 누적됐다(10분 측정에 약 100초 지연).

퇴행이 아니라 `7a9ce1d`(2026-05-17)에서 `post_sample`이 도입될 때부터 있던 결함이다.

## 변경

모듈 공용 `httpx.Client` 하나를 지연 생성해 재사용한다. `get_shared_client()`가 락 아래에서 단일 인스턴스를 반환하고 두 함수가 공유한다. `check_health`의 5초 타임아웃은 요청별 인자로 넘겨 기존 동작을 보존했다. `close_shared_client()`는 프로세스 종료와 테스트 격리용이다.

`AsyncClient`를 쓰지 않는 기존 제약은 그대로다 — Emotiv Cortex SDK 콜백이 이벤트 루프 없는 동기 스레드에서 호출한다.

## 효과

블록당 비용 869 밀리초에서 **7.76 밀리초** (1초 예산의 87%에서 0.8%).

## 검증

회귀 테스트 3건을 추가했고 **옛 코드에서 실제로 실패하는 것을 확인**했다(`3 == 1`, `2 == 1`). 기존 12건은 옛 코드에서도 통과하므로 새 테스트가 이 결함만 정확히 잡는다.

검증 루프 4단계 통과 — black, isort, flake8, **pytest 259 passed**.

**2 PC 실기기 3분 측정으로 확인했다.** 합격 기준은 `clockSkewSec`가 시간에 따라 선형 증가하지 않는 것이다(결함 상태 기울기 0.203 초/초).

| | clockSkewSec 추이 | 초당 CSV 행 | dropped |
|---|---|---|---|
| PC A (결함이 나던 쪽) | 0.227 → 0.235 → 0.227 → 0.223 → 0.168 → 0.207 | 0.97 | 0 |
| 노트북 B | 0.256 → 0.211 → 0.212 → 0.229 → 0.222 → 0.211 | 0.99 | 0 |

양쪽 모두 평평하고 `eegEvents`가 초당 128로 정확히 붙는다.

## 남은 것

- `register_to_proxy`가 20초마다 `AsyncClient`를 새로 만드는 같은 계열 결함이 `server/services/webhook.py:119`에 있다. 별도 PR로 분리했다(OPS-W005). 모듈 전역이 아니라 lifespan이 소유하고 인자로 주입하는 설계로 간다.
- 690 밀리초 두 번이면 손실률이 100%를 넘어야 하는데 실측은 22%였다. GIL 부분 겹침 가능성이 있으나 미확정으로 남긴다. 690 밀리초는 정상 상태 수치가 아니라 상한으로 읽을 것.

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * HTTP 요청 처리 성능과 연결 재사용성을 개선했습니다.
  * 반복 요청에서 공유 클라이언트를 안정적으로 재사용하며, 종료되거나 필요한 경우 새 클라이언트를 자동으로 생성합니다.
  * 동시 요청에서도 클라이언트가 효율적으로 관리됩니다.
  * 기존 HTTP 오류 처리, 재시도 및 백오프 동작은 유지됩니다.

* **테스트**
  * 클라이언트 재사용, 종료 후 재생성, 상태 확인과 요청 간 공유 동작을 검증하는 회귀 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->