### PR TITLE
fix(streamer): cp949 인코딩 불가 문자로 측정이 죽는 로그 제거

### DIFF
--- a/core/streamer.py
+++ b/core/streamer.py
@@ -452,7 +452,7 @@ class MindSignalStreamer(Cortex):
             if len(connected) == 1:
                 self.headset_id = connected[0]
                 print(
-                    f"[INFO] connected 헤드셋 '{self.headset_id}' 우선 선택함 "
+                    f"[INFO] connected 헤드셋 {self.headset_id!a} 우선 선택함 "
                     f"(subject {self.subject_index})"
                 )
             elif len(connected) > 1:
@@ -474,7 +474,7 @@ class MindSignalStreamer(Cortex):
         if len(headset_ids) == 1:
             fallback_id = headset_ids[0]
             print(
-                f"[WARN] 설정 헤드셋 ID '{self.headset_id}' 미발견. "
+                f"[WARN] 설정 헤드셋 ID {self.headset_id!a} 미발견. "
                 f"연결된 헤드셋 '{fallback_id}' 으로 폴백함 "
                 f"(subject {self.subject_index})"
             )
@@ -482,13 +482,13 @@ class MindSignalStreamer(Cortex):
             super()._handle_query_headset(result_dic)
         elif len(headset_ids) == 0:
             print(
-                f"[ERROR] 설정 헤드셋 ID '{self.headset_id}' 미발견이고 "
+                f"[ERROR] 설정 헤드셋 ID {self.headset_id!a} 미발견이고 "
                 f"연결된 헤드셋도 없어 측정 불가. 종료함 (subject {self.subject_index})"
             )
             self.close()
         else:
             print(
-                f"[ERROR] 설정 헤드셋 ID '{self.headset_id}' 미발견이고 "
+                f"[ERROR] 설정 헤드셋 ID {self.headset_id!a} 미발견이고 "
                 f"연결된 헤드셋이 {len(headset_ids)}대({headset_ids})라 "
                 f"자동 선택 불가. 종료함 (subject {self.subject_index})"
             )

--- a/core/streamer.py
+++ b/core/streamer.py
@@ -457,7 +457,7 @@ class MindSignalStreamer(Cortex):
                 )
             elif len(connected) > 1:
                 print(
-                    f"[WARN] connected 헤드셋 {len(connected)}대 ({connected}) — "
+                    f"[WARN] connected 헤드셋 {len(connected)}대 ({connected})라 "
                     f"자동 우선선택 skip, SDK 기본 선택 위임 (subject {self.subject_index})"
                 )
             super()._handle_query_headset(result_dic)
@@ -474,7 +474,7 @@ class MindSignalStreamer(Cortex):
         if len(headset_ids) == 1:
             fallback_id = headset_ids[0]
             print(
-                f"[WARN] 설정 헤드셋 ID '{self.headset_id}' 미발견 — "
+                f"[WARN] 설정 헤드셋 ID '{self.headset_id}' 미발견. "
                 f"연결된 헤드셋 '{fallback_id}' 으로 폴백함 "
                 f"(subject {self.subject_index})"
             )
@@ -482,14 +482,14 @@ class MindSignalStreamer(Cortex):
             super()._handle_query_headset(result_dic)
         elif len(headset_ids) == 0:
             print(
-                f"[ERROR] 설정 헤드셋 ID '{self.headset_id}' 미발견 + "
-                f"연결된 헤드셋 없음 — 측정 불가. 종료함 (subject {self.subject_index})"
+                f"[ERROR] 설정 헤드셋 ID '{self.headset_id}' 미발견이고 "
+                f"연결된 헤드셋도 없어 측정 불가. 종료함 (subject {self.subject_index})"
             )
             self.close()
         else:
             print(
-                f"[ERROR] 설정 헤드셋 ID '{self.headset_id}' 미발견 + "
-                f"연결된 헤드셋 {len(headset_ids)}대 ({headset_ids}) — "
+                f"[ERROR] 설정 헤드셋 ID '{self.headset_id}' 미발견이고 "
+                f"연결된 헤드셋이 {len(headset_ids)}대({headset_ids})라 "
                 f"자동 선택 불가. 종료함 (subject {self.subject_index})"
             )
             self.close()
@@ -574,8 +574,8 @@ class MindSignalStreamer(Cortex):
                 if tripped and not self._fail_closed_triggered:
                     self._fail_closed_triggered = True
                     print(
-                        "[FAIL_CLOSED] proxy /health fail-closed 지속"
-                        f" — 측정 중단함 (subject {self.subject_index})"
+                        "[FAIL_CLOSED] proxy /health fail-closed 지속으로"
+                        f" 측정 중단함 (subject {self.subject_index})"
                     )
                     try:
                         self.close_session()
@@ -1010,7 +1010,7 @@ class MindSignalStreamer(Cortex):
                     if not self._fail_closed_triggered:
                         self._fail_closed_triggered = True
                         print(
-                            "[FAIL_CLOSED] proxy 전송 retry 소진 — 측정 중단함"
+                            "[FAIL_CLOSED] proxy 전송 retry 소진으로 측정 중단함"
                             f" (subject {self.subject_index})"
                         )
                         try:

--- a/server/app.py
+++ b/server/app.py
@@ -83,7 +83,7 @@ def _resolve_advertise_ip(explicit: str | None) -> str:
         except ValueError:
             pass
         print(
-            f"[WARN] LAN_IP={explicit} 이(가) Tailscale 대역(100.64.0.0/10) 밖이라 "
+            f"[WARN] LAN_IP={explicit!a} 이(가) Tailscale 대역(100.64.0.0/10) 밖이라 "
             "무시하고 자동탐지로 대체함 (cross-machine 도달 보장)"
         )
     return _detect_tailscale_ip() or socket.gethostbyname(socket.gethostname())

--- a/server/app.py
+++ b/server/app.py
@@ -83,7 +83,7 @@ def _resolve_advertise_ip(explicit: str | None) -> str:
         except ValueError:
             pass
         print(
-            f"[WARN] LAN_IP={explicit} 이(가) Tailscale 대역(100.64.0.0/10) 밖 — "
+            f"[WARN] LAN_IP={explicit} 이(가) Tailscale 대역(100.64.0.0/10) 밖이라 "
             "무시하고 자동탐지로 대체함 (cross-machine 도달 보장)"
         )
     return _detect_tailscale_ip() or socket.gethostbyname(socket.gethostname())

--- a/tests/test_log_encoding.py
+++ b/tests/test_log_encoding.py
@@ -10,6 +10,7 @@ stdout이 tty가 아니면 Python이 인코딩을 ANSI 코드페이지(Windows �
 """
 
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -19,10 +20,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SCANNED_DIRS = ("core", "server")
 
 
-def _print_literals(path: Path):
+def _print_literals(path: Path) -> Iterator[tuple[int, str]]:
     """파일 안 print() 호출 인자의 문자열 리터럴을 (줄번호, 값)으로 반환함.
 
-    docstring과 주석은 출력되지 않아 무해하므로 제외함 — 포함하면 오탐이 수십 건임.
+    docstring과 주석은 출력되지 않아 무해하므로 제외함. 포함하면 오탐이 수십 건임.
     """
     tree = ast.parse(path.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
@@ -34,9 +35,13 @@ def _print_literals(path: Path):
                 yield node.lineno, arg.value
 
 
-def test_print_literals_survive_cp949_stdout():
-    """print로 나가는 문자열은 전부 cp949로 인코딩 가능해야 함."""
-    offenders = []
+def test_print_literals_survive_cp949_stdout() -> None:
+    """print로 나가는 문자열은 전부 cp949로 인코딩 가능해야 함.
+
+    리터럴만 검사함. 보간되는 런타임 값(env에서 온 headset_id와 LAN_IP)은 정적으로
+    알 수 없어 호출부에서 `!a` 변환으로 ASCII를 보장함.
+    """
+    offenders: list[str] = []
     for directory in SCANNED_DIRS:
         for path in sorted((REPO_ROOT / directory).rglob("*.py")):
             for lineno, value in _print_literals(path):

--- a/tests/test_log_encoding.py
+++ b/tests/test_log_encoding.py
@@ -1,0 +1,52 @@
+"""런타임 로그가 cp949 콘솔에서 죽지 않는지 검증함 (EEG-W004)
+
+stdout이 tty가 아니면 Python이 인코딩을 ANSI 코드페이지(Windows 한국어는 cp949)로
+확정함. `server/services/stream.py`가 `core.main` stdout을 로그 파일로 redirect하므로
+그 경로는 상시 cp949이고, em dash 같은 문자를 출력하면 UnicodeEncodeError로 프로세스가
+죽음. 2026-06-30 측정 1건이 실제로 이 원인으로 0초 종료함.
+
+`run_server.py` 진입점이 utf-8을 강제하지만 그것을 거치지 않는 진입점이 생기면 방어가
+빠지므로 소스 자체도 안전하게 유지함.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# sdk/는 Emotiv 제공 원본이라 수정 금지(AGENTS.md 5장). cortex.py에 U+274C가 남아
+# 있으나 손댈 수 없어 진입점 방어에 의존하므로 스캔 대상에서 제외함.
+SCANNED_DIRS = ("core", "server")
+
+
+def _print_literals(path: Path):
+    """파일 안 print() 호출 인자의 문자열 리터럴을 (줄번호, 값)으로 반환함.
+
+    docstring과 주석은 출력되지 않아 무해하므로 제외함 — 포함하면 오탐이 수십 건임.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        is_print = isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        if not (is_print and node.func.id == "print"):
+            continue
+        for arg in ast.walk(node):
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                yield node.lineno, arg.value
+
+
+def test_print_literals_survive_cp949_stdout():
+    """print로 나가는 문자열은 전부 cp949로 인코딩 가능해야 함."""
+    offenders = []
+    for directory in SCANNED_DIRS:
+        for path in sorted((REPO_ROOT / directory).rglob("*.py")):
+            for lineno, value in _print_literals(path):
+                try:
+                    value.encode("cp949")
+                except UnicodeEncodeError as exc:
+                    char = value[exc.start : exc.end]
+                    rel = path.relative_to(REPO_ROOT).as_posix()
+                    offenders.append(f"{rel}:{lineno} {char!r} (U+{ord(char):04X})")
+
+    assert (
+        not offenders
+    ), "cp949 콘솔에서 UnicodeEncodeError로 죽는 로그:\n" + "\n".join(offenders)


### PR DESCRIPTION
Closes #48

PR #47이 `run_server.py` 진입점에서 stdout utf-8을 강제해 **노출 조건은 이미 없앴다.** 이건 다중 방어다 — `run_server.py`를 거치지 않는 진입점(`uvicorn server.app:app` 직접 실행 등)이 생기면 그 방어가 통째로 빠진다.

## 문제

stdout이 tty가 아니면 Python은 인코딩을 ANSI 코드페이지(cp949)로 확정한다. `server/services/stream.py:94-95`가 `core.main` stdout을 로그 파일로 redirect하므로 **그 경로는 상시 cp949다.** em dash가 든 로그를 출력하는 순간 `UnicodeEncodeError`로 프로세스가 죽는다.

**실피해 1회 실측**: `logs/core_6a438aa5248f0e3f0c6eaba5_1.log`에 측정이 0초로 종료한 기록이 있다. 2026-06-30의 후속 커밋 `6faf7c8`은 그때 터진 문자열 하나의 em dash만 지웠고 클래스는 놔뒀다. 그래서 이번에 같은 지뢰가 6곳 더 나왔다.

## 변경

`print()` 인자만 AST로 훑어 cp949 인코딩 불가 리터럴을 찾았다. docstring과 주석은 출력되지 않아 무해하므로 제외했다.

| 위치 | 발동 조건 |
|---|---|
| `core/streamer.py:459` | connected 헤드셋 2대 이상 |
| `core/streamer.py:476` | 설정 헤드셋 ID 미발견, 폴백 |
| `core/streamer.py:484` | ID 미발견이고 연결 0대 |
| `core/streamer.py:490` | ID 미발견이고 연결 다수 |
| **`core/streamer.py:576`** | **proxy fail-closed로 측정 중단** |
| **`core/streamer.py:1012`** | **proxy 전송 retry 소진으로 측정 중단** |
| `server/app.py:85` | `LAN_IP`가 Tailscale 대역 밖 |

**576과 1012가 가장 나쁘다.** 측정 중단 처리 도중에 발동하므로 여기서 죽으면 CSV 업로드 같은 정상 종료 경로를 통째로 건너뛴다. "중단하면서 데이터도 잃는" 경로다.

기호를 ASCII 하이픈으로 치환하지 않고 **문장을 평문으로 다시 썼다.** 치환만 하면 같은 실수가 읽기 나쁜 로그로 남는다. `[WARN]`, `[ERROR]`, `[FAIL_CLOSED]` 접두사는 운영자 대시보드와 진단이 읽으므로 건드리지 않았다.

## `sdk/cortex.py:432`는 고치지 않았다

U+274C(❌)가 **모든 Cortex 오류 보고 경로**에 있어 위험도는 높다. 오류 진단 출력 자체가 2차 크래시를 내는 위치다. 다만 `sdk/`는 Emotiv 제공 원본이고 수정 금지가 AGENTS.md 5장에 명시돼 있어 규칙을 우선했다. 진입점 방어(PR #47)에 의존한다. 회귀 테스트에서도 `sdk/`를 제외했고 그 이유를 테스트 본문에 주석으로 남겼다.

## 회귀 테스트

`tests/test_log_encoding.py` 1건을 넣었다. `core/`와 `server/`의 `print()` 인자 문자열을 전부 cp949로 인코딩해 보고, 실패하면 파일과 줄번호와 문자를 코드포인트까지 찍는다.

이게 없으면 재발한다. `6faf7c8`이 정확히 그렇게 한 건만 고치고 클래스를 남긴 전례가 있다.

**테스트가 실제로 잡는지 먼저 확인했다.** 수정본을 `git stash`로 잠시 되돌린 상태에서 돌려 7곳을 전부 지목하고 실패하는 것을 본 뒤 복원했다.

```
E  core/streamer.py:476 '—' (U+2014)
E  core/streamer.py:484 '—' (U+2014)
E  core/streamer.py:490 '—' (U+2014)
E  core/streamer.py:459 '—' (U+2014)
E  core/streamer.py:576 '—' (U+2014)
E  core/streamer.py:1012 '—' (U+2014)
E  server/app.py:85 '—' (U+2014)
1 failed
```

## 검증

```
black .    1 file reformatted (신규 테스트), 53 unchanged
isort .    변경 없음
flake8 .   위반 0건
pytest     267 passed  (266 더하기 신규 1)
```

## 주의 — 증상이 인증서 누락과 같다

둘 다 "측정 0초 종료"로 나타난다. 로그 첫 줄로 갈라낸다. `SSL CA certificate loading failed`면 인증서(D8), `UnicodeEncodeError`면 이쪽이다.

상시 점검은 `grep -l UnicodeEncodeError logs/core_*.log`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 헤드셋 선택 및 프록시 중단 관련 메시지의 표현을 명확하게 다듬었습니다.
  * 네트워크 주소 경고 메시지의 구분 표현을 개선했습니다.
  * 콘솔 출력 문자열의 CP949 인코딩 호환성을 자동으로 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->