### PR TITLE
feat(server): DEV_RELOAD 스위치 추가하고 stdout utf-8 강제

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -1,9 +1,40 @@
 import os
+import sys
 
-# Phase 17.5.3 — Windows uvicorn reloader 환경에서 print() stdout buffering으로
-# lifespan 로그가 누락되는 현상 방지함. reloader process가 worker stdout을 pipe
-# forwarding하는 과정에서 flush 지연 + 터미널 라인 잘림 발생 가능.
-os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+def _apply_io_env() -> None:
+    """자식 프로세스용 IO 환경변수 주입함 (reload 워커와 core.main spawn에 상속됨)."""
+    # Phase 17.5.3 — Windows uvicorn reloader 환경에서 print() stdout buffering으로
+    # lifespan 로그가 누락되는 현상 방지함. reloader process가 worker stdout을 pipe
+    # forwarding하는 과정에서 flush 지연 + 터미널 라인 잘림 발생 가능. DEV_RELOAD=0
+    # 단일 프로세스 경로에서도 로그 가시성에 유용해 유지함.
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    # OPS-W006 — stdout이 tty가 아니면(파이프, 파일 redirect, Start-Process) 인코딩이
+    # ANSI 코드페이지(cp949)로 확정돼 em dash 같은 비ASCII 로그에서
+    # UnicodeEncodeError로 프로세스가 죽음. server/services/stream.py가 core.main
+    # stdout을 로그 파일로 redirect하므로 그 경로는 상시 노출됨 — 2026-06-30 측정
+    # 1건이 이 원인으로 0초 종료함(logs/core_6a438aa5..._1.log, 후속 커밋 6faf7c8).
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+
+def _force_utf8_stdout() -> None:
+    """현재 프로세스 stdout/stderr를 utf-8로 재설정함 (멱등, 미지원 스트림은 무시)."""
+    # 위 환경변수는 자식에만 먹음. 이미 시작된 자기 인터프리터는 이쪽이 필요하고,
+    # DEV_RELOAD=0으로 lifespan이 이 프로세스에서 도는 경로가 정확히 그 대상임.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8")
+
+
+def _dev_reload() -> bool:
+    """개발용 자동 reload 활성화 여부 반환함. 런처 경로는 0을 주입해 단일 프로세스 기동."""
+    return os.getenv("DEV_RELOAD", "1") == "1"
+
+
+# server.app import 시 logbuffer가 stdout을 감싸므로 그 전에 원본을 교정해 둠.
+_apply_io_env()
+_force_utf8_stdout()
 
 import uvicorn  # noqa: E402
 
@@ -14,5 +45,5 @@ if __name__ == "__main__":
         "server.app:app",
         host="0.0.0.0",
         port=settings.fastapi_port,
-        reload=True,
+        reload=_dev_reload(),
     )

--- a/tests/test_run_server_startup.py
+++ b/tests/test_run_server_startup.py
@@ -1,0 +1,51 @@
+"""run_server 기동 정책 테스트 — DEV_RELOAD 파싱과 stdout 인코딩 강제 검증함 (OPS-W006)"""
+
+import run_server
+
+
+def test_dev_reload_defaults_to_true(monkeypatch):
+    """미설정이면 개발자 기본인 reload 유지함."""
+    monkeypatch.delenv("DEV_RELOAD", raising=False)
+    assert run_server._dev_reload() is True
+
+
+def test_dev_reload_zero_disables(monkeypatch):
+    """런처 경로는 0을 주입해 단일 프로세스로 기동함."""
+    monkeypatch.setenv("DEV_RELOAD", "0")
+    assert run_server._dev_reload() is False
+
+
+def test_dev_reload_one_enables(monkeypatch):
+    monkeypatch.setenv("DEV_RELOAD", "1")
+    assert run_server._dev_reload() is True
+
+
+def test_io_env_defaults_to_utf8(monkeypatch):
+    """미설정 환경에서 자식 프로세스용 utf-8 기본값 주입함."""
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+    run_server._apply_io_env()
+    assert run_server.os.environ["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_explicit_io_env_is_preserved(monkeypatch):
+    """사용자 명시 값은 덮어쓰지 않음 — setdefault 의미 고정함."""
+    monkeypatch.setenv("PYTHONIOENCODING", "cp949")
+    run_server._apply_io_env()
+    assert run_server.os.environ["PYTHONIOENCODING"] == "cp949"
+
+
+def test_force_utf8_stdout_is_safe_without_reconfigure(monkeypatch):
+    """reconfigure 보유 스트림엔 utf-8 지정, 미보유 스트림은 예외 없이 통과함."""
+    calls = []
+
+    class _Reconfigurable:
+        def reconfigure(self, encoding):
+            calls.append(encoding)
+
+    class _Plain:
+        pass
+
+    monkeypatch.setattr(run_server.sys, "stdout", _Reconfigurable())
+    monkeypatch.setattr(run_server.sys, "stderr", _Plain())
+    run_server._force_utf8_stdout()
+    assert calls == ["utf-8"]

--- a/tests/test_run_server_startup.py
+++ b/tests/test_run_server_startup.py
@@ -20,11 +20,13 @@ def test_dev_reload_one_enables(monkeypatch):
     assert run_server._dev_reload() is True
 
 
-def test_io_env_defaults_to_utf8(monkeypatch):
-    """미설정 환경에서 자식 프로세스용 utf-8 기본값 주입함."""
+def test_io_env_defaults_are_injected(monkeypatch):
+    """미설정 환경에서 자식 프로세스용 기본값 둘 다 주입함."""
     monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+    monkeypatch.delenv("PYTHONUNBUFFERED", raising=False)
     run_server._apply_io_env()
     assert run_server.os.environ["PYTHONIOENCODING"] == "utf-8"
+    assert run_server.os.environ["PYTHONUNBUFFERED"] == "1"
 
 
 def test_explicit_io_env_is_preserved(monkeypatch):


### PR DESCRIPTION
Closes #46

OPS-W006(개발 서버 기동과 종료 스크립트 수정) 진행 중 발견한 두 가지를 `run_server.py` 한 파일에서 고친다.

## 변경 1. DEV_RELOAD 스위치

`reload=True` 고정을 `_dev_reload()`로 뺐다. `DEV_RELOAD=0`이면 uvicorn reload 없이 단일 프로세스로 뜬다. 기본값은 `1`이라 개발자 경로는 그대로다.

기본값을 0으로 뒤집지 않은 이유는, 기본 0의 위험("reload가 없는 줄 모르고 코드를 고친 개발자가 옛 코드로 측정")이 이번에 고치려던 사고와 같은 유형인데 그걸 막아줄 게이트가 없기 때문이다. 고아 구조 자체의 위험은 아래 종료 스크립트가 흡수한다.

## 변경 2. stdout utf-8 강제 (cp949 UnicodeEncodeError)

stdout이 tty가 아니면(파이프, 파일 redirect, `Start-Process`) 인코딩이 ANSI 코드페이지 cp949로 확정되고, em dash가 들어간 로그를 `print`하는 순간 lifespan이 죽는다.

**이미 실피해가 났다.** `server/services/stream.py:94-95`가 `core.main` stdout을 로그 파일로 redirect하므로 그 경로는 상시 cp949다. `logs/core_6a438aa5248f0e3f0c6eaba5_1.log`에 이 예외로 측정이 0초 종료한 기록이 있고, 후속 커밋 `6faf7c8`은 해당 문자열 하나의 em dash만 지웠다. `chcp 65001` 콘솔에서는 stdout이 tty라 재현되지 않아 지금까지 안 보였다.

**두 겹으로 막는 이유**: Python은 시작 시 stdout 인코딩을 확정하므로 `os.environ.setdefault`는 자식 프로세스에만 먹는다. 즉 환경변수 하나로는 이 PR이 새로 만드는 `DEV_RELOAD=0` 경로(lifespan이 부모에서 도는 경로)를 못 덮는다.

| 계층 | 적용 대상 |
|---|---|
| `PYTHONIOENCODING` setdefault | 자식 — reload 워커, `core.main` spawn |
| `sys.stdout.reconfigure` | 자기 프로세스 — `DEV_RELOAD=0` 경로 |

`_force_utf8_stdout()` 호출은 `import uvicorn`보다 **위**에 있어야 한다. `server.app` import 시 `logbuffer.install()`이 stdout을 감싸므로 그때 원본이 이미 utf-8이어야 링버퍼 경로까지 안전하다.

## 커밋 단위에 대해

`1 task = 1 commit` 규칙의 예외다. 같은 파일 인접 10줄이고, 분리하면 검증 루프 4단계를 2회 중복 실행하며, 두 변경이 같은 "프로세스 기동 계약"을 다룬다. **이 커밋을 revert하면 인코딩 3줄은 재적용할 것.**

## 검증

```
black .    53 files unchanged
isort .    변경 없음
flake8 .   위반 0건
pytest     266 passed  (기존 260 더하기 신규 6)
```

신규 6건은 `tests/test_run_server_startup.py`다. `DEV_RELOAD` 파싱 3케이스와, `PYTHONIOENCODING` setdefault 의미(미설정 시 utf-8 주입, 명시값은 보존) 2케이스, `reconfigure` 미보유 스트림에서 예외 없이 통과하는지 1케이스다. 전부 프로세스를 띄우지 않고 검증된다.

인코딩 수정은 A/B로 확인했다.

| | 결과 |
|---|---|
| 대조군 — 일반 python, stdout을 파일로 redirect하고 em dash 출력 | `UnicodeEncodeError`, exit 1 |
| 처치군 — `run_server` import 후 동일 출력 | 정상 출력, exit 0 |

`DEV_RELOAD=0`으로 기동해 `spawn_main` 워커가 없는 단일 프로세스임도 확인했다.

## 이 PR에 안 들어간 것 — 기동과 종료 스크립트

OPS-W006의 나머지는 워크스페이스 루트(`Team-project/mind-signal/`)에 있고, **그 루트는 git 저장소가 아니라** 이 PR에 포함되지 않는다. 리뷰어가 볼 수 있도록 위치와 결과를 남긴다. 향후 런처 레포 분리(OPS-W007) 때 정식 버전 관리로 들어간다.

| 파일 | 역할 |
|---|---|
| `scripts/dev-stop.ps1` (140줄) | 포트 소유자 검증 킬, uvicorn 고아 워커 역추적, 최종 listener 게이트 |
| `scripts/dev-start.ps1` (111줄) | redis, backend, proxy, engine, frontend, monitor 순차 기동과 health 게이트 |
| `scripts/verify-orphan-repro.ps1` | 고아 상태를 의도적으로 재현하는 회귀 검증 |
| `stop-dev.bat`, `start-dev.bat` | ASCII 진입점(6줄, 12줄). 박스 문자, `wmic`, `tasklist` CSV 공백 파싱, `findstr` 과매치 전부 제거 |

기존 `stop-dev.bat`은 5002를 못 내리고도 "모든 서비스가 종료되었습니다"를 출력했다(거짓 성공). 새 종료 경로는 실제 TCP listener 잔존으로만 성공을 판정하고, 소유자를 확인할 수 없는 포트는 **죽이지 않고** exit 1로 보고한다.

검증 결과 요약이다.

| 시나리오 | 결과 |
|---|---|
| 전체 기동 | PASS. health 게이트 전부 통과, exit 0 |
| 전체 종료 | PASS. 4개 서비스와 redis 컨테이너, 5포트 소멸, exit 0 |
| 고아 재현 후 종료 | PASS. 부모만 죽여 5002가 남은 상태에서 exit 0과 포트 소멸 |
| 남의 프로세스가 5002 점유 | PASS. 죽이지 않고 exit 1 |
| 무관한 Node와 python 보호 | PASS. 둘 다 생존 |

재현 과정에서 초안 코드만으로는 안 잡히던 결함 4건을 찾아 고쳤다. `taskkill /T`가 spawn 워커를 못 잡는 것, 엔진이 `python run_server.py`로 떠서 명령줄에 레포 경로가 없다는 것, `-Root "%~dp0"`의 끝 백슬래시가 닫는 따옴표를 이스케이프하는 것, PowerShell이 함수 반환 시 원소 1개 배열을 풀어 `.Count`가 `$null`이 되는 것이다.

## 후속 (이 PR 범위 밖)

`core/streamer.py` 460, 477, 485, 491, 577, 1013의 런타임 `print`에 em dash가 남아 있다. 577과 1013은 측정 중단 처리 도중에 발동해 CSV 업로드 경로를 건너뛸 수 있다. `sdk/cortex.py:432`의 U+274C는 `sdk/` 수정 금지라 진입점 방어에 의존한다. 진입점 방어가 노출 조건을 없앴으므로 급하지 않지만, `run_server.py`를 거치지 않는 새 진입점이 생기면 재발한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * `DEV_RELOAD` 설정으로 개발 서버의 자동 재시작 여부를 제어할 수 있습니다.
  * 기본적으로 자동 재시작이 활성화되며, `0`으로 비활성화하고 `1`로 활성화할 수 있습니다.
  * 서버 출력의 UTF-8 인코딩과 버퍼링 처리가 개선되어 비ASCII 문자가 안정적으로 표시됩니다.

* **테스트**
  * 자동 재시작 설정과 출력 인코딩 처리를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->