### PR TITLE
release: 대역 파워 Welch PSD 전환과 프록시 클라이언트 재사용

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,20 @@ Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>
 
 - **FAA (Frontal Alpha Asymmetry)** — 좌우 전두엽 알파파 비대칭, 감정 접근/회피 지표
 - **5대역 파워** — delta(0.5-4Hz), theta(4-8Hz), alpha(8-12Hz), beta(13-30Hz), gamma(30-45Hz)
-- **RMS Power** — 필터링된 신호의 Root Mean Square, 각 대역 강도
+- **RMS Power** — 각 대역 강도를 Root Mean Square(uV)로 표현한 값
+
+### 대역 파워 산출 계약 (ANALYSIS-W001, 2026-07-31)
+
+- **산출 방식은 PSD 대역 합산이다.** `welch(nperseg=창길이, detrend=False)`로 PSD를 구하고 대역 빈을 합산한 뒤 빈 간격을 곱해 제곱근을 취한다. **대역통과 필터뱅크로 되돌리지 말 것** — 인과 필터는 128샘플 창에서 초기조건 0 과도응답이 창 전체를 지배해 대역 파워가 뇌파가 아니라 DC 약 4200uV에 비례하는 상수로 나왔고(alpha 200 고정 결함), 영위상 필터로 바꿔도 시작 위상에 따라 회복률이 94.4에서 97.7%로 흔들려 위상 안정성 테스트가 실패한다.
+- **평균화가 없는 단일 세그먼트다.** `nperseg`가 창 전체와 같으므로 이름은 Welch지만 실체는 Hann 창 피리오도그램이다. 창당 추정 분산이 크다(백색잡음 실측 변동계수 0.31). 세션 평균 지표는 수백 창 평균이라 무해하나, 동조율은 창 단위 시계열 상관이라 이 잡음이 상관을 다소 감쇠시킨다. 겹침 평균은 이미 취약한 delta 해상도를 더 깎으므로 택하지 않았다.
+- **적분은 직사각형 합이다.** 사다리꼴(`np.trapezoid`)로 바꾸지 말 것. 사다리꼴은 대역 경계 빈 가중치를 절반으로 깎아 delta 1Hz 회복률을 91.3%에서 70.7%로 떨어뜨린다. `test_delta_recovery_pins_rectangular_quadrature`가 이 계약을 지킨다(대역 중앙 톤은 두 방식 결과가 같아 판별에 못 쓴다). 빈 간격을 곱하는 스케일 인자는 `test_bin_width_scaling_holds_for_non_unit_resolution`이 2초 창으로 지킨다 — 1초 창은 빈 간격이 정확히 1.0이라 곱을 빼도 값이 같다.
+- **RMS 환산은 근사다.** PSD 빈 합에 빈 간격을 곱한 값은 정확히는 Hann 제곱 가중 평균이라 단순 평균 제곱과 다르다. 정상 신호에서 근사 성립하고 대역 중앙 정현파에서는 정확히 일치하나, 추세가 강한 신호에서는 어긋난다(랜덤워크 실측 비율 0.33, 백색잡음 1.18). 상대 비교용 지표로 쓰고 절대 교정값으로 쓰지 말 것.
+- **RMS 규모** — 정상 측정에서 한 자리수에서 십 단위다. 20uV 알파 정현파 1초 창의 alpha는 14.14(참값의 100%)다. 세 자리수(예: alpha 200 고정)가 나오면 DC 오프셋 또는 인과 필터 과도응답 결함이다. 라이브 뇌파의 절대 규모는 실기기 검증 전까지 미확인이므로 위 수치는 합성 신호 기준이다.
+- **delta 정확도 주의** — 1초 창에서 회복률이 2Hz 이상은 100%이나 1Hz 91.3%, 0.7Hz 64.1%로 떨어진다. 원인은 1Hz 빈 해상도이며 창을 늘려야만 개선된다. 대역 하한 근처 성분은 과소평가되므로 대역 간 비교와 유사도 해석에 주의한다.
+- **대역 경계 겹침** — 경계는 닫힌 구간이라 4Hz, 8Hz, 30Hz 빈이 인접 두 대역에 모두 계산된다. 연속 스펙트럼에서는 경계 빈이 항상 존재하므로 **이 중복은 예외가 아니라 상시 발생**하며, 광대역 신호에서 대역별 값의 합은 전체 파워보다 크다. 다만 두 피실험자에게 동일하게 걸리는 왜곡이라 방향성 편향이 없고 코사인 유사도 영향은 1e-4 수준으로 실측됐다. 중앙 주파수 정확도를 위한 의도된 선택이며 `test_band_edges_are_closed_intervals`가 고정한다.
+- **제거된 API** — `filter_delta`부터 `filter_gamma`까지 5개 메서드와 `_butter_bandpass`와 `get_rms_power`는 제거됐다(Welch 경로에 "필터링된 시계열"이라는 중간 산출물이 없어 전부 호출자 0건이었음). 대체는 `get_band_power(values, band)`다.
+- **짧은 창 금지** — 128샘플 미만은 빈 간격이 넓어져 대역에 빈이 안 잡히고 예외 없이 0.0이나 무의미한 값이 나온다(길이 16에서 theta와 alpha가 나란히 11.86). `_band_powers_from` 진입부에서 `ValueError`로 막으므로 `get_all_powers`와 `get_band_power` 모두 보호된다. 라이브 경로는 `streamer`가 비오버랩으로 버퍼를 비워 항상 128이다.
+- **DC 제거자는 하나다** — `_remove_dc`가 유일하며 `welch`는 `detrend=False`로 부른다. 둘을 겹쳐 두면 어느 쪽을 없애도 결과가 같아져 회귀 테스트가 무력해진다. 상수 DC 입력 테스트가 이 계약을 지킨다.
 - **Synchrony** — 두 피실험자 간 뇌파 상관계수 (Pearson correlation)
 - **EmotivMetrics (MET)** — Emotiv 자체 산출 지표 6종 (focus, engagement, interest, excitement, stress, relaxation)
 - **Cortex API** — Emotiv 헤드셋과 WebSocket(wss://localhost:6868) JSON-RPC 인터페이스
@@ -238,7 +251,7 @@ mind-signal은 4레포 멀티레포 제품이므로 계획 산출물 `.plans/`�
 
 - 현재 작업 정본: `mind-signal/.plans/DASHBOARD.md`
 - 세션 핸드오프 정본: `mind-signal/.plans/HANDOFF.md` (대체 시 `_archive/HANDOFF-YYYYMMDD.md`)
-- ID와 상태 규칙 정본: `mind-signal/.plans/README.md` (v1.3, LOCK 대기 — 주체는 사용자)
+- ID와 상태 규칙 정본: `mind-signal/.plans/README.md` (v1.3, **LOCK** — 2026-07-31 사용자 승인)
 - 소급 W-ID 매핑 정본: `mind-signal/.plans/LEGACY-REGISTRY.md`
 - 작업 폴더: `mind-signal/.plans/{WORK-ID}[-{slug}]` (예: `ANALYSIS-W001-eeg-dc-offset-removal`)
 - 상태 서술: `mind-signal/.plans/STATE.md`

--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -1,8 +1,29 @@
 import numpy as np
-from scipy.signal import butter, lfilter, welch
+from scipy.signal import welch
 
 
 class MindSignalAnalyzer:
+    """EEG 대역 파워와 파생 지표 산출함.
+
+    대역 파워는 대역통과 필터뱅크가 아니라 Welch PSD 대역 합산으로 구함.
+    필터뱅크로 되돌리지 말 것 — 인과 필터는 128샘플 창에서 초기조건 0
+    과도응답이 창 전체를 지배해 DC 크기에 비례하는 상수를 출력했고(alpha가
+    항상 200 근처로 고정된 결함의 원인), 영위상 필터로 바꿔도 시작 위상에
+    따라 회복률이 94.4에서 97.7%로 흔들림. 상세는 ANALYSIS-W001 참조.
+    """
+
+    BANDS: dict[str, tuple[float, float]] = {
+        "delta": (0.5, 4.0),
+        "theta": (4.0, 8.0),
+        "alpha": (8.0, 12.0),
+        "beta": (13.0, 30.0),
+        "gamma": (30.0, 45.0),
+    }
+
+    # 이보다 짧은 창은 빈 간격이 넓어져 대역에 빈이 하나도 안 잡히고
+    # 예외 없이 0.0이 반환됨. 하류 유한성 검사가 그 0을 통과시키므로 막음
+    MIN_WINDOW_SAMPLES: int = 128
+
     @staticmethod
     def calculate_faa(eeg_data, ch_left_idx, ch_right_idx):
         """
@@ -13,7 +34,9 @@ class MindSignalAnalyzer:
         fs = 128  # Emotiv Insight 샘플링 레이트
         freqs, psd = welch(eeg_data, fs, nperseg=fs * 2)
 
-        # 2. Alpha 대역(8-13Hz) 추출
+        # 2. Alpha 대역(8-13Hz) 추출.
+        # 주의: BANDS의 alpha는 8-12Hz인데 여기는 8-13Hz임. FAA 문헌 관례를
+        # 따른 것이라 의도적 불일치임. 현재 파이프라인에서 미호출 상태임
         alpha_mask = (freqs >= 8) & (freqs <= 13)
         alpha_power = np.mean(psd[:, alpha_mask], axis=1)
 
@@ -30,45 +53,119 @@ class MindSignalAnalyzer:
         correlation = np.corrcoef(user1_eeg, user2_eeg)[0, 1]
         return correlation
 
-    def __init__(self, sampling_rate=128):
-        # Emotiv Insight의 샘플링 레이트는 초당 128Hz입니다.
+    def __init__(self, sampling_rate: int = 128) -> None:
+        # Emotiv Insight의 샘플링 레이트는 초당 128Hz임
         self.fs = sampling_rate
 
-    def _butter_bandpass(self, lowcut, highcut, order=5):
-        """버터워스 필터 계수 계산"""
-        nyq = 0.5 * self.fs
-        low = lowcut / nyq
-        high = highcut / nyq
-        b, a = butter(order, [low, high], btype="band")
-        return b, a
+    @staticmethod
+    def _remove_dc(eeg_values: np.ndarray) -> np.ndarray:
+        """창별 평균을 빼서 DC 오프셋 제거함.
 
-    # --- 5가지 주요 파형 필터 ---
-    def filter_delta(self, data):
-        return lfilter(*self._butter_bandpass(0.5, 4), data)
+        Emotiv Insight의 부동 DC 준위는 약 4200uV이며 제조사 문서가 FFT류
+        분석 전 DC 제거를 요구함. **이 단계가 파이프라인의 유일한 DC 제거자임**
+        — welch는 detrend=False로 호출함. 제거자를 하나로 두어야 이 줄이
+        실제로 부하를 지고 상수 입력 회귀 테스트가 그것을 지킴(둘을 겹쳐 두면
+        어느 쪽을 없애도 결과가 같아 테스트가 무력해짐).
 
-    def filter_theta(self, data):
-        return lfilter(*self._butter_bandpass(4, 8), data)
+        Args:
+            eeg_values: 1차원 EEG 시계열임
 
-    def filter_alpha(self, data):
-        return lfilter(*self._butter_bandpass(8, 12), data)
+        Returns:
+            평균이 0인 시계열 반환
+        """
+        data = np.asarray(eeg_values, dtype=float)
+        return data - np.mean(data)
 
-    def filter_beta(self, data):
-        return lfilter(*self._butter_bandpass(13, 30), data)
+    def _band_rms(self, freqs: np.ndarray, psd: np.ndarray, band: str) -> float:
+        """대역 PSD를 합산해 RMS 진폭으로 환산함.
 
-    def filter_gamma(self, data):
-        return lfilter(*self._butter_bandpass(30, 45), data)
+        PSD 빈 합에 빈 간격을 곱한 값의 제곱근을 대역 RMS(uV)로 씀. 정확히는
+        창(Hann) 제곱 가중 평균이라 단순 평균 제곱과 같지 않음 — 정상 신호에서
+        근사 성립하고 대역 중앙 정현파에서는 정확히 일치하나, 추세가 강한
+        신호에서는 어긋남(랜덤워크 실측 비율 0.33). 절대 교정값이 필요한
+        용도에는 그대로 쓰지 말 것.
 
-    def get_rms_power(self, filtered_data):
-        """필터링된 신호의 강도(RMS) 계산"""
-        # 신호의 크기를 수치화하여 '현재 알파파가 얼마나 강한지' 판단할 때 씁니다.
-        return np.sqrt(np.mean(np.square(filtered_data)))
+        사다리꼴(np.trapezoid)이 아니라 직사각형 합을 쓰는 이유: 사다리꼴은
+        대역 경계 빈 가중치를 절반으로 깎아 delta 1Hz 회복률을 91.3%에서
+        70.7%로 떨어뜨림. 회귀 테스트가 이 값으로 고정함.
 
-    def get_all_powers(self, eeg_values):
-        """5개 파형의 강도를 한 번에 계산하여 반환"""
-        return {
-            "delta": self.get_rms_power(self.filter_delta(eeg_values)),
-            "theta": self.get_rms_power(self.filter_theta(eeg_values)),
-            "alpha": self.get_rms_power(self.filter_alpha(eeg_values)),
-            "beta": self.get_rms_power(self.filter_beta(eeg_values)),
-            "gamma": self.get_rms_power(self.filter_gamma(eeg_values)),
-        }
+        대역 경계는 닫힌 구간이라 경계 빈이 인접 두 대역에 모두 계산됨.
+        광대역 신호에서 대역별 값의 합이 전체보다 커지지만, 두 피실험자에
+        동일하게 걸리는 왜곡이라 코사인 유사도 영향은 1e-4 수준임.
+
+        Args:
+            freqs: welch가 반환한 주파수 축임
+            psd: welch가 반환한 전력 스펙트럼 밀도임
+            band: BANDS의 키임
+
+        Returns:
+            해당 대역의 RMS 진폭(uV) 반환
+        """
+        low, high = self.BANDS[band]
+        mask = (freqs >= low) & (freqs <= high)
+        if not mask.any():
+            return 0.0
+        bin_width = float(freqs[1] - freqs[0])
+        return float(np.sqrt(np.sum(psd[mask]) * bin_width))
+
+    def _band_powers_from(self, eeg_values: np.ndarray) -> dict[str, float]:
+        """단일 welch 호출로 5대역 RMS 산출함.
+
+        nperseg를 창 전체로 두므로 세그먼트가 1개임. 즉 평균화가 있는 Welch가
+        아니라 **Hann 창 피리오도그램**이며 창당 추정 분산이 큼(백색잡음 실측
+        변동계수 0.31). 세션 평균 지표는 수백 창 평균이라 무해하나 동조율은
+        창 단위 시계열 상관이라 이 잡음이 상관을 0쪽으로 다소 감쇠시킴.
+        겹침 평균(nperseg를 절반으로)은 이미 취약한 delta 해상도를 더 깎으므로
+        택하지 않음.
+
+        detrend=False인 이유: DC 제거는 _remove_dc 한 곳에서만 함.
+
+        Raises:
+            ValueError: 창이 MIN_WINDOW_SAMPLES 미만임
+        """
+        data = self._remove_dc(eeg_values)
+        if data.size < self.MIN_WINDOW_SAMPLES:
+            raise ValueError(
+                f"창은 {self.MIN_WINDOW_SAMPLES}샘플 이상이어야 함. "
+                f"받은 길이 {data.size}"
+            )
+        freqs, psd = welch(
+            data,
+            fs=self.fs,
+            nperseg=len(data),
+            detrend=False,
+            scaling="density",
+        )
+        return {band: self._band_rms(freqs, psd, band) for band in self.BANDS}
+
+    def get_all_powers(self, eeg_values: np.ndarray) -> dict[str, float]:
+        """5개 대역의 RMS 강도를 한 번에 계산해 반환함.
+
+        Args:
+            eeg_values: 길이 MIN_WINDOW_SAMPLES 이상의 1차원 EEG 시계열임
+                (채널 공간 평균)
+
+        Returns:
+            delta, theta, alpha, beta, gamma를 키로 하는 RMS(uV) dict 반환
+
+        Raises:
+            ValueError: 창이 MIN_WINDOW_SAMPLES 미만임
+        """
+        return self._band_powers_from(eeg_values)
+
+    def get_band_power(self, eeg_values: np.ndarray, band: str) -> float:
+        """단일 대역 RMS 반환함. 제거된 filter_* 계열의 대체 진입점임.
+
+        Args:
+            eeg_values: 길이 MIN_WINDOW_SAMPLES 이상의 1차원 EEG 시계열임
+            band: BANDS의 키임
+
+        Returns:
+            해당 대역의 RMS 진폭(uV) 반환
+
+        Raises:
+            ValueError: 창이 너무 짧거나 미등록 대역임
+        """
+        if band not in self.BANDS:
+            raise ValueError(f"미등록 대역 {band}")
+        return self._band_powers_from(eeg_values)[band]

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -790,11 +790,11 @@ class MindSignalStreamer(Cortex):
             # 공간(채널) 평균을 내어 1차원 시간 신호(길이 128)로 변환함
             mean_eeg_time_series = np.mean(buffer_arr, axis=1)
 
-            # 시계열 데이터를 필터에 통과시켜 파워 대역 계산함
+            # 시계열 데이터의 PSD를 구해 대역 파워 계산함
             powers = self.analyzer.get_all_powers(mean_eeg_time_series)
 
-            # 필터는 대역별 독립 계산이라 샘플이 전부 유한해도 overflow로 한
-            # 대역만 비유한이 될 수 있음. 그 행은 쓰지 않고 버림 — coverage 계약이
+            # 5대역이 같은 PSD를 공유하므로 비유한 입력은 전 대역에 전파됨
+            # (실측 확인). 그 행은 쓰지 않고 버림 — coverage 계약이
             # "요청 대역 중 하나라도 비유한이면 그 초 전체 무효"라 어차피 못 씀.
             # 시각도 함께 검사함. 불량 cortex_time은 fromtimestamp()에서 예외를 내
             # 콜백 자체를 죽임 (이후 이벤트가 전부 유실됨). 유한성만으로는 부족해서

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -47,7 +47,14 @@ COUNTER_MODULUS = 128
 # clock jump로 판정함. 0.5초는 CSV 1행(1초) 절반이라 행 단위 결측 직전에 잡힘.
 TIMESTAMP_JUMP_TOLERANCE_SEC = 0.5
 # 같은 종류의 이상을 무한히 찍지 않기 위한 상한임. 초과분은 개수만 세어 종료 요약에 남김.
+# 주의: 이 상한은 개별 이벤트에만 걸리고 stream_rollup에는 걸리지 않음. 상한만
+# 두면 초반에 소진돼 이후 구간이 통째로 무기록이 됨(2026-07-31 실측: receive_gap
+# 20건이 4.1초에서 29.1초 사이에 소진, 이후 6분 무기록).
 CONTINUITY_LOG_CAP_PER_KIND = 20
+# 롤업 주기임. 상한 없이 전 구간의 추이를 남기는 유일한 경로라 너무 길면
+# 사건 발생 구간을 좁히지 못하고, 너무 짧으면 로그가 불필요하게 늘어남.
+# 10분 측정 기준 20줄이라 부담이 없음.
+CONTINUITY_ROLLUP_INTERVAL_SEC = 30
 # 매 샘플 발생 가능한 경보의 재발행 최소 간격임. BE도 같은 status 연속 수신을
 # 억제하지만(stream-health.service.ts), Redis에 초당 128건을 던질 이유가 없음.
 HEALTH_REPUBLISH_INTERVAL_SEC = 10
@@ -373,6 +380,9 @@ class MindSignalStreamer(Cortex):
         self.dropped_samples = 0
         self.dropped_blocks = 0
         self._continuity_log_counts: dict[str, int] = {}
+        # 직전 롤업 시점의 이상 누적치임. 구간 증분 계산용
+        self._rollup_prev_counts: dict[str, int] = {}
+        self._rollup_active = False
         self._health_published_at: dict[str, float] = {}
         self._last_event_monotonic: float | None = None
         self._eeg_stale = False
@@ -537,6 +547,9 @@ class MindSignalStreamer(Cortex):
         self._watchdog_active = True
         self._start_watchdog()
 
+        # 30초 롤업 시작함 (상한 없는 전 구간 추이 기록)
+        self._start_rollup_thread()
+
         # proxy 모드 시 health 폴링 데몬 시작함
         if self.alignment_location == "proxy":
             self._start_proxy_health_monitor()
@@ -698,6 +711,66 @@ class MindSignalStreamer(Cortex):
                     "met_value_rejected",
                     {"metric": key, "value": repr(data[index])},
                 )
+
+    def _start_rollup_thread(self) -> None:
+        """30초 주기 롤업 스레드 기동함.
+
+        개별 이벤트 로그는 종류별 상한에 걸려 초반에 소진됨. 2026-07-31 회차는
+        receive_gap 20건을 측정 4.1초에서 29.1초 사이에 다 써버려 이후 6분이
+        무기록이었고, 그래서 subject 1의 전달 지연 누적을 사후에 볼 수 없었음.
+
+        이 롤업은 상한을 적용하지 않고 전 구간을 덮음. 콜백이 아니라 별도
+        스레드인 이유: 스트림이 완전히 멎으면 콜백이 안 오므로 콜백 기반
+        롤업은 바로 그 순간부터 침묵함. 스레드는 계속 찍으며 csvRows가 멈춘
+        것을 보여줌.
+        """
+        self._rollup_active = True
+
+        def loop() -> None:
+            while self._rollup_active:
+                time.sleep(CONTINUITY_ROLLUP_INTERVAL_SEC)
+                if not self._rollup_active:
+                    break
+                try:
+                    self._log_rollup()
+                except Exception as e:  # 롤업 실패가 측정을 멈추면 안 됨
+                    logger.warning(f"[CONTINUITY] 롤업 실패 (무시): {e}")
+
+        threading.Thread(target=loop, daemon=True, name="continuity-rollup").start()
+
+    def _log_rollup(self) -> None:
+        """직전 구간의 누적 지표를 상한 없이 1행으로 남김.
+
+        clockSkewSec가 핵심 필드임. 로컬 현재 시각에서 마지막 Cortex 취득
+        시각을 뺀 값이라, 이 값이 선형 증가하면 전달이 실시간보다 느려 지연이
+        쌓이는 것이고(2026-07-31 증상), 계단식으로 튀면 스트림이 멎은 것임.
+        """
+        now = time.time()
+        last_cortex = self.continuity.prev_time
+        skew = None if last_cortex is None else round(now - last_cortex, 3)
+        counts = dict(self._continuity_log_counts)
+        delta_counts = {
+            k: v - self._rollup_prev_counts.get(k, 0)
+            for k, v in counts.items()
+            if v - self._rollup_prev_counts.get(k, 0) > 0
+        }
+        self._rollup_prev_counts = counts
+
+        record = {
+            "kind": "stream_rollup",
+            "groupId": self.group_id,
+            "subjectIndex": self.subject_index,
+            "elapsedSec": round(now - self.start_time, 1),
+            "csvRows": self.csv_rows_written,
+            "eegEvents": self.continuity.events_seen,
+            # 로컬 시각과 Cortex 시각의 차이임. 지연 누적 판별의 핵심 지표
+            "clockSkewSec": skew,
+            "droppedSamples": self.dropped_samples,
+            "droppedBlocks": self.dropped_blocks,
+            # 이번 구간에 새로 발생한 이상만. 전체 누적은 종료 summary에 있음
+            "anomalyDelta": delta_counts,
+        }
+        logger.warning("[CONTINUITY] %s", json.dumps(record))
 
     def _log_continuity(self, kind: str, payload: dict) -> None:
         """연속성 이벤트를 구조화 로그 1행으로 남김 (종류별 상한 적용).
@@ -961,6 +1034,14 @@ class MindSignalStreamer(Cortex):
 
     def on_close(self, *args, **kwargs):
         self._watchdog_active = False
+        # 마지막 구간(직전 롤업 이후)을 남기고 스레드를 멈춤. 순서가 중요함 —
+        # 먼저 끄면 30초 미만의 꼬리 구간이 통째로 사라짐
+        if getattr(self, "_rollup_active", False):
+            try:
+                self._log_rollup()
+            except Exception as e:
+                logger.warning(f"[CONTINUITY] 종료 롤업 실패 (무시): {e}")
+            self._rollup_active = False
         elapsed = time.time() - self.start_time if hasattr(self, "start_time") else 0
 
         # 총 EEG 이벤트 대비 CSV 행 수를 남김. 128 이벤트당 1행이 정상이라

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -51,6 +51,11 @@ CONTINUITY_LOG_CAP_PER_KIND = 20
 # 매 샘플 발생 가능한 경보의 재발행 최소 간격임. BE도 같은 status 연속 수신을
 # 억제하지만(stream-health.service.ts), Redis에 초당 128건을 던질 이유가 없음.
 HEALTH_REPUBLISH_INTERVAL_SEC = 10
+# Emotiv Insight의 뇌파 채널임. CSV 채널별 컬럼 순서의 정본이며, 실제 헤드셋에
+# 일부 채널이 없어도 헤더는 이 순서 그대로 고정함(스키마 안정성).
+TARGET_EEG_CHANNELS = ["AF3", "T7", "Pz", "T8", "AF4"]
+# 대역별 컬럼 순서의 정본임. analyzer.BANDS와 같은 순서를 유지함.
+BAND_NAMES = ["delta", "theta", "alpha", "beta", "gamma"]
 
 
 class StreamContinuityTracker:
@@ -334,25 +339,29 @@ class MindSignalStreamer(Cortex):
         self.csv_file = open(self.csv_path, "w", newline="", encoding="utf-8")
         self.writer = csv.writer(self.csv_file)
 
+        # 앞 12열은 기존 스키마 그대로 유지함. 하류(엔진 분석, markdown, 유사도,
+        # BE coverage)가 이 이름들을 화이트리스트로 읽으므로 순서와 이름을
+        # 바꾸지 않음. 5대역 값은 채널 공간 평균 기준임.
+        # 뒤 25열은 채널별 대역 파워임. 부위별 분석을 위해 평균 전 값을 함께 남김.
+        # 미지 컬럼은 하류 화이트리스트 파서가 무시하므로 추가로 인한 회귀가 없음.
         header = [
             "timestamp",
-            "delta",
-            "theta",
-            "alpha",
-            "beta",
-            "gamma",
+            *BAND_NAMES,
             "focus",
             "engagement",
             "interest",
             "excitement",
             "stress",
             "relaxation",
+            *[f"{ch}_{band}" for ch in TARGET_EEG_CHANNELS for band in BAND_NAMES],
         ]
         self.writer.writerow(header)
 
         # 4. 런타임 매핑, 상태 변수 및 버퍼 초기화 수행함
         self.met_map = {}
         self.eeg_channel_indices = []
+        # eeg_channel_indices와 같은 순서의 채널 이름임. 버퍼 열과 채널을 잇는 키임
+        self.eeg_channel_names = []
         self.eeg_buffer = []
 
         # 스트림 연속성 계측 상태 초기화함 (P0-1). COUNTER와 INTERPOLATED 인덱스는
@@ -485,11 +494,20 @@ class MindSignalStreamer(Cortex):
                 print(f"[WARN] MET 라벨 미발견: {missing} (labels={labels})")
 
         elif stream_name == "eeg":
-            target_eeg_channels = ["AF3", "T7", "Pz", "T8", "AF4"]
+            # 이름과 인덱스를 같은 순서로 함께 보존함. 채널이 하나라도 빠지면
+            # 인덱스 목록만으로는 버퍼 열이 어느 채널인지 알 수 없어 채널별
+            # 대역 파워를 잘못된 컬럼에 쓰게 됨
+            self.eeg_channel_names = [ch for ch in TARGET_EEG_CHANNELS if ch in labels]
             self.eeg_channel_indices = [
-                labels.index(ch) for ch in target_eeg_channels if ch in labels
+                labels.index(ch) for ch in self.eeg_channel_names
             ]
-            print(f"EEG 채널 인덱스 매핑 완료됨: {self.eeg_channel_indices}")
+            print(
+                f"EEG 채널 인덱스 매핑 완료됨: "
+                f"{dict(zip(self.eeg_channel_names, self.eeg_channel_indices))}"
+            )
+            missing_eeg = [ch for ch in TARGET_EEG_CHANNELS if ch not in labels]
+            if missing_eeg:
+                print(f"[WARN] EEG 채널 미발견: {missing_eeg} (해당 컬럼은 공란임)")
 
             # 연속성 계측용 메타 채널 인덱스 확보함. 없으면 계측만 비활성되고
             # 측정 자체는 그대로 진행함.
@@ -793,6 +811,14 @@ class MindSignalStreamer(Cortex):
             # 시계열 데이터의 PSD를 구해 대역 파워 계산함
             powers = self.analyzer.get_all_powers(mean_eeg_time_series)
 
+            # 평균으로 뭉개기 전 채널별 대역 파워도 함께 산출함. 부위별 분석
+            # (예: 전두엽 알파 대 후두엽 알파)이 평균값만으로는 불가능해서임.
+            # 채널 하나가 불량이어도 나머지는 유효하므로 채널별로 독립 계산함
+            channel_powers = {
+                name: self.analyzer.get_all_powers(buffer_arr[:, col])
+                for col, name in enumerate(self.eeg_channel_names)
+            }
+
             # 5대역이 같은 PSD를 공유하므로 비유한 입력은 전 대역에 전파됨
             # (실측 확인). 그 행은 쓰지 않고 버림 — coverage 계약이
             # "요청 대역 중 하나라도 비유한이면 그 초 전체 무효"라 어차피 못 씀.
@@ -827,21 +853,24 @@ class MindSignalStreamer(Cortex):
             # Cortex 타임스탬프를 문자열로 변환함 (위 검사에서 변환된 값 재사용)
             formatted_time = timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")
 
-            # 1. CSV 기록 수행함
+            # 1. CSV 기록 수행함.
+            # 채널별 컬럼은 TARGET_EEG_CHANNELS 순서로 고정하고, 헤드셋에 없는
+            # 채널은 공란으로 남김. 헤더가 회차마다 달라지면 하류 파서가 깨짐
             self.writer.writerow(
                 [
                     formatted_time,
-                    powers["delta"],
-                    powers["theta"],
-                    powers["alpha"],
-                    powers["beta"],
-                    powers["gamma"],
+                    *[powers[band] for band in BAND_NAMES],
                     self.latest_met["focus"],
                     self.latest_met["engagement"],
                     self.latest_met["interest"],
                     self.latest_met["excitement"],
                     self.latest_met["stress"],
                     self.latest_met["relaxation"],
+                    *[
+                        channel_powers.get(ch, {}).get(band, "")
+                        for ch in TARGET_EEG_CHANNELS
+                        for band in BAND_NAMES
+                    ],
                 ]
             )
             self.csv_file.flush()

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -383,6 +383,13 @@ class MindSignalStreamer(Cortex):
         # 직전 롤업 시점의 이상 누적치임. 구간 증분 계산용
         self._rollup_prev_counts: dict[str, int] = {}
         self._rollup_active = False
+        # 롤업 스레드와 종료 경로가 _log_rollup을 동시에 부르면 증분 계산의
+        # 스냅샷과 교체 사이가 갈라져 anomalyDelta가 중복 계상되거나 구간
+        # 경계가 깨짐. 두 호출을 직렬화함
+        self._rollup_lock = threading.Lock()
+        # sleep 대신 이 이벤트를 기다림. 종료 시 최대 30초를 기다리지 않고
+        # 즉시 깨어남
+        self._rollup_stop = threading.Event()
         self._health_published_at: dict[str, float] = {}
         self._last_event_monotonic: float | None = None
         self._eeg_stale = False
@@ -712,6 +719,35 @@ class MindSignalStreamer(Cortex):
                     {"metric": key, "value": repr(data[index])},
                 )
 
+    def _finite_or_blank(
+        self, channel_powers: dict, channel: str, band: str
+    ) -> float | str:
+        """채널별 대역 값이 유한하면 그대로, 아니면 공란 반환함.
+
+        평균값 5대역은 행 단위 유한성 검사를 이미 거치지만(non_finite_power로
+        행 전체를 버림) 채널별 값은 그 검사 대상이 아님. 채널 하나가 비유한이어도
+        나머지 채널은 유효하므로 행을 버리지 않고 해당 셀만 비움. 비우지 않으면
+        "nan" 문자열이 CSV에 박혀 하류 파서를 오염시킴.
+
+        Args:
+            channel_powers: 채널 이름을 키로 하는 대역 파워 dict임
+            channel: 대상 채널 이름임
+            band: 대상 대역 이름임
+
+        Returns:
+            유한한 값 또는 빈 문자열 반환
+        """
+        value = channel_powers.get(channel, {}).get(band)
+        if value is None:
+            return ""
+        if not np.isfinite(value):
+            self._log_continuity(
+                "channel_power_non_finite",
+                {"channel": channel, "band": band, "value": repr(value)},
+            )
+            return ""
+        return value
+
     def _start_rollup_thread(self) -> None:
         """30초 주기 롤업 스레드 기동함.
 
@@ -725,18 +761,22 @@ class MindSignalStreamer(Cortex):
         것을 보여줌.
         """
         self._rollup_active = True
+        self._rollup_stop.clear()
 
         def loop() -> None:
-            while self._rollup_active:
-                time.sleep(CONTINUITY_ROLLUP_INTERVAL_SEC)
-                if not self._rollup_active:
-                    break
+            # wait는 이벤트가 설정되면 True를 반환함. 즉 종료 신호가 오면
+            # 남은 대기를 건너뛰고 즉시 빠져나감
+            while not self._rollup_stop.wait(CONTINUITY_ROLLUP_INTERVAL_SEC):
                 try:
-                    self._log_rollup()
+                    with self._rollup_lock:
+                        self._log_rollup()
                 except Exception as e:  # 롤업 실패가 측정을 멈추면 안 됨
                     logger.warning(f"[CONTINUITY] 롤업 실패 (무시): {e}")
 
-        threading.Thread(target=loop, daemon=True, name="continuity-rollup").start()
+        self._rollup_thread = threading.Thread(
+            target=loop, daemon=True, name="continuity-rollup"
+        )
+        self._rollup_thread.start()
 
     def _log_rollup(self) -> None:
         """직전 구간의 누적 지표를 상한 없이 1행으로 남김.
@@ -940,7 +980,7 @@ class MindSignalStreamer(Cortex):
                     self.latest_met["stress"],
                     self.latest_met["relaxation"],
                     *[
-                        channel_powers.get(ch, {}).get(band, "")
+                        self._finite_or_blank(channel_powers, ch, band)
                         for ch in TARGET_EEG_CHANNELS
                         for band in BAND_NAMES
                     ],
@@ -1034,14 +1074,23 @@ class MindSignalStreamer(Cortex):
 
     def on_close(self, *args, **kwargs):
         self._watchdog_active = False
-        # 마지막 구간(직전 롤업 이후)을 남기고 스레드를 멈춤. 순서가 중요함 —
-        # 먼저 끄면 30초 미만의 꼬리 구간이 통째로 사라짐
+        # 롤업 스레드를 먼저 멈춘 뒤 마지막 구간(직전 롤업 이후)을 남김.
+        # 순서가 중요함 — 스레드를 안 멈추고 기록하면 두 호출이 증분 계산의
+        # 스냅샷과 교체 사이에서 갈라짐. 반대로 기록을 생략하면 30초 미만의
+        # 꼬리 구간이 통째로 사라짐
         if getattr(self, "_rollup_active", False):
+            self._rollup_active = False
+            self._rollup_stop.set()
+            thread = getattr(self, "_rollup_thread", None)
+            if thread is not None and thread.is_alive():
+                # 대기 중이면 이벤트로 즉시 깨어나고, 기록 중이면 그것이 끝날
+                # 때까지만 기다림. 종료 경로를 오래 붙잡지 않도록 상한을 둠
+                thread.join(timeout=5)
             try:
-                self._log_rollup()
+                with self._rollup_lock:
+                    self._log_rollup()
             except Exception as e:
                 logger.warning(f"[CONTINUITY] 종료 롤업 실패 (무시): {e}")
-            self._rollup_active = False
         elapsed = time.time() - self.start_time if hasattr(self, "start_time") else 0
 
         # 총 EEG 이벤트 대비 CSV 행 수를 남김. 128 이벤트당 1행이 정상이라

--- a/server/services/proxy_client.py
+++ b/server/services/proxy_client.py
@@ -4,9 +4,38 @@ Emotiv Cortex SDK 콜백(동기 스레드)에서 직접 호출되므로 httpx.Cl
 AsyncClient 사용 금지 — 동기 스레드에서 이벤트 루프 없이 호출됨.
 """
 
+import threading
 import time
 
 import httpx
+
+_client_lock = threading.Lock()
+_shared_client: httpx.Client | None = None
+
+
+def get_shared_client() -> httpx.Client:
+    """모듈 공용 httpx.Client 반환함 (미생성 시 생성).
+
+    호출마다 Client를 새로 만들면 그때마다 SSL 컨텍스트를 새로 구성하며
+    certifi CA 번들 약 271KB를 다시 파싱함. PC A 실측 약 690ms 소요됨.
+    이 비용이 128샘플 블록당 1초 예산을 잠식해 수신 백로그가 초당 약 0.2초씩
+    누적됐음 (EEG-W003, 10분 측정에 약 100초 지연). 재사용 시 같은 POST가
+    약 5ms로 떨어짐.
+    """
+    global _shared_client
+    with _client_lock:
+        if _shared_client is None or _shared_client.is_closed:
+            _shared_client = httpx.Client(timeout=10)
+        return _shared_client
+
+
+def close_shared_client() -> None:
+    """공용 Client 해제함 (프로세스 종료와 테스트 격리용)"""
+    global _shared_client
+    with _client_lock:
+        if _shared_client is not None:
+            _shared_client.close()
+            _shared_client = None
 
 
 class ProxyForwardError(Exception):
@@ -26,9 +55,8 @@ def check_health(proxy_url: str, timeout: float = 5.0) -> bool:
         HTTP 200 응답 시 True, 그 외(503/비200/네트워크 오류) False 반환함.
     """
     try:
-        with httpx.Client(timeout=timeout) as client:
-            response = client.get(f"{proxy_url}/health")
-            return response.status_code == 200
+        response = get_shared_client().get(f"{proxy_url}/health", timeout=timeout)
+        return response.status_code == 200
     except httpx.RequestError:
         return False
 
@@ -135,19 +163,20 @@ def post_sample(
             time.sleep(wait_sec)
 
         try:
-            with httpx.Client(timeout=10) as client:
-                response = client.post(
-                    f"{proxy_url}/ingest/sample",
-                    headers={
-                        "X-Engine-Secret": secret_key,
-                        "Content-Type": "application/json",
-                    },
-                    json=body,
-                )
-                # 4xx/5xx 응답 시 HTTPStatusError raise함
-                response.raise_for_status()
-                # 전송 성공 — 즉시 반환함
-                return
+            # 공용 Client 재사용함 — 호출마다 생성하면 SSL 컨텍스트 재구성으로
+            # 블록당 예산을 잠식함 (get_shared_client docstring 참조)
+            response = get_shared_client().post(
+                f"{proxy_url}/ingest/sample",
+                headers={
+                    "X-Engine-Secret": secret_key,
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+            # 4xx/5xx 응답 시 HTTPStatusError raise함
+            response.raise_for_status()
+            # 전송 성공 — 즉시 반환함
+            return
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
             # 네트워크 오류 또는 상태 코드 오류 — retry 대상임
             last_exc = exc

--- a/tests/services/test_proxy_client.py
+++ b/tests/services/test_proxy_client.py
@@ -2,6 +2,8 @@
 
 import inspect
 import json
+import threading
+from typing import Any, Generator
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -298,3 +300,163 @@ def test_tracker_healthy_after_trip_resets_to_false() -> None:
     assert tracker.record(False, 5.0) is False  # 첫 fail — threshold 미도달
     assert tracker.record(False, 7.999) is False  # 2999ms 미도달
     assert tracker.record(False, 8.0) is True  # 3000ms 도달 — True
+
+
+# ──────────────────────────────────────────────
+# T-PC-8: Client 재사용 회귀 (EEG-W003)
+#
+# 결함: post_sample이 호출마다 httpx.Client를 새로 만들어 매번 SSL 컨텍스트를
+# 재구성했고, PC A 실측 약 690ms가 소요됐음. 128샘플 블록당 1초 예산을 잠식해
+# Cortex 수신 백로그가 초당 약 0.2초씩 누적됐음(10분 측정에 약 100초 지연).
+# 실측 근거: httpx.Client() 생성만 694ms, 재사용 시 POST 왕복 5.3ms.
+# 아래 테스트는 "호출 횟수와 무관하게 Client 생성은 1회"를 잠금.
+# ──────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _reset_shared_client() -> Generator[None, None, None]:
+    """테스트 간 공용 Client 격리함 — mock transport가 새 Client에 적용되게 함.
+
+    getattr 폴백은 공용 Client가 없는 구현에서도 나머지 테스트가 정상 실행되어
+    본 회귀 테스트가 AttributeError가 아니라 생성 횟수로 실패하게 하려는 것임.
+    """
+    from server.services import proxy_client
+
+    reset = getattr(proxy_client, "close_shared_client", lambda: None)
+    reset()
+    yield
+    reset()
+
+
+def _count_client_constructions(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """httpx.Client 생성 횟수를 세는 카운터 설치하고 리스트로 반환함"""
+    import httpx
+
+    from server.services import proxy_client
+
+    calls = [0]
+    real_client = httpx.Client
+
+    def counting_client(*args: Any, **kwargs: Any) -> httpx.Client:
+        calls[0] += 1
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(proxy_client.httpx, "Client", counting_client)
+    return calls
+
+
+def test_post_sample_reuses_single_client(httpx_mock: HTTPXMock, monkeypatch) -> None:
+    """post_sample 3회 호출 시 httpx.Client 생성은 1회뿐임을 확인함"""
+    from server.services import proxy_client
+
+    monkeypatch.setattr(proxy_client.time, "monotonic_ns", lambda: FIXED_TS_NS)
+    calls = _count_client_constructions(monkeypatch)
+
+    for _ in range(3):
+        httpx_mock.add_response(url=INGEST_SAMPLE_URL, method="POST", status_code=200)
+
+    for seq in range(3):
+        proxy_client.post_sample(
+            proxy_url=MOCK_PROXY_URL,
+            secret_key=MOCK_SECRET_KEY,
+            group_id=MOCK_GROUP_ID,
+            subject_idx=MOCK_SUBJECT_IDX,
+            seq=seq,
+            payload=MOCK_PAYLOAD,
+            sync_meta=MOCK_SYNC_META,
+        )
+
+    assert len(httpx_mock.get_requests(url=INGEST_SAMPLE_URL)) == 3
+    assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 호출마다 생성하면 안 됨"
+
+
+def test_check_health_reuses_same_client_as_post_sample(
+    httpx_mock: HTTPXMock, monkeypatch
+) -> None:
+    """check_health와 post_sample이 같은 Client를 공유함을 확인함"""
+    from server.services import proxy_client
+
+    monkeypatch.setattr(proxy_client.time, "monotonic_ns", lambda: FIXED_TS_NS)
+    calls = _count_client_constructions(monkeypatch)
+
+    httpx_mock.add_response(
+        url=f"{MOCK_PROXY_URL}/health", method="GET", status_code=200
+    )
+    httpx_mock.add_response(url=INGEST_SAMPLE_URL, method="POST", status_code=200)
+
+    assert proxy_client.check_health(MOCK_PROXY_URL) is True
+    proxy_client.post_sample(
+        proxy_url=MOCK_PROXY_URL,
+        secret_key=MOCK_SECRET_KEY,
+        group_id=MOCK_GROUP_ID,
+        subject_idx=MOCK_SUBJECT_IDX,
+        seq=MOCK_SEQ,
+        payload=MOCK_PAYLOAD,
+        sync_meta=MOCK_SYNC_META,
+    )
+
+    assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 두 경로가 공유해야 함"
+
+
+def test_concurrent_get_shared_client_constructs_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """여러 스레드가 동시에 진입해도 Client는 1개만 생성됨을 확인함.
+
+    get_shared_client가 락 없이 None 검사와 대입을 하면 첫 호출들이 겹칠 때
+    각자 Client를 만들고 마지막 하나만 남아 나머지가 누수됨. Barrier로 동시
+    진입을 강제해 그 경합을 재현함.
+    """
+    from server.services import proxy_client
+
+    # 실물 Client 대신 더미를 세움 — 실물 생성은 CA 번들을 읽어 파일시스템에
+    # 의존하고, 이 테스트는 HTTP가 아니라 생성 횟수와 동일성만 검증함
+    calls = [0]
+
+    class _DummyClient:
+        is_closed = False
+
+        def close(self) -> None:
+            pass
+
+    def counting_client(*args: Any, **kwargs: Any) -> Any:
+        calls[0] += 1
+        return _DummyClient()
+
+    monkeypatch.setattr(proxy_client.httpx, "Client", counting_client)
+
+    thread_count = 8
+    barrier = threading.Barrier(thread_count)
+    results: list[object] = [None] * thread_count
+    errors: list[tuple[int, BaseException]] = []
+
+    def worker(idx: int) -> None:
+        try:
+            barrier.wait()
+            results[idx] = proxy_client.get_shared_client()
+        except BaseException as exc:  # 진단 목적으로 캡처함
+            errors.append((idx, exc))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, f"워커 스레드에서 예외 발생: {errors}"
+    assert all(
+        result is results[0] for result in results
+    ), "스레드마다 다른 Client 반환됨"
+    assert calls[0] == 1, f"Client 생성이 {calls[0]}회 — 동시 진입에도 1회여야 함"
+
+
+def test_close_shared_client_allows_recreation() -> None:
+    """close 후 재요청 시 새 Client가 생성되어 재사용 가능함을 확인함"""
+    from server.services import proxy_client
+
+    first = proxy_client.get_shared_client()
+    assert proxy_client.get_shared_client() is first
+
+    proxy_client.close_shared_client()
+
+    second = proxy_client.get_shared_client()
+    assert second is not first
+    assert second.is_closed is False

--- a/tests/test_analyzer_dsp.py
+++ b/tests/test_analyzer_dsp.py
@@ -1,0 +1,184 @@
+"""MindSignalAnalyzer DSP 계약 회귀 테스트
+
+전 테스트가 합성 신호 기반임. 기존 CSV는 결함 산출물이라 기준선으로 못 씀
+(원시 EEG 미보존으로 재계산 불가 — ANALYSIS-W001 3.1절).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from core.analyzer import MindSignalAnalyzer
+
+FS = 128
+DC_LEVEL = 4200.0  # Emotiv Insight 부동 DC 준위 약 4200uV
+TONE_AMPLITUDE = 20.0  # 합성 정현파 진폭(uV)
+TRUE_RMS = TONE_AMPLITUDE / np.sqrt(2)  # 14.1421
+
+
+def _tone(freq: float, dc: float = DC_LEVEL, n: int = 128, phase: float = 0.0):
+    """DC 오프셋 위에 단일 정현파를 얹은 1초 창 생성함"""
+    t = np.arange(n) / FS
+    return dc + TONE_AMPLITUDE * np.sin(2 * np.pi * freq * t + phase)
+
+
+def test_constant_dc_input_yields_zero_band_power():
+    """[회귀 A] 뇌파 0인 상수 입력은 전 대역 0이어야 함.
+
+    welch를 detrend=False로 호출하므로 _remove_dc가 유일한 DC 제거자임.
+    그 호출을 빼면 이 테스트가 delta 약 2425로 실패함.
+    """
+    powers = MindSignalAnalyzer().get_all_powers(np.full(128, DC_LEVEL))
+    assert max(powers.values()) < 1e-06
+
+
+def test_alpha_rms_recovers_true_amplitude():
+    """[회귀 B] 10Hz 20uV 알파의 RMS 회복률이 참값의 95~105%여야 함"""
+    powers = MindSignalAnalyzer().get_all_powers(_tone(10.0))
+    ratio = powers["alpha"] / TRUE_RMS
+    assert 0.95 <= ratio <= 1.05
+
+
+@pytest.mark.parametrize(
+    "band,freq,min_selectivity",
+    [
+        ("delta", 2.0, 3.0),
+        ("theta", 6.0, 3.0),
+        ("alpha", 10.0, 3.0),
+        ("beta", 20.0, 3.0),
+        ("gamma", 38.0, 3.0),
+    ],
+)
+def test_band_selectivity(band, freq, min_selectivity):
+    """해당 대역 중앙 정현파를 넣으면 그 대역이 최대이고 차순위의 3배 이상이어야 함.
+
+    대역 중앙만 보장함. 대역 경계(4Hz, 8Hz, 30Hz)는 닫힌 구간 설계라 인접
+    대역과 동률이며 이는 알려진 성질임 — ANALYSIS-W001 결정 2 참조.
+    """
+    powers = MindSignalAnalyzer().get_all_powers(_tone(freq))
+    runner_up = max(v for k, v in powers.items() if k != band)
+    assert powers[band] == max(powers.values())
+    # 채택안은 타 대역이 수치 잡음 수준이라 선택도가 매우 큼. 기준 3.0은
+    # 설계가 필터뱅크로 되돌아가는 경우까지 커버하는 하한임
+    assert runner_up == 0.0 or powers[band] / runner_up >= min_selectivity
+
+
+@pytest.mark.parametrize("phase_index", range(8))
+def test_alpha_recovery_is_phase_stable(phase_index):
+    """[회귀 E] 시작 위상이 달라져도 알파 회복률이 95~105%를 유지해야 함.
+
+    영위상 필터뱅크는 이 테스트를 통과하지 못함(위상에 따라 94.43%까지
+    내려감). Welch 채택의 핵심 근거이므로 계약으로 고정함.
+    """
+    phase = 2 * np.pi * phase_index / 8
+    window = _tone(10.0, phase=phase)
+    ratio = MindSignalAnalyzer().get_all_powers(window)["alpha"] / TRUE_RMS
+    assert 0.95 <= ratio <= 1.05
+
+
+def test_dc_level_does_not_change_result():
+    """DC 준위가 3000/4200/5000으로 달라져도 알파 값이 동일해야 함"""
+    analyzer = MindSignalAnalyzer()
+    values = [
+        analyzer.get_all_powers(_tone(10.0, dc=dc))["alpha"]
+        for dc in (3000.0, 4200.0, 5000.0)
+    ]
+    assert max(values) - min(values) < 1e-09
+
+
+def test_remove_dc_returns_zero_mean():
+    """[회귀 D1] DC 제거 헬퍼의 단위 계약 — 출력 평균이 0임"""
+    out = MindSignalAnalyzer._remove_dc(_tone(10.0))
+    assert abs(float(np.mean(out))) < 1e-09
+
+
+def test_delta_recovery_pins_rectangular_quadrature():
+    """[회귀 F] 대역 적분이 직사각형 합임을 delta 1Hz 회복률로 고정함.
+
+    사다리꼴(np.trapezoid)은 대역 경계 빈 가중치를 절반으로 깎음. 1Hz 톤은
+    에너지가 대역 하한 근처에 있어 둘을 판별함 — 직사각형 91.3%, 사다리꼴
+    70.7%. 반면 대역 중앙 톤(예: alpha 10Hz)은 경계 빈이 0이라 두 방식의
+    결과가 같으므로 판별에 쓸 수 없음.
+    """
+    delta = MindSignalAnalyzer().get_all_powers(_tone(1.0))["delta"]
+    ratio = delta / TRUE_RMS
+    assert 0.90 <= ratio <= 0.93
+
+
+def test_bin_width_scaling_holds_for_non_unit_resolution():
+    """[회귀 G] PSD 합에 빈 간격을 곱하는 스케일 인자를 고정함.
+
+    1초 창(128샘플 at 128Hz)은 빈 간격이 정확히 1.0이라 곱을 빼도 결과가
+    같음. 2초 창은 0.5가 되므로 스케일 인자 누락이 드러남(참값의 141%).
+    """
+    n = 256  # 2초 창이라 빈 간격 0.5Hz임
+    t = np.arange(n) / FS
+    window = DC_LEVEL + TONE_AMPLITUDE * np.sin(2 * np.pi * 10.0 * t)
+    ratio = MindSignalAnalyzer().get_all_powers(window)["alpha"] / TRUE_RMS
+    assert 0.95 <= ratio <= 1.05
+
+
+def test_band_edges_are_closed_intervals():
+    """대역 경계가 닫힌 구간임을 고정함.
+
+    8Hz는 theta 상한이자 alpha 하한이라 두 대역에 같은 값으로 계산됨.
+    반열린 구간으로 바꾸면 한쪽만 잡혀 이 계약이 깨짐. 중앙 주파수 정확도를
+    위한 의도된 선택임 — ANALYSIS-W001 결정 2 참조.
+    """
+    powers = MindSignalAnalyzer().get_all_powers(_tone(8.0))
+    assert powers["theta"] == pytest.approx(powers["alpha"], rel=1e-09)
+    assert powers["alpha"] / TRUE_RMS > 0.5
+
+
+@pytest.mark.parametrize("entry", ["get_all_powers", "get_band_power"])
+def test_short_window_raises_instead_of_returning_zero(entry):
+    """창이 짧으면 조용한 0.0 대신 예외여야 함.
+
+    빈 간격이 넓어지면 대역에 빈이 안 잡혀 톤이 있어도 0.0이 나오거나
+    (길이 16에서는) theta와 alpha가 나란히 11.86인 무의미한 값이 나옴.
+    하류 유한성 검사가 그 값을 통과시키므로 진입점에서 막음. 실사용 진입점은
+    get_all_powers 쪽이므로 두 경로 모두 검사함.
+    """
+    analyzer = MindSignalAnalyzer()
+    short = _tone(10.0, n=64)
+    with pytest.raises(ValueError):
+        if entry == "get_all_powers":
+            analyzer.get_all_powers(short)
+        else:
+            analyzer.get_band_power(short, "alpha")
+
+
+def test_synchrony_recovers_common_alpha_modulation():
+    """[회귀 C] 공통 알파 변조를 가진 두 피실험자의 동조율이 0.90 이상이어야 함"""
+    from server.services.analysis import compute_synchrony
+
+    n_sec = 260
+    modulation = 1.0 + 0.5 * np.sin(2 * np.pi * np.arange(n_sec) / 50.0)
+    frames = [_synthesize_session(seed, n_sec, modulation) for seed in (11, 22)]
+    score = compute_synchrony(frames[0], frames[1])
+    assert score is not None
+    assert score >= 0.90
+
+
+def _synthesize_session(seed: int, n_sec: int, modulation: np.ndarray) -> pd.DataFrame:
+    """공통 알파 변조와 개별 위상 및 잡음을 가진 합성 세션 DataFrame 생성함"""
+    analyzer = MindSignalAnalyzer()
+    rng = np.random.default_rng(seed)
+    t = np.arange(128) / FS
+    start = pd.Timestamp("2026-01-01 00:00:00")
+    rows = []
+    for i in range(n_sec):
+        amplitude = TONE_AMPLITUDE * modulation[i] * (1.0 + 0.05 * rng.normal())
+        window = (
+            DC_LEVEL
+            + 30.0 * rng.normal()
+            + amplitude * np.sin(2 * np.pi * 10 * t + rng.uniform(0, 2 * np.pi))
+            + rng.normal(0, 5.0, 128)
+        )
+        rows.append(
+            {
+                "timestamp": start + pd.Timedelta(seconds=i),
+                **analyzer.get_all_powers(window),
+            }
+        )
+    return pd.DataFrame(rows)


### PR DESCRIPTION
`dev`에 쌓인 6커밋을 `main`으로 올린다.

## 포함 내용

**EEG-W003 — 프록시 클라이언트 SSL 컨텍스트 재구성 제거 (#44, Closes #43)**

`post_sample`과 `check_health`가 호출마다 `httpx.Client`를 새로 만들어 매번 certifi CA 번들을 다시 파싱했다. 평문 HTTP로 로컬 프록시에 보내면서 쓰지도 않을 신뢰 저장소를 초당 두 번 읽고 있었다. 공용 Client 재사용으로 블록당 비용이 869 밀리초에서 7.76 밀리초가 됐다.

2 PC 실기기 3분 측정으로 검증했다. `clockSkewSec`가 양쪽 모두 평평하다(PC A 0.227에서 0.207, 노트북 B 0.256에서 0.211). 결함 상태 기울기는 0.203 초매초였다.

**ANALYSIS-W001 — 대역 파워 산출을 Welch PSD 합산으로 전환 (#41)**

인과 필터뱅크를 PSD 대역 합산으로 바꿨다. 128샘플 창에서 초기조건 0 과도응답이 창 전체를 지배해 대역 파워가 뇌파가 아니라 DC에 비례하는 상수로 나오던 결함을 없앴다.

**채널별 대역 파워 CSV 기록과 30초 rollup (#42)**

채널별 대역 값을 CSV에 남기고, 상한 없는 30초 rollup에 clock skew를 포함한다. 위 EEG-W003 진단이 이 rollup 덕에 가능했다.

## 검증

`black`, `isort`, `flake8` 통과. `pytest` **260 passed**.