### PR TITLE
feat(analysis): friendship score 정본 수식 1단계 (ANALYSIS-W004)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,8 @@ FS_W_FAA=           # FAA 회피 항 가중치, 기본 0.0 (2단계에서 0.25)
 FS_CORR_METHOD=     # spearman 또는 pearson, 기본 spearman
 FS_SYNC_CHANNEL=    # 동조 대상 채널, 기본 Pz. 비우면 채널 공간평균 열 사용
 FS_SYNC_BAND=       # 동조 대상 대역, 기본 gamma
-FS_TRIM_START_SEC=  # 앞쪽 진정 구간 초, 기본 15
-FS_TRIM_END_SEC=    # 뒤쪽 진정 구간 초, 기본 15
-# trim 이후 유효 구간의 최소 초, 기본 180. 실제 필요 측정 시간은 앞뒤 trim을
+FS_TRIM_START_SEC=  # 앞쪽 제외 구간 초, 기본 30 (정본의 초반 30초 제외)
+FS_TRIM_END_SEC=    # 뒤쪽 제외 구간 초, 기본 0 (정본은 뒤를 자르지 않음)
+# trim 이후 유효 구간의 최소 초, 기본 180. 실제 필요 측정 시간은 trim을
 # 더한 210초(3분 30초)임. 백엔드와 프론트도 같은 이름을 쓰므로 FS_ 접두사 없음
 MIN_ANALYSIS_SECONDS=

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ FS_CORR_METHOD=     # spearman 또는 pearson, 기본 spearman
 FS_SYNC_CHANNELS=   # 동조 대상 채널, 쉼표 구분. 기본 T7,T8,Pz (측두-두정엽)
                     # none을 주면 채널별 열 대신 CSV 공간평균 열 사용
 FS_SYNC_BAND=       # 동조 대상 대역, 기본 gamma
+FS_MIN_SYNCHRONY_PAIRS=  # 상관을 낼 최소 유효 쌍 수, 기본 10
 FS_TRIM_START_SEC=  # 앞쪽 제외 구간 초, 기본 30 (정본의 초반 30초 제외)
 FS_TRIM_END_SEC=    # 뒤쪽 제외 구간 초, 기본 0 (정본은 뒤를 자르지 않음)
 # trim 이후 유효 구간의 최소 초, 기본 180. 실제 필요 측정 시간은 trim을

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,8 @@ GOOGLE_API_KEY=
 FS_W_SYNC=          # 동조 항 가중치, 기본 1.0
 FS_W_FAA=           # FAA 회피 항 가중치, 기본 0.0 (2단계에서 0.25)
 FS_CORR_METHOD=     # spearman 또는 pearson, 기본 spearman
-FS_SYNC_CHANNEL=    # 동조 대상 채널, 기본 Pz. 비우면 채널 공간평균 열 사용
+FS_SYNC_CHANNELS=   # 동조 대상 채널, 쉼표 구분. 기본 T7,T8,Pz (측두-두정엽)
+                    # none을 주면 채널별 열 대신 CSV 공간평균 열 사용
 FS_SYNC_BAND=       # 동조 대상 대역, 기본 gamma
 FS_TRIM_START_SEC=  # 앞쪽 제외 구간 초, 기본 30 (정본의 초반 30초 제외)
 FS_TRIM_END_SEC=    # 뒤쪽 제외 구간 초, 기본 0 (정본은 뒤를 자르지 않음)

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,16 @@ NGROK_AUTH_TOKEN=
 
 # External API
 GOOGLE_API_KEY=
+
+# Friendship Score 파라미터 (ANALYSIS-W004). 전부 비우면 정본 기본값 사용
+# 실제 사용값은 분석 결과의 score_params에 그대로 실려 사후 구분이 가능함
+FS_W_SYNC=          # 동조 항 가중치, 기본 1.0
+FS_W_FAA=           # FAA 회피 항 가중치, 기본 0.0 (2단계에서 0.25)
+FS_CORR_METHOD=     # spearman 또는 pearson, 기본 spearman
+FS_SYNC_CHANNEL=    # 동조 대상 채널, 기본 Pz. 비우면 채널 공간평균 열 사용
+FS_SYNC_BAND=       # 동조 대상 대역, 기본 gamma
+FS_TRIM_START_SEC=  # 앞쪽 진정 구간 초, 기본 15
+FS_TRIM_END_SEC=    # 뒤쪽 진정 구간 초, 기본 15
+# trim 이후 유효 구간의 최소 초, 기본 180. 실제 필요 측정 시간은 앞뒤 trim을
+# 더한 210초(3분 30초)임. 백엔드와 프론트도 같은 이름을 쓰므로 FS_ 접두사 없음
+MIN_ANALYSIS_SECONDS=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,8 @@ Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>
 - **제거된 API** — `filter_delta`부터 `filter_gamma`까지 5개 메서드와 `_butter_bandpass`와 `get_rms_power`는 제거됐다(Welch 경로에 "필터링된 시계열"이라는 중간 산출물이 없어 전부 호출자 0건이었음). 대체는 `get_band_power(values, band)`다.
 - **짧은 창 금지** — 128샘플 미만은 빈 간격이 넓어져 대역에 빈이 안 잡히고 예외 없이 0.0이나 무의미한 값이 나온다(길이 16에서 theta와 alpha가 나란히 11.86). `_band_powers_from` 진입부에서 `ValueError`로 막으므로 `get_all_powers`와 `get_band_power` 모두 보호된다. 라이브 경로는 `streamer`가 비오버랩으로 버퍼를 비워 항상 128이다.
 - **DC 제거자는 하나다** — `_remove_dc`가 유일하며 `welch`는 `detrend=False`로 부른다. 둘을 겹쳐 두면 어느 쪽을 없애도 결과가 같아져 회귀 테스트가 무력해진다. 상수 DC 입력 테스트가 이 계약을 지킨다.
-- **Synchrony** — 두 피실험자 간 뇌파 상관계수 (Pearson correlation)
+- **Synchrony** — 두 피실험자 간 뇌파 상관계수. **2026-08-03(ANALYSIS-W004)부터 스피어만 순위상관이고 대상은 측두-두정엽(T7, T8, Pz) 감마 채널 평균이다.** 피어슨과 alpha 공간평균은 그 이전 구현이며 `FS_CORR_METHOD=pearson`으로만 재현된다. 방식과 대상은 `server/services/score_params.py`의 `ScoreParams`가 정본이고 실제 사용값은 분석 결과의 `score_params`에 실린다
+- **Friendship Score** — 정본 수식 점수(0..100). 동조율에 100을 곱한 값이 **아니라** 민맥스 정규화 가중합이라 상관 0이 50점이다. FAA 회피 항은 2단계 미연결 상태다
 - **EmotivMetrics (MET)** — Emotiv 자체 산출 지표 6종 (focus, engagement, interest, excitement, stress, relaxation)
 - **Cortex API** — Emotiv 헤드셋과 WebSocket(wss://localhost:6868) JSON-RPC 인터페이스
 

--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -49,7 +49,11 @@ class MindSignalAnalyzer:
         return faa_score
 
     @staticmethod
-    def calculate_synchrony(user1_eeg, user2_eeg, method: str = "pearson"):
+    def calculate_synchrony(
+        user1_eeg: np.ndarray,
+        user2_eeg: np.ndarray,
+        method: str = "pearson",
+    ) -> float:
         """두 사용자 간의 뇌파 동조율 계산함.
 
         **상관 계산은 이 메서드 한 곳으로만 들어감.** 호출부가 scipy를 직접
@@ -67,13 +71,24 @@ class MindSignalAnalyzer:
         Raises:
             ValueError: 미지원 method임
         """
+        if method not in ("pearson", "spearman"):
+            raise ValueError(f"미지원 상관 방식 {method!r}")
+
+        # 결측 제거를 두 경로에서 통일함. corrcoef는 NaN이 하나만 있어도
+        # 전체가 nan이고 spearmanr(nan_policy="omit")은 쌍만 빼므로, 마스크를
+        # 미리 걸지 않으면 같은 입력에서 방식마다 결과 의미가 달라짐
+        left = np.asarray(user1_eeg, dtype=float)
+        right = np.asarray(user2_eeg, dtype=float)
+        mask = np.isfinite(left) & np.isfinite(right)
+        left, right = left[mask], right[mask]
+        if left.size < 2:
+            return float("nan")
+
         if method == "pearson":
-            return np.corrcoef(user1_eeg, user2_eeg)[0, 1]
-        if method == "spearman":
-            # 순위상관은 단조 변환에 불변이라 대역 값이 파워인지 RMS인지에
-            # 영향받지 않음. nan_policy는 결측 쌍만 제외함
-            return spearmanr(user1_eeg, user2_eeg, nan_policy="omit").statistic
-        raise ValueError(f"미지원 상관 방식 {method!r}")
+            return float(np.corrcoef(left, right)[0, 1])
+        # 순위상관은 단조 변환에 불변이라 대역 값이 파워인지 RMS인지에
+        # 영향받지 않음. scipy 1.15에서 결과 객체의 statistic을 씀
+        return float(spearmanr(left, right).statistic)
 
     def __init__(self, sampling_rate: int = 128) -> None:
         # Emotiv Insight의 샘플링 레이트는 초당 128Hz임

--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.signal import welch
+from scipy.stats import spearmanr
 
 
 class MindSignalAnalyzer:
@@ -48,10 +49,31 @@ class MindSignalAnalyzer:
         return faa_score
 
     @staticmethod
-    def calculate_synchrony(user1_eeg, user2_eeg):
-        """두 사용자 간의 뇌파 동기화(Correlation) 계산"""
-        correlation = np.corrcoef(user1_eeg, user2_eeg)[0, 1]
-        return correlation
+    def calculate_synchrony(user1_eeg, user2_eeg, method: str = "pearson"):
+        """두 사용자 간의 뇌파 동조율 계산함.
+
+        **상관 계산은 이 메서드 한 곳으로만 들어감.** 호출부가 scipy를 직접
+        부르면 여기를 mock한 기존 테스트가 조용히 무력화됨.
+
+        Args:
+            user1_eeg: 첫 피실험자 시계열임
+            user2_eeg: 둘째 피실험자 시계열임
+            method: "pearson" 또는 "spearman"임. 정본 수식은 스피어만 순위상관
+
+        Returns:
+            상관계수 반환. 한쪽이 상수면 nan이 나올 수 있으므로 호출부가
+            유한성을 확인해야 함
+
+        Raises:
+            ValueError: 미지원 method임
+        """
+        if method == "pearson":
+            return np.corrcoef(user1_eeg, user2_eeg)[0, 1]
+        if method == "spearman":
+            # 순위상관은 단조 변환에 불변이라 대역 값이 파워인지 RMS인지에
+            # 영향받지 않음. nan_policy는 결측 쌍만 제외함
+            return spearmanr(user1_eeg, user2_eeg, nan_policy="omit").statistic
+        raise ValueError(f"미지원 상관 방식 {method!r}")
 
     def __init__(self, sampling_rate: int = 128) -> None:
         # Emotiv Insight의 샘플링 레이트는 초당 128Hz임

--- a/server/app.py
+++ b/server/app.py
@@ -4,7 +4,6 @@ import socket
 from contextlib import asynccontextmanager
 
 import httpx
-from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
@@ -22,7 +21,7 @@ from server.services.webhook import (
     unregister_to_backend_pending,
 )
 
-load_dotenv(".env.local")
+# .env.local 로드는 server.config가 import 시점에 처리함(순서 의존 제거)
 
 # Preflight soft-check: ENGINE_SECRET_KEY가 placeholder면 WARNING 로그만 출력함
 # (Phase 17.5.1 — abort 제거). 실기기 테스트 등 placeholder 그대로 쓰다가 실험 후

--- a/server/config.py
+++ b/server/config.py
@@ -1,8 +1,18 @@
 import os
+from pathlib import Path
 from typing import Literal
 
 import certifi
+from dotenv import load_dotenv
 from pydantic_settings import BaseSettings
+
+# .env.local을 os.environ에 실제로 싣는 유일한 지점임. Settings의 env_file은
+# 이 클래스만 채우고 os.environ에는 넣지 않으므로, os.getenv로 읽는 쪽
+# (ScoreParams.from_env 등)은 이것이 없으면 값을 못 봄.
+# **config에서 하는 이유**: app.py에서 부르면 그보다 먼저 import되는 모듈이
+# 이미 os.getenv를 끝낸 뒤라 설정이 조용히 무시됨(실측: FS_ 파라미터 전부).
+# 절대경로인 이유는 cwd에 의존하지 않기 위함임
+load_dotenv(Path(__file__).resolve().parent.parent / ".env.local")
 
 # SSL_CERT_FILE이 존재하지 않는 경로를 가리키면 certifi 번들로 교정함.
 # conda base 활성화가 심는 stale 값(miniconda3/ssl/cacert.pem 부재)으로 httpx가

--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -109,6 +109,10 @@ class PipelineResponse(BaseModel):
     pair_features: dict[str, float] | None = None
     y_score: float | None = None
     synchrony_score: float | None = None
+    # 정본 수식 점수임. 동조율에 100을 곱한 값이 아니라 민맥스 정규화 가중합이며
+    # 상관 0이 50점임. score_params에 실제 사용값 원장이 실림
+    friendship_score: float | None = None
+    score_params: dict | None = None
     pipeline_params: dict
     markdown: str | None = None
     similarity_features: dict | None = None  # SEQUENTIAL 모드 전용 유사도 결과
@@ -169,6 +173,8 @@ async def analyze_pipeline(
             pair_features=result.get("pair_features"),
             y_score=result.get("y_score"),
             synchrony_score=result.get("synchrony_score"),
+            friendship_score=result.get("friendship_score"),
+            score_params=result.get("score_params"),
             pipeline_params=result.get("pipeline_params", {}),
             similarity_features={"mode": "DUAL_2PC"},  # 메타데이터
         )

--- a/server/routes/analyze.py
+++ b/server/routes/analyze.py
@@ -112,7 +112,10 @@ class PipelineResponse(BaseModel):
     # 정본 수식 점수임. 동조율에 100을 곱한 값이 아니라 민맥스 정규화 가중합이며
     # 상관 0이 50점임. score_params에 실제 사용값 원장이 실림
     friendship_score: float | None = None
+    # 설정 원장(score_params)과 산출 메타(score_meta)를 분리함. 원장은 항상
+    # 같은 키를 내고, 메타에는 사용한 열과 유효 쌍 수와 미산출 사유가 담김
     score_params: dict | None = None
+    score_meta: dict | None = None
     pipeline_params: dict
     markdown: str | None = None
     similarity_features: dict | None = None  # SEQUENTIAL 모드 전용 유사도 결과
@@ -175,6 +178,7 @@ async def analyze_pipeline(
             synchrony_score=result.get("synchrony_score"),
             friendship_score=result.get("friendship_score"),
             score_params=result.get("score_params"),
+            score_meta=result.get("score_meta"),
             pipeline_params=result.get("pipeline_params", {}),
             similarity_features={"mode": "DUAL_2PC"},  # 메타데이터
         )

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections import OrderedDict
 from dataclasses import dataclass
 from math import ceil
@@ -9,18 +8,31 @@ import numpy as np
 import pandas as pd
 
 from core.analyzer import MindSignalAnalyzer
+from server.services.friendship import compute_friendship_score
+from server.services.score_params import ScoreParams
 
 logger = logging.getLogger(__name__)
 
 # CSV 저장 기본 경로 (streamer.py와 동일한 위치)
 CSV_BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "csv"
 
-# 측정 진정 구간 — 분석 제외, 표시만 함
-TRIM_START_SECONDS = 15
-TRIM_END_SECONDS = 15
+# 구간 상수의 정본은 ScoreParams임. 아래 세 이름은 하위 호환 별칭이며
+# **import 시점 스냅샷**이라 이후의 환경변수 변경을 반영하지 않음.
+# 런타임 값이 필요하면 ScoreParams.from_env()를 호출할 것
+_DEFAULT_PARAMS = ScoreParams.from_env()
 
-# 최소 분석 가능 시간 (trimming 후 유효 구간 기준, 임시값 — 교수 확인 후 확정)
-MIN_ANALYSIS_SECONDS = int(os.getenv("MIN_ANALYSIS_SECONDS", 180))
+# 측정 진정 구간 — 분석 제외, 표시만 함
+TRIM_START_SECONDS = _DEFAULT_PARAMS.trim_start_sec
+TRIM_END_SECONDS = _DEFAULT_PARAMS.trim_end_sec
+
+# 최소 분석 가능 시간 (trimming 후 유효 구간 기준, 임시값 — 교수 확인 후 확정).
+# 실제 필요 측정 시간은 여기에 앞뒤 trim을 더한 ScoreParams.required_total_sec임
+MIN_ANALYSIS_SECONDS = _DEFAULT_PARAMS.min_analysis_sec
+
+
+def _resolve_params(params: ScoreParams | None) -> ScoreParams:
+    """생략된 파라미터를 모듈 기본값으로 채움"""
+    return params if params is not None else _DEFAULT_PARAMS
 
 
 class AnalysisContractError(Exception):
@@ -44,16 +56,20 @@ class WindowSlot:
     data: pd.DataFrame | None
 
 
-def classify_session_tier(total_samples: int) -> str:
+def classify_session_tier(total_samples: int, params: ScoreParams | None = None) -> str:
     """측정 시간 기반 세션 tier를 분류함 (1행 = 1초 가정)
 
+    판정 기준은 trim 이후 유효 구간이므로, VALID에 필요한 총 측정 시간은
+    params.required_total_sec임(기본값 210초). trim을 바꾸면 함께 흔들림.
+
     Returns:
-        "VALID" — 유효 구간 ≥ MIN_ANALYSIS_SECONDS
-        "PARTIAL" — trimming 후 > 0초, < MIN
-        "ABORTED" — trimming 후 ≤ 0초
+        "VALID" — 유효 구간이 min_analysis_sec 이상임
+        "PARTIAL" — trimming 후 0초 초과, 최소 미만임
+        "ABORTED" — trimming 후 0초 이하임
     """
-    effective = total_samples - TRIM_START_SECONDS - TRIM_END_SECONDS
-    if effective >= MIN_ANALYSIS_SECONDS:
+    resolved = _resolve_params(params)
+    effective = total_samples - resolved.trim_start_sec - resolved.trim_end_sec
+    if effective >= resolved.min_analysis_sec:
         return "VALID"
     elif effective > 0:
         return "PARTIAL"
@@ -61,19 +77,24 @@ def classify_session_tier(total_samples: int) -> str:
         return "ABORTED"
 
 
-def trim_dataframe(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+def trim_dataframe(
+    df: pd.DataFrame, params: ScoreParams | None = None
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """진정 구간 trimming 수행함
 
     Returns:
         (trimmed_df, baseline_df)
-        - trimmed_df: 유효 분석 구간 (시작 15초 ~ 종료-15초)
-        - baseline_df: 시작 15초 구간 (기저 뇌파 참조용)
+        - trimmed_df: 유효 분석 구간 (시작 trim 이후부터 종료 trim 이전까지)
+        - baseline_df: 시작 trim 구간 (기저 뇌파 참조용)
     """
+    resolved = _resolve_params(params)
     total = len(df)
-    end_trim = max(0, total - TRIM_END_SECONDS)
+    end_trim = max(0, total - resolved.trim_end_sec)
 
-    baseline_df = df.iloc[:TRIM_START_SECONDS].copy()
-    trimmed_df = df.iloc[TRIM_START_SECONDS:end_trim].copy().reset_index(drop=True)
+    baseline_df = df.iloc[: resolved.trim_start_sec].copy()
+    trimmed_df = (
+        df.iloc[resolved.trim_start_sec : end_trim].copy().reset_index(drop=True)
+    )
 
     return trimmed_df, baseline_df
 
@@ -185,39 +206,114 @@ def align_on_second(
     return frames[0].merge(frames[1], on="sec", how="inner", suffixes=("_1", "_2"))
 
 
-def compute_synchrony(df1: pd.DataFrame, df2: pd.DataFrame) -> float | None:
-    """두 피실험자 간 뇌파 동기화 점수를 계산함 (trimming 적용).
+MIN_SYNCHRONY_PAIRS = 10
 
-    각 피실험자의 진정 구간을 먼저 제거한 뒤 공통 절대시각 구간만 비교함.
-    측정 시작 시각이 어긋나도(2026-07-10 라이브: 38.3초 차이) 같은 시각끼리
-    맞대므로 시차가 상관에 섞이지 않음.
+
+def resolve_sync_column(
+    df1: pd.DataFrame, df2: pd.DataFrame, params: ScoreParams
+) -> str | None:
+    """양쪽 DataFrame에 모두 있는 동조 대상 열을 우선순위대로 고름.
+
+    정본은 Pz 감마지만 채널별 열은 현행 37열 CSV에만 있음. 구형 CSV에서는
+    공간평균 열로 폴백하되 **무엇을 썼는지 호출부가 결과에 남겨야 함** —
+    조용한 폴백은 나중에 "왜 점수가 다르지"를 만듦.
+
+    Returns:
+        선택된 열 이름 반환. 후보가 하나도 없으면 None 반환
     """
+    for candidate in params.sync_column_candidates:
+        if candidate in df1.columns and candidate in df2.columns:
+            return candidate
+    return None
+
+
+def _correlate_pair(
+    df1: pd.DataFrame,
+    df2: pd.DataFrame,
+    column: str,
+    params: ScoreParams,
+) -> tuple[float | None, int]:
+    """지정 열의 두 시계열을 정렬해 상관과 유효 쌍 수를 반환함"""
     analyzer = MindSignalAnalyzer()
-
-    # trimming 적용 — 진정 구간 제외한 유효 구간만 사용함
-    trimmed1, _ = trim_dataframe(df1)
-    trimmed2, _ = trim_dataframe(df2)
-
-    aligned = align_on_second(trimmed1, trimmed2, "alpha")
+    aligned = align_on_second(df1, df2, column)
 
     if aligned is None:
         # timestamp 부재 시 구 위치 정렬로 폴백함 (합성 픽스처 호환)
         logger.warning("timestamp 컬럼 부재로 위치 기반 정렬 폴백함")
-        min_len = min(len(trimmed1), len(trimmed2))
-        if min_len < 10:
-            return None
-        alpha1 = trimmed1["alpha"].values[:min_len]
-        alpha2 = trimmed2["alpha"].values[:min_len]
-        return float(analyzer.calculate_synchrony(alpha1, alpha2))
+        min_len = min(len(df1), len(df2))
+        if min_len < MIN_SYNCHRONY_PAIRS:
+            return None, min_len
+        series1 = df1[column].values[:min_len]
+        series2 = df2[column].values[:min_len]
+        n_pairs = min_len
+    else:
+        if len(aligned) < MIN_SYNCHRONY_PAIRS:
+            return None, len(aligned)
+        series1 = aligned[f"{column}_1"].values
+        series2 = aligned[f"{column}_2"].values
+        n_pairs = len(aligned)
 
-    if len(aligned) < 10:
-        return None
+    rho = analyzer.calculate_synchrony(series1, series2, method=params.corr_method)
+    # 한쪽이 상수면 상관이 nan임. 그대로 흘리면 응답 직렬화에서 터지므로
+    # 미측정으로 낮춤(_finite_mask 주석의 Inf 사례와 같은 계열)
+    if rho is None or not np.isfinite(rho):
+        return None, n_pairs
+    return float(rho), n_pairs
 
-    return float(
-        analyzer.calculate_synchrony(
-            aligned["alpha_1"].values, aligned["alpha_2"].values
-        )
-    )
+
+def compute_synchrony(
+    df1: pd.DataFrame,
+    df2: pd.DataFrame,
+    params: ScoreParams | None = None,
+) -> tuple[float | None, dict]:
+    """두 피실험자 간 뇌파 동조율을 계산함 (trimming 적용).
+
+    각 피실험자의 진정 구간을 먼저 제거한 뒤 공통 절대시각 구간만 비교함.
+    측정 시작 시각이 어긋나도(2026-07-10 라이브: 38.3초 차이) 같은 시각끼리
+    맞대므로 시차가 상관에 섞이지 않음.
+
+    입력은 반드시 원본 CSV DataFrame임. average_by_timestamp를 거친 쪽은
+    band_cols만 남아 채널별 열이 사라짐.
+
+    Returns:
+        (동조율 또는 None, 메타 dict) 튜플 반환. 메타에는 사용한 열과 유효 쌍
+        수, 상관 방식, 그리고 공간평균 기준 병기값(sync_secondary)이 담김
+    """
+    resolved = _resolve_params(params)
+
+    # trimming 적용 — 진정 구간 제외한 유효 구간만 사용함
+    trimmed1, _ = trim_dataframe(df1, resolved)
+    trimmed2, _ = trim_dataframe(df2, resolved)
+
+    meta: dict = {
+        "corr_method": resolved.corr_method,
+        "sync_column_used": None,
+        "n_pairs": 0,
+        "sync_secondary": None,
+    }
+
+    column = resolve_sync_column(trimmed1, trimmed2, resolved)
+    if column is None:
+        logger.warning("동조 대상 열 부재함. 후보 %s", resolved.sync_column_candidates)
+        return None, meta
+
+    rho, n_pairs = _correlate_pair(trimmed1, trimmed2, column, resolved)
+    meta["sync_column_used"] = column
+    meta["n_pairs"] = n_pairs
+
+    # 공간평균 기준값 병기함. 점수에는 쓰지 않되, 감마가 근전도로 오염됐을 때
+    # "정본 준수와 강건성 중 무엇이 문제였나"를 사후에 판별할 유일한 수단임
+    # (docs/research/friendship-score-validity-threats.md 2절 권고)
+    spatial = resolved.sync_band
+    if (
+        column != spatial
+        and spatial in trimmed1.columns
+        and spatial in trimmed2.columns
+    ):
+        secondary, _ = _correlate_pair(trimmed1, trimmed2, spatial, resolved)
+        meta["sync_secondary"] = secondary
+
+    return rho, meta
 
 
 def compute_session_analysis(group_id: str, subject_indices: list[int]) -> dict:
@@ -240,7 +336,7 @@ def compute_session_analysis(group_id: str, subject_indices: list[int]) -> dict:
     synchrony_score = None
     if len(dataframes) == 2:
         keys = list(dataframes.keys())
-        synchrony_score = compute_synchrony(dataframes[keys[0]], dataframes[keys[1]])
+        synchrony_score, _ = compute_synchrony(dataframes[keys[0]], dataframes[keys[1]])
 
     return {
         "group_id": group_id,
@@ -556,6 +652,7 @@ def run_full_pipeline(
     baseline_duration_sec: int = 30,
     band_cols: list[str] | None = None,
     satisfaction_scores: dict[int, float] | None = None,
+    params: ScoreParams | None = None,
 ) -> dict:
     """알고리즘 명세의 전체 파이프라인을 실행함
 
@@ -605,6 +702,8 @@ def run_full_pipeline(
             "pair_features": None,
             "y_score": None,
             "synchrony_score": None,
+            "friendship_score": None,
+            "score_params": _resolve_params(params).to_dict(),
             "pipeline_params": {
                 "stimulus_duration_sec": stimulus_duration_sec,
                 "window_size_sec": window_size_sec,
@@ -697,13 +796,21 @@ def run_full_pipeline(
         if idx_a in satisfaction_scores and idx_b in satisfaction_scores:
             y_score = compute_y(satisfaction_scores[idx_a], satisfaction_scores[idx_b])
 
-    # 기존 compute_synchrony를 활용한 synchrony_score 계산 수행함
+    # 동조율과 Friendship Score 산출함. 입력은 반드시 raw_dataframes임 —
+    # normalized 쪽은 band_cols만 남아 채널별 열(Pz_gamma)이 사라짐
+    score_params = _resolve_params(params)
     synchrony_score = None
+    sync_meta: dict = {}
     if len(raw_dataframes) == 2:
         keys = list(raw_dataframes.keys())
-        synchrony_score = compute_synchrony(
-            raw_dataframes[keys[0]], raw_dataframes[keys[1]]
+        synchrony_score, sync_meta = compute_synchrony(
+            raw_dataframes[keys[0]], raw_dataframes[keys[1]], score_params
         )
+
+    # 1단계는 FAA 회피율이 없으므로 avoidance_rate=None임 (2단계에서 연결)
+    friendship_score, score_meta = compute_friendship_score(
+        synchrony_score, None, score_params
+    )
 
     return {
         "group_id": group_id,
@@ -711,6 +818,8 @@ def run_full_pipeline(
         "pair_features": pair_features,
         "y_score": y_score,
         "synchrony_score": synchrony_score,
+        "friendship_score": friendship_score,
+        "score_params": {**score_params.to_dict(), **sync_meta, **score_meta},
         "pipeline_params": {
             "stimulus_duration_sec": stimulus_duration_sec,
             "window_size_sec": window_size_sec,

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -19,7 +19,13 @@ CSV_BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "csv"
 # 구간 상수의 정본은 ScoreParams임. 아래 세 이름은 하위 호환 별칭이며
 # **import 시점 스냅샷**이라 이후의 환경변수 변경을 반영하지 않음.
 # 런타임 값이 필요하면 ScoreParams.from_env()를 호출할 것
-_DEFAULT_PARAMS = ScoreParams.from_env()
+try:
+    _DEFAULT_PARAMS = ScoreParams.from_env()
+except ValueError as exc:
+    # 잘못된 FS_ 값 하나로 서버가 통째로 못 뜨면 런처의 /health 게이트에서
+    # 원인 불명 기동 실패로 보임. 기본값으로 낮추고 무엇이 거부됐는지 남김
+    logger.error("점수 파라미터 환경변수가 유효하지 않아 기본값 사용함: %s", exc)
+    _DEFAULT_PARAMS = ScoreParams()
 
 # 측정 진정 구간 — 분석 제외, 표시만 함
 TRIM_START_SECONDS = _DEFAULT_PARAMS.trim_start_sec
@@ -103,7 +109,7 @@ def compute_baseline_from_warmup(
     baseline_df: pd.DataFrame,
     band_cols: list[str],
 ) -> dict[str, float]:
-    """시작 15초 진정 구간에서 기저 뇌파 평균을 추출함"""
+    """시작 trim 구간에서 기저 뇌파 평균을 추출함 (기본 30초)"""
     result = {}
     for band in band_cols:
         if band in baseline_df.columns:
@@ -217,6 +223,9 @@ _EMPTY_SCORE_META: dict = {
     "sync_secondary": None,
     "terms": [],
     "w_effective": None,
+    # 동조율이 왜 없는가(sync_reason)와 점수가 왜 없는가(reason)는 다른 질문임.
+    # 한 키로 합치면 뒤에 병합되는 쪽이 앞을 덮어써 원인이 사라짐
+    "sync_reason": None,
     "reason": None,
 }
 
@@ -248,7 +257,11 @@ def _sync_series(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
     채널 평균은 정본이 지정한 영역 전체를 하나의 시계열로 다루기 위함이며,
     단일 채널보다 창당 추정 잡음이 상쇄됨.
     """
-    series = df[columns].mean(axis=1)
+    # 한 채널이라도 결측이면 그 행을 NaN으로 둠(DataFrame.mean에는 min_count가
+    # 없어 마스크로 처리함). skipna 기본값 그대로면 행마다 평균 대상 채널이
+    # 달라져 상류의 결측 마스크 통일이 무의미해짐
+    values = df[columns]
+    series = values.mean(axis=1).where(values.notna().all(axis=1))
     frame = pd.DataFrame({SYNC_SERIES_COLUMN: series.values})
     if "timestamp" in df.columns:
         frame.insert(0, "timestamp", df["timestamp"].values)
@@ -741,7 +754,7 @@ def run_full_pipeline(
             "synchrony_score": None,
             "friendship_score": None,
             "score_params": _resolve_params(params).to_dict(),
-            "score_meta": {**_EMPTY_SCORE_META, "reason": "no_usable_csv"},
+            "score_meta": {**_EMPTY_SCORE_META, "sync_reason": "no_usable_csv"},
             "pipeline_params": {
                 "stimulus_duration_sec": stimulus_duration_sec,
                 "window_size_sec": window_size_sec,
@@ -841,7 +854,7 @@ def run_full_pipeline(
     # 나오는 상태가 됨(판정 기준을 pair_features와 통일함)
     score_params = _resolve_params(params)
     synchrony_score = None
-    sync_meta: dict = {"reason": "insufficient_subjects"}
+    sync_meta: dict = {"sync_reason": "insufficient_subjects"}
     usable = [idx for idx in subject_indices if idx in subject_features]
     if len(usable) == 2:
         synchrony_score, sync_meta = compute_synchrony(

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -209,22 +209,41 @@ def align_on_second(
 MIN_SYNCHRONY_PAIRS = 10
 
 
-def resolve_sync_column(
-    df1: pd.DataFrame, df2: pd.DataFrame, params: ScoreParams
-) -> str | None:
-    """양쪽 DataFrame에 모두 있는 동조 대상 열을 우선순위대로 고름.
+SYNC_SERIES_COLUMN = "_sync_series"
 
-    정본은 Pz 감마지만 채널별 열은 현행 37열 CSV에만 있음. 구형 CSV에서는
-    공간평균 열로 폴백하되 **무엇을 썼는지 호출부가 결과에 남겨야 함** —
-    조용한 폴백은 나중에 "왜 점수가 다르지"를 만듦.
+
+def resolve_sync_columns(
+    df1: pd.DataFrame, df2: pd.DataFrame, params: ScoreParams
+) -> list[str]:
+    """양쪽 DataFrame에 모두 있는 동조 대상 열을 고름.
+
+    정본은 측두-두정엽 셋(T7, T8, Pz)의 감마임. 채널별 열은 현행 37열 CSV에만
+    있으므로 구형 CSV에서는 공간평균 열로 폴백하되 **무엇을 썼는지 호출부가
+    결과에 남겨야 함** — 조용한 폴백은 나중에 "왜 점수가 다르지"를 만듦.
 
     Returns:
-        선택된 열 이름 반환. 후보가 하나도 없으면 None 반환
+        선택된 열 이름 목록 반환. 쓸 열이 없으면 빈 목록 반환
     """
-    for candidate in params.sync_column_candidates:
-        if candidate in df1.columns and candidate in df2.columns:
-            return candidate
-    return None
+    shared = set(df1.columns) & set(df2.columns)
+    channel_cols = [c for c in params.channel_columns if c in shared]
+    if channel_cols:
+        return channel_cols
+    if params.spatial_column in shared:
+        return [params.spatial_column]
+    return []
+
+
+def _sync_series(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+    """대상 열들의 채널 평균을 단일 시계열 열로 만든 DataFrame 반환함.
+
+    채널 평균은 정본이 지정한 영역 전체를 하나의 시계열로 다루기 위함이며,
+    단일 채널보다 창당 추정 잡음이 상쇄됨.
+    """
+    series = df[columns].mean(axis=1)
+    frame = pd.DataFrame({SYNC_SERIES_COLUMN: series.values})
+    if "timestamp" in df.columns:
+        frame.insert(0, "timestamp", df["timestamp"].values)
+    return frame
 
 
 def _correlate_pair(
@@ -276,7 +295,7 @@ def compute_synchrony(
     band_cols만 남아 채널별 열이 사라짐.
 
     Returns:
-        (동조율 또는 None, 메타 dict) 튜플 반환. 메타에는 사용한 열과 유효 쌍
+        (동조율 또는 None, 메타 dict) 튜플 반환. 메타에는 사용한 열들과 유효 쌍
         수, 상관 방식, 그리고 공간평균 기준 병기값(sync_secondary)이 담김
     """
     resolved = _resolve_params(params)
@@ -287,26 +306,35 @@ def compute_synchrony(
 
     meta: dict = {
         "corr_method": resolved.corr_method,
-        "sync_column_used": None,
+        "sync_columns_used": [],
         "n_pairs": 0,
         "sync_secondary": None,
     }
 
-    column = resolve_sync_column(trimmed1, trimmed2, resolved)
-    if column is None:
-        logger.warning("동조 대상 열 부재함. 후보 %s", resolved.sync_column_candidates)
+    columns = resolve_sync_columns(trimmed1, trimmed2, resolved)
+    if not columns:
+        logger.warning(
+            "동조 대상 열 부재함. 후보 %s 또는 %s",
+            resolved.channel_columns,
+            resolved.spatial_column,
+        )
         return None, meta
 
-    rho, n_pairs = _correlate_pair(trimmed1, trimmed2, column, resolved)
-    meta["sync_column_used"] = column
+    rho, n_pairs = _correlate_pair(
+        _sync_series(trimmed1, columns),
+        _sync_series(trimmed2, columns),
+        SYNC_SERIES_COLUMN,
+        resolved,
+    )
+    meta["sync_columns_used"] = columns
     meta["n_pairs"] = n_pairs
 
     # 공간평균 기준값 병기함. 점수에는 쓰지 않되, 감마가 근전도로 오염됐을 때
     # "정본 준수와 강건성 중 무엇이 문제였나"를 사후에 판별할 유일한 수단임
     # (docs/research/friendship-score-validity-threats.md 2절 권고)
-    spatial = resolved.sync_band
+    spatial = resolved.spatial_column
     if (
-        column != spatial
+        columns != [spatial]
         and spatial in trimmed1.columns
         and spatial in trimmed2.columns
     ):

--- a/server/services/analysis.py
+++ b/server/services/analysis.py
@@ -206,10 +206,19 @@ def align_on_second(
     return frames[0].merge(frames[1], on="sec", how="inner", suffixes=("_1", "_2"))
 
 
-MIN_SYNCHRONY_PAIRS = 10
-
-
 SYNC_SERIES_COLUMN = "_sync_series"
+
+# 산출 메타의 고정 키 집합임. 어느 경로로 나가든 같은 키가 나오게 해서
+# 하류가 키 존재를 가정할 수 있게 함
+_EMPTY_SCORE_META: dict = {
+    "corr_method": None,
+    "sync_columns_used": [],
+    "n_pairs": 0,
+    "sync_secondary": None,
+    "terms": [],
+    "w_effective": None,
+    "reason": None,
+}
 
 
 def resolve_sync_columns(
@@ -260,13 +269,13 @@ def _correlate_pair(
         # timestamp 부재 시 구 위치 정렬로 폴백함 (합성 픽스처 호환)
         logger.warning("timestamp 컬럼 부재로 위치 기반 정렬 폴백함")
         min_len = min(len(df1), len(df2))
-        if min_len < MIN_SYNCHRONY_PAIRS:
+        if min_len < params.min_synchrony_pairs:
             return None, min_len
         series1 = df1[column].values[:min_len]
         series2 = df2[column].values[:min_len]
         n_pairs = min_len
     else:
-        if len(aligned) < MIN_SYNCHRONY_PAIRS:
+        if len(aligned) < params.min_synchrony_pairs:
             return None, len(aligned)
         series1 = aligned[f"{column}_1"].values
         series2 = aligned[f"{column}_2"].values
@@ -732,6 +741,7 @@ def run_full_pipeline(
             "synchrony_score": None,
             "friendship_score": None,
             "score_params": _resolve_params(params).to_dict(),
+            "score_meta": {**_EMPTY_SCORE_META, "reason": "no_usable_csv"},
             "pipeline_params": {
                 "stimulus_duration_sec": stimulus_duration_sec,
                 "window_size_sec": window_size_sec,
@@ -825,14 +835,17 @@ def run_full_pipeline(
             y_score = compute_y(satisfaction_scores[idx_a], satisfaction_scores[idx_b])
 
     # 동조율과 Friendship Score 산출함. 입력은 반드시 raw_dataframes임 —
-    # normalized 쪽은 band_cols만 남아 채널별 열(Pz_gamma)이 사라짐
+    # normalized 쪽은 band_cols만 남아 채널별 열(T7_gamma 등)이 사라짐.
+    # 대상은 feature 산출에 성공한 subject로 한정함 — 계약 위반으로 분석에서
+    # 빠진 subject의 원본으로 점수를 내면 pair_features는 None인데 점수만
+    # 나오는 상태가 됨(판정 기준을 pair_features와 통일함)
     score_params = _resolve_params(params)
     synchrony_score = None
-    sync_meta: dict = {}
-    if len(raw_dataframes) == 2:
-        keys = list(raw_dataframes.keys())
+    sync_meta: dict = {"reason": "insufficient_subjects"}
+    usable = [idx for idx in subject_indices if idx in subject_features]
+    if len(usable) == 2:
         synchrony_score, sync_meta = compute_synchrony(
-            raw_dataframes[keys[0]], raw_dataframes[keys[1]], score_params
+            raw_dataframes[usable[0]], raw_dataframes[usable[1]], score_params
         )
 
     # 1단계는 FAA 회피율이 없으므로 avoidance_rate=None임 (2단계에서 연결)
@@ -847,7 +860,11 @@ def run_full_pipeline(
         "y_score": y_score,
         "synchrony_score": synchrony_score,
         "friendship_score": friendship_score,
-        "score_params": {**score_params.to_dict(), **sync_meta, **score_meta},
+        # 설정 원장과 산출 메타를 섞지 않음. 섞으면 경로마다 키 집합이 달라져
+        # 하류가 키 존재를 가정할 수 없고, corr_method처럼 양쪽에 있는 키가
+        # 조용히 덮어써짐. score_params는 항상 같은 키를 낸다
+        "score_params": score_params.to_dict(),
+        "score_meta": {**_EMPTY_SCORE_META, **sync_meta, **score_meta},
         "pipeline_params": {
             "stimulus_duration_sec": stimulus_duration_sec,
             "window_size_sec": window_size_sec,

--- a/server/services/friendship.py
+++ b/server/services/friendship.py
@@ -5,6 +5,8 @@
 잘라 0점을 냈고 그것이 가장 큰 왜곡이었음).
 """
 
+import math
+
 from server.services.score_params import ScoreParams
 
 
@@ -38,7 +40,10 @@ def compute_friendship_score(
     """
     meta: dict = {"terms": []}
 
-    if synchrony is None:
+    # nan을 그냥 흘리면 아래 clamp에서 max(0.0, nan)이 0.0을 내어 미측정이
+    # 완전 역상관과 같은 값이 됨. 상류(_correlate_pair)가 이미 막지만 이 함수도
+    # 공개 진입점이라 방어를 한 곳에만 두지 않음
+    if synchrony is None or not math.isfinite(synchrony):
         meta["reason"] = "synchrony_missing"
         return None, meta
 

--- a/server/services/friendship.py
+++ b/server/services/friendship.py
@@ -1,0 +1,67 @@
+"""Friendship Score 산출함.
+
+2026-06-22 회의 정본 수식의 가중 합을 0..100으로 환산함. 1단계는 FAA 회피
+항을 뺀 부분식이라 동조 항만 유효하고, 상관 0이 50점이 됨(기존 구현은 음수를
+잘라 0점을 냈고 그것이 가장 큰 왜곡이었음).
+"""
+
+from server.services.score_params import ScoreParams
+
+
+def normalize_synchrony(rho: float) -> float:
+    """상관계수를 민맥스 정규화함. 정의역 [-1, 1]에서 [0, 1]로 옮김"""
+    return (rho + 1.0) / 2.0
+
+
+def compute_friendship_score(
+    synchrony: float | None,
+    avoidance_rate: float | None,
+    params: ScoreParams,
+) -> tuple[float | None, dict]:
+    """정본 수식의 가중 합을 0..100 점수로 환산해 반환함.
+
+    동조율은 필수 항이고 FAA는 선택 항임. 이 비대칭은 의도이며 2단계에서도
+    유지함 — 수식 전체가 동조율 위에 서 있으므로 동조율 결측은 세션 실패로
+    보고 점수를 내지 않고, FAA 결측은 항만 빼고 분모를 줄임.
+
+    Args:
+        synchrony: 동조율(순위상관 등), 미측정이면 None임
+        avoidance_rate: FAA 회피율 [0, 1], 1단계는 항상 None임
+        params: 가중치와 구간 파라미터임
+
+    Returns:
+        (점수 또는 None, 산출 메타 dict) 튜플 반환. 점수는 소수 1자리이며
+        정수화는 저장 시점에 함
+
+    Raises:
+        ValueError: avoidance_rate가 [0, 1] 범위 밖임
+    """
+    meta: dict = {"terms": []}
+
+    if synchrony is None:
+        meta["reason"] = "synchrony_missing"
+        return None, meta
+
+    numerator = params.w_sync * normalize_synchrony(synchrony)
+    w_effective = params.w_sync
+    meta["terms"].append("sync")
+
+    if avoidance_rate is not None:
+        if not 0.0 <= avoidance_rate <= 1.0:
+            raise ValueError(
+                f"avoidance_rate는 [0, 1]이어야 함. 받은 값 {avoidance_rate}"
+            )
+        numerator += params.w_faa * (1.0 - avoidance_rate)
+        w_effective += params.w_faa
+        meta["terms"].append("faa")
+
+    # w_sync=0에 w_faa>0인 설정은 ScoreParams 검증을 통과하는데, 1단계는
+    # avoidance가 항상 None이라 유효 가중치가 0이 됨. 0으로 나누지 않고
+    # 미산출로 낮춤 — 파라미터를 실험용으로 열어둔 이상 이 조합은 들어옴
+    if w_effective <= 0:
+        meta["reason"] = "no_effective_term"
+        return None, meta
+
+    score = 100.0 * numerator / w_effective
+    meta["w_effective"] = w_effective
+    return round(min(100.0, max(0.0, score)), 1), meta

--- a/server/services/score_params.py
+++ b/server/services/score_params.py
@@ -1,0 +1,125 @@
+"""Friendship Score 산출 파라미터 정의함.
+
+2026-06-22 회의 정본 수식의 가중치와 구간을 전부 파라미터로 노출함. 졸업
+프로젝트가 자유로운 실험 체계여야 하므로 상수로 박지 않고, 실제 사용값을
+결과에 실어 어떤 설정으로 나온 점수인지 사후 구분 가능하게 함.
+"""
+
+import os
+from dataclasses import dataclass
+
+# 파라미터 값이 같아도 구현이 바뀐 경우를 구분하기 위한 식별자임.
+# 소급 부여가 불가능한 정보라 처음부터 결과에 실음. 2단계(FAA)에서 "2"로 올림
+FORMULA_VERSION = "1"
+
+_VALID_CORR_METHODS = ("spearman", "pearson")
+
+
+def _env_float(name: str, default: float) -> float:
+    """환경변수를 실수로 읽음. 미설정이거나 빈 값이면 기본값 반환"""
+    raw = os.getenv(name, "")
+    return float(raw) if raw.strip() else default
+
+
+def _env_int(name: str, default: int) -> int:
+    """환경변수를 정수로 읽음. 미설정이거나 빈 값이면 기본값 반환"""
+    raw = os.getenv(name, "")
+    return int(raw) if raw.strip() else default
+
+
+@dataclass(frozen=True)
+class ScoreParams:
+    """Friendship Score 산출에 쓰는 가중치와 구간 묶음임.
+
+    Attributes:
+        w_sync: 동조 항 가중치임. 정본 1.0
+        w_faa: FAA 회피 항 가중치임. 1단계는 0, 2단계에서 0.25
+        corr_method: 상관 방식임. 정본은 스피어만 순위상관
+        sync_channel: 동조 대상 채널임. None이면 채널 공간평균 열 사용
+        sync_band: 동조 대상 대역임. 정본은 감마
+        trim_start_sec: 측정 앞쪽 진정 구간 초임
+        trim_end_sec: 측정 뒤쪽 진정 구간 초임
+        min_analysis_sec: trim 이후 유효 구간의 최소 초임
+    """
+
+    w_sync: float = 1.0
+    w_faa: float = 0.0
+    corr_method: str = "spearman"
+    sync_channel: str | None = "Pz"
+    sync_band: str = "gamma"
+    trim_start_sec: int = 15
+    trim_end_sec: int = 15
+    min_analysis_sec: int = 180
+
+    def __post_init__(self) -> None:
+        """가중치 부호와 합, 상관 방식의 유효성을 검사함
+
+        Raises:
+            ValueError: 가중치가 음수이거나 합이 0 이하이거나 미지원 상관 방식임
+        """
+        if self.w_sync < 0 or self.w_faa < 0:
+            raise ValueError(
+                f"가중치는 음수일 수 없음. w_sync={self.w_sync} w_faa={self.w_faa}"
+            )
+        if self.w_sync + self.w_faa <= 0:
+            raise ValueError("w_sync와 w_faa의 합이 양수여야 함")
+        if self.corr_method not in _VALID_CORR_METHODS:
+            raise ValueError(
+                f"미지원 상관 방식 {self.corr_method!r}. "
+                f"허용값 {_VALID_CORR_METHODS}"
+            )
+
+    @property
+    def required_total_sec(self) -> int:
+        """tier VALID에 필요한 총 측정 초를 파생함.
+
+        min_analysis_sec은 trim 이후 유효 구간 기준이므로 앞뒤 진정 구간을
+        더해야 실제 필요 측정 시간이 됨(기본값에서 210초, 즉 3분 30초).
+        이 값을 별도 상수로 박지 말 것 — trim을 바꾸면 함께 흔들림.
+        """
+        return self.min_analysis_sec + self.trim_start_sec + self.trim_end_sec
+
+    @property
+    def sync_column_candidates(self) -> list[str]:
+        """동조 대상 열 후보를 우선순위 순으로 반환함.
+
+        채널별 열이 없는 구형 CSV를 위해 공간평균 열로 폴백함.
+        """
+        if self.sync_channel:
+            return [f"{self.sync_channel}_{self.sync_band}", self.sync_band]
+        return [self.sync_band]
+
+    @classmethod
+    def from_env(cls) -> "ScoreParams":
+        """환경변수에서 파라미터를 읽음.
+
+        모듈 import 시점이 아니라 호출 시점에 읽으므로 프로세스 재기동 없이도
+        테스트에서 monkeypatch로 바꿀 수 있음. MIN_ANALYSIS_SECONDS만 FS_
+        접두사가 없는데, 백엔드와 프론트도 같은 이름을 쓰는 의도적 예외임.
+        """
+        channel = os.getenv("FS_SYNC_CHANNEL", "Pz").strip()
+        return cls(
+            w_sync=_env_float("FS_W_SYNC", 1.0),
+            w_faa=_env_float("FS_W_FAA", 0.0),
+            corr_method=os.getenv("FS_CORR_METHOD", "spearman").strip() or "spearman",
+            sync_channel=channel or None,
+            sync_band=os.getenv("FS_SYNC_BAND", "gamma").strip() or "gamma",
+            trim_start_sec=_env_int("FS_TRIM_START_SEC", 15),
+            trim_end_sec=_env_int("FS_TRIM_END_SEC", 15),
+            min_analysis_sec=_env_int("MIN_ANALYSIS_SECONDS", 180),
+        )
+
+    def to_dict(self) -> dict:
+        """결과에 실을 파라미터 원장을 반환함"""
+        return {
+            "formula_version": FORMULA_VERSION,
+            "w_sync": self.w_sync,
+            "w_faa": self.w_faa,
+            "corr_method": self.corr_method,
+            "sync_channel": self.sync_channel,
+            "sync_band": self.sync_band,
+            "trim_start_sec": self.trim_start_sec,
+            "trim_end_sec": self.trim_end_sec,
+            "min_analysis_sec": self.min_analysis_sec,
+            "required_total_sec": self.required_total_sec,
+        }

--- a/server/services/score_params.py
+++ b/server/services/score_params.py
@@ -5,6 +5,7 @@
 결과에 실어 어떤 설정으로 나온 점수인지 사후 구분 가능하게 함.
 """
 
+import math
 import os
 from dataclasses import dataclass
 
@@ -41,6 +42,7 @@ class ScoreParams:
         trim_start_sec: 측정 앞쪽 제외 구간 초임. 정본은 baseline과 같은 30초
         trim_end_sec: 측정 뒤쪽 제외 구간 초임. 정본은 제외하지 않음(0)
         min_analysis_sec: trim 이후 유효 구간의 최소 초임
+        min_synchrony_pairs: 상관을 낼 최소 유효 쌍 수임
     """
 
     w_sync: float = 1.0
@@ -57,13 +59,31 @@ class ScoreParams:
     trim_start_sec: int = 30
     trim_end_sec: int = 0
     min_analysis_sec: int = 180
+    # 상관을 낼 최소 유효 쌍 수임. 동조율 산출 계약의 일부라 원장에 함께 실음
+    min_synchrony_pairs: int = 10
 
     def __post_init__(self) -> None:
-        """가중치 부호와 합, 상관 방식의 유효성을 검사함
+        """가중치와 구간과 상관 방식의 유효성을 검사함
+
+        설정을 실험용으로 열어 둔 구조라 잘못된 값은 반드시 들어옴. 로딩
+        지점에서 거부하지 않으면 음수 trim이 예외 없이 엉뚱한 구간을 자르고
+        nan 가중치가 검증을 다 통과해 응답 직렬화에서 터짐.
 
         Raises:
-            ValueError: 가중치가 음수이거나 합이 0 이하이거나 미지원 상관 방식임
+            ValueError: 가중치가 음수이거나 비유한이거나 합이 0 이하인 경우,
+                구간이 음수인 경우, 미지원 상관 방식인 경우임
         """
+        if not all(math.isfinite(w) for w in (self.w_sync, self.w_faa)):
+            raise ValueError(
+                f"가중치는 유한해야 함. w_sync={self.w_sync} w_faa={self.w_faa}"
+            )
+        for name in ("trim_start_sec", "trim_end_sec", "min_analysis_sec"):
+            if getattr(self, name) < 0:
+                raise ValueError(
+                    f"{name}는 음수일 수 없음. 받은 값 {getattr(self, name)}"
+                )
+        if self.min_synchrony_pairs < 2:
+            raise ValueError("min_synchrony_pairs는 2 이상이어야 함")
         if self.w_sync < 0 or self.w_faa < 0:
             raise ValueError(
                 f"가중치는 음수일 수 없음. w_sync={self.w_sync} w_faa={self.w_faa}"
@@ -119,14 +139,18 @@ class ScoreParams:
         return cls(
             w_sync=_env_float("FS_W_SYNC", base.w_sync),
             w_faa=_env_float("FS_W_FAA", base.w_faa),
-            corr_method=os.getenv("FS_CORR_METHOD", base.corr_method).strip()
+            # 대소문자를 정규화함. 오타 하나가 모듈 로드 실패로 이어지지 않게 함
+            corr_method=os.getenv("FS_CORR_METHOD", base.corr_method).strip().lower()
             or base.corr_method,
             sync_channels=channels,
-            sync_band=os.getenv("FS_SYNC_BAND", base.sync_band).strip()
+            sync_band=os.getenv("FS_SYNC_BAND", base.sync_band).strip().lower()
             or base.sync_band,
             trim_start_sec=_env_int("FS_TRIM_START_SEC", base.trim_start_sec),
             trim_end_sec=_env_int("FS_TRIM_END_SEC", base.trim_end_sec),
             min_analysis_sec=_env_int("MIN_ANALYSIS_SECONDS", base.min_analysis_sec),
+            min_synchrony_pairs=_env_int(
+                "FS_MIN_SYNCHRONY_PAIRS", base.min_synchrony_pairs
+            ),
         )
 
     def to_dict(self) -> dict:
@@ -141,5 +165,6 @@ class ScoreParams:
             "trim_start_sec": self.trim_start_sec,
             "trim_end_sec": self.trim_end_sec,
             "min_analysis_sec": self.min_analysis_sec,
+            "min_synchrony_pairs": self.min_synchrony_pairs,
             "required_total_sec": self.required_total_sec,
         }

--- a/server/services/score_params.py
+++ b/server/services/score_params.py
@@ -35,7 +35,8 @@ class ScoreParams:
         w_sync: 동조 항 가중치임. 정본 1.0
         w_faa: FAA 회피 항 가중치임. 1단계는 0, 2단계에서 0.25
         corr_method: 상관 방식임. 정본은 스피어만 순위상관
-        sync_channel: 동조 대상 채널임. None이면 채널 공간평균 열 사용
+        sync_channels: 동조 대상 채널 묶음임. 둘 이상이면 채널 평균을 씀.
+            비어 있으면 CSV의 공간평균 열을 그대로 사용
         sync_band: 동조 대상 대역임. 정본은 감마
         trim_start_sec: 측정 앞쪽 제외 구간 초임. 정본은 baseline과 같은 30초
         trim_end_sec: 측정 뒤쪽 제외 구간 초임. 정본은 제외하지 않음(0)
@@ -45,7 +46,10 @@ class ScoreParams:
     w_sync: float = 1.0
     w_faa: float = 0.0
     corr_method: str = "spearman"
-    sync_channel: str | None = "Pz"
+    # 정본은 측두-두정엽 셋임. 제안서 원문이 "두 참여자의 측두, 두정엽 감마파의
+    # 시계열 데이터 간의 스피어만 순위 상관계수"이고 지표 표도 (T7, T8, Pz)임.
+    # Pz 단독은 HANDOFF 요약 표기였고 원문과 어긋남
+    sync_channels: tuple[str, ...] = ("T7", "T8", "Pz")
     sync_band: str = "gamma"
     # 정본은 "초반 30초 제외"임. 기존 앞뒤 15초는 계약 위반이었고, 그 값으로는
     # 동조율이 보는 구간과 feature baseline 구간(compute_baseline의
@@ -83,33 +87,46 @@ class ScoreParams:
         return self.min_analysis_sec + self.trim_start_sec + self.trim_end_sec
 
     @property
-    def sync_column_candidates(self) -> list[str]:
-        """동조 대상 열 후보를 우선순위 순으로 반환함.
+    def channel_columns(self) -> list[str]:
+        """채널별 대상 열 이름을 반환함. 채널 미지정이면 빈 목록임"""
+        return [f"{ch}_{self.sync_band}" for ch in self.sync_channels]
 
-        채널별 열이 없는 구형 CSV를 위해 공간평균 열로 폴백함.
-        """
-        if self.sync_channel:
-            return [f"{self.sync_channel}_{self.sync_band}", self.sync_band]
-        return [self.sync_band]
+    @property
+    def spatial_column(self) -> str:
+        """채널별 열이 없는 구형 CSV용 공간평균 열 이름을 반환함"""
+        return self.sync_band
 
     @classmethod
     def from_env(cls) -> "ScoreParams":
         """환경변수에서 파라미터를 읽음.
 
         모듈 import 시점이 아니라 호출 시점에 읽으므로 프로세스 재기동 없이도
-        테스트에서 monkeypatch로 바꿀 수 있음. MIN_ANALYSIS_SECONDS만 FS_
-        접두사가 없는데, 백엔드와 프론트도 같은 이름을 쓰는 의도적 예외임.
+        테스트에서 monkeypatch로 바꿀 수 있음. 기본값은 전부 이 클래스의 필드
+        기본값을 그대로 씀 — 두 자리에 숫자를 적으면 반드시 갈라짐.
+        MIN_ANALYSIS_SECONDS만 FS_ 접두사가 없는데, 백엔드와 프론트도 같은
+        이름을 쓰는 의도적 예외임.
         """
-        channel = os.getenv("FS_SYNC_CHANNEL", "Pz").strip()
+        base = cls()
+        raw_channels = os.getenv("FS_SYNC_CHANNELS", "").strip()
+        channels = (
+            tuple(c.strip() for c in raw_channels.split(",") if c.strip())
+            if raw_channels
+            else base.sync_channels
+        )
+        # 명시적으로 빈 값을 주면 공간평균 열을 쓰겠다는 뜻임
+        if raw_channels in ("none", "-"):
+            channels = ()
         return cls(
-            w_sync=_env_float("FS_W_SYNC", 1.0),
-            w_faa=_env_float("FS_W_FAA", 0.0),
-            corr_method=os.getenv("FS_CORR_METHOD", "spearman").strip() or "spearman",
-            sync_channel=channel or None,
-            sync_band=os.getenv("FS_SYNC_BAND", "gamma").strip() or "gamma",
-            trim_start_sec=_env_int("FS_TRIM_START_SEC", 15),
-            trim_end_sec=_env_int("FS_TRIM_END_SEC", 15),
-            min_analysis_sec=_env_int("MIN_ANALYSIS_SECONDS", 180),
+            w_sync=_env_float("FS_W_SYNC", base.w_sync),
+            w_faa=_env_float("FS_W_FAA", base.w_faa),
+            corr_method=os.getenv("FS_CORR_METHOD", base.corr_method).strip()
+            or base.corr_method,
+            sync_channels=channels,
+            sync_band=os.getenv("FS_SYNC_BAND", base.sync_band).strip()
+            or base.sync_band,
+            trim_start_sec=_env_int("FS_TRIM_START_SEC", base.trim_start_sec),
+            trim_end_sec=_env_int("FS_TRIM_END_SEC", base.trim_end_sec),
+            min_analysis_sec=_env_int("MIN_ANALYSIS_SECONDS", base.min_analysis_sec),
         )
 
     def to_dict(self) -> dict:
@@ -119,7 +136,7 @@ class ScoreParams:
             "w_sync": self.w_sync,
             "w_faa": self.w_faa,
             "corr_method": self.corr_method,
-            "sync_channel": self.sync_channel,
+            "sync_channels": list(self.sync_channels),
             "sync_band": self.sync_band,
             "trim_start_sec": self.trim_start_sec,
             "trim_end_sec": self.trim_end_sec,

--- a/server/services/score_params.py
+++ b/server/services/score_params.py
@@ -37,8 +37,8 @@ class ScoreParams:
         corr_method: 상관 방식임. 정본은 스피어만 순위상관
         sync_channel: 동조 대상 채널임. None이면 채널 공간평균 열 사용
         sync_band: 동조 대상 대역임. 정본은 감마
-        trim_start_sec: 측정 앞쪽 진정 구간 초임
-        trim_end_sec: 측정 뒤쪽 진정 구간 초임
+        trim_start_sec: 측정 앞쪽 제외 구간 초임. 정본은 baseline과 같은 30초
+        trim_end_sec: 측정 뒤쪽 제외 구간 초임. 정본은 제외하지 않음(0)
         min_analysis_sec: trim 이후 유효 구간의 최소 초임
     """
 
@@ -47,8 +47,11 @@ class ScoreParams:
     corr_method: str = "spearman"
     sync_channel: str | None = "Pz"
     sync_band: str = "gamma"
-    trim_start_sec: int = 15
-    trim_end_sec: int = 15
+    # 정본은 "초반 30초 제외"임. 기존 앞뒤 15초는 계약 위반이었고, 그 값으로는
+    # 동조율이 보는 구간과 feature baseline 구간(compute_baseline의
+    # baseline_duration_sec=30)이 어긋나 같은 세션을 두 기준으로 잘랐음
+    trim_start_sec: int = 30
+    trim_end_sec: int = 0
     min_analysis_sec: int = 180
 
     def __post_init__(self) -> None:

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -455,6 +455,7 @@ class TestRunFullPipeline:
             "synchrony_score",
             "friendship_score",
             "score_params",
+            "score_meta",
             "pipeline_params",
             "dataframes",
         }

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -682,6 +682,11 @@ class TestRunFullPipeline:
         assert failed["error_code"] == "TIMESTAMP_COLUMN_MISSING"
         assert healthy_subject["n_features"] == 1
         assert result["pair_features"] is None
+        # 분석에서 빠진 subject의 원본으로 점수를 내면 pair_features는 None인데
+        # 점수만 나오는 상태가 됨. 판정 기준을 pair_features와 통일함
+        assert result["friendship_score"] is None
+        assert result["score_meta"]["sync_reason"] == "insufficient_subjects"
+        assert result["score_meta"]["reason"] == "synchrony_missing"
 
     def test_baseline_mean_uses_complete_observations_only(self):
         """coverage 판정에서 제외한 불완전 관측 초는 평균에도 포함하지 않음"""

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -453,6 +453,8 @@ class TestRunFullPipeline:
             "pair_features",
             "y_score",
             "synchrony_score",
+            "friendship_score",
+            "score_params",
             "pipeline_params",
             "dataframes",
         }

--- a/tests/services/test_friendship.py
+++ b/tests/services/test_friendship.py
@@ -1,0 +1,182 @@
+"""Friendship Score 산출과 파라미터 계약 검증함.
+
+핵심 회귀는 "상관 0이 50점"임. 기존 구현은 음수를 잘라 0점을 냈고 그것이
+정본 대비 가장 큰 왜곡이었음(상관 0에서 0점 대 50점).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from server.services.analysis import classify_session_tier, compute_synchrony
+from server.services.friendship import compute_friendship_score
+from server.services.score_params import ScoreParams
+
+ALPHA_PARAMS = ScoreParams(sync_channel=None, sync_band="alpha")
+
+
+def _session(start: str, n: int, values: dict[str, np.ndarray]) -> pd.DataFrame:
+    """초당 1행 시계열 DataFrame 생성함"""
+    ts = pd.date_range(start=start, periods=n, freq="1s")
+    return pd.DataFrame({"timestamp": ts, **values})
+
+
+class TestFriendshipScore:
+    """가중 합과 정규화 계약 검증함"""
+
+    def test_zero_correlation_is_fifty(self):
+        """[핵심 회귀] 상관 0은 0점이 아니라 50점임"""
+        score, _ = compute_friendship_score(0.0, None, ScoreParams())
+        assert score == pytest.approx(50.0)
+
+    def test_perfect_and_inverse_correlation(self):
+        """상관 1은 100점, 상관 -1은 0점임"""
+        params = ScoreParams()
+        assert compute_friendship_score(1.0, None, params)[0] == pytest.approx(100.0)
+        assert compute_friendship_score(-1.0, None, params)[0] == pytest.approx(0.0)
+
+    def test_missing_synchrony_is_none_not_zero(self):
+        """동조율 미측정은 None임. 0점으로 대체하면 완전 역상관과 구분 불가함"""
+        score, meta = compute_friendship_score(None, None, ScoreParams())
+        assert score is None
+        assert meta["reason"] == "synchrony_missing"
+
+    def test_faa_term_excluded_when_avoidance_missing(self):
+        """avoidance가 없으면 FAA 항을 분자와 분모 양쪽에서 제외함"""
+        with_faa = ScoreParams(w_sync=1.0, w_faa=0.25)
+        without_faa = ScoreParams(w_sync=1.0, w_faa=0.0)
+        assert (
+            compute_friendship_score(0.4, None, with_faa)[0]
+            == compute_friendship_score(0.4, None, without_faa)[0]
+        )
+
+    def test_faa_term_applied_when_avoidance_present(self):
+        """avoidance가 있으면 가중 합에 포함됨"""
+        params = ScoreParams(w_sync=1.0, w_faa=1.0)
+        # sync_norm = 0.5, faa_term = 1 - 0.0 = 1.0 이므로 (0.5 + 1.0) / 2 = 0.75
+        score, meta = compute_friendship_score(0.0, 0.0, params)
+        assert score == pytest.approx(75.0)
+        assert meta["terms"] == ["sync", "faa"]
+
+    def test_zero_effective_weight_returns_none(self):
+        """w_sync=0에 avoidance 결측이면 0으로 나누지 않고 미산출로 낮춤"""
+        params = ScoreParams(w_sync=0.0, w_faa=0.25)
+        score, meta = compute_friendship_score(0.5, None, params)
+        assert score is None
+        assert meta["reason"] == "no_effective_term"
+
+    def test_avoidance_out_of_range_raises(self):
+        """회피율은 [0, 1] 계약임"""
+        with pytest.raises(ValueError):
+            compute_friendship_score(0.5, 1.5, ScoreParams(w_faa=0.25))
+
+
+class TestScoreParams:
+    """파라미터 검증과 파생값 계약 검증함"""
+
+    def test_required_total_derives_from_trim(self):
+        """필요 측정 시간은 상수가 아니라 trim에서 파생됨"""
+        assert ScoreParams().required_total_sec == 210
+        assert ScoreParams(trim_start_sec=30).required_total_sec == 225
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(ValueError):
+            ScoreParams(w_sync=-1.0)
+
+    def test_unknown_corr_method_rejected(self):
+        with pytest.raises(ValueError):
+            ScoreParams(corr_method="kendall")
+
+    def test_ledger_carries_formula_version(self):
+        """파라미터 값이 같아도 구현 세대를 구분할 수 있어야 함"""
+        assert ScoreParams().to_dict()["formula_version"] == "1"
+
+    def test_from_env_reads_at_call_time(self, monkeypatch):
+        """환경변수는 import 시점이 아니라 호출 시점에 읽음"""
+        monkeypatch.setenv("FS_SYNC_BAND", "beta")
+        monkeypatch.setenv("FS_W_FAA", "0.25")
+        params = ScoreParams.from_env()
+        assert params.sync_band == "beta"
+        assert params.w_faa == 0.25
+
+    def test_blank_channel_env_means_spatial_mean(self, monkeypatch):
+        """FS_SYNC_CHANNEL이 빈 값이면 공간평균 열을 대상으로 삼음"""
+        monkeypatch.setenv("FS_SYNC_CHANNEL", "")
+        assert ScoreParams.from_env().sync_column_candidates == ["gamma"]
+
+
+class TestSessionTier:
+    """trim 파생 tier 판정의 고정 케이스임"""
+
+    def test_three_minute_session_is_partial(self):
+        """3분(180초) 측정은 VALID가 아니라 PARTIAL임. 유효 구간이 150초"""
+        assert classify_session_tier(180) == "PARTIAL"
+
+    def test_required_total_is_valid(self):
+        """210초(3분 30초)부터 VALID임"""
+        assert classify_session_tier(210) == "VALID"
+
+    def test_tier_follows_trim_params(self):
+        """trim을 늘리면 같은 측정이 등급을 잃음"""
+        params = ScoreParams(trim_start_sec=30, trim_end_sec=30)
+        assert classify_session_tier(210, params) == "PARTIAL"
+
+
+class TestSynchronyColumnSelection:
+    """대상 열 해석과 폴백 계약 검증함"""
+
+    def test_prefers_channel_column(self):
+        """현행 CSV에서는 Pz 감마를 씀"""
+        rng = np.random.default_rng(0)
+        wave = rng.normal(size=60)
+        cols = {"gamma": wave, "Pz_gamma": wave}
+        a = _session("2026-08-01 10:00:00", 60, cols)
+        b = _session("2026-08-01 10:00:00", 60, cols)
+        rho, meta = compute_synchrony(a, b)
+        assert meta["sync_column_used"] == "Pz_gamma"
+        assert rho == pytest.approx(1.0)
+        # 공간평균 병기값도 함께 계산됨 (감마 오염 사후 판별용)
+        assert meta["sync_secondary"] == pytest.approx(1.0)
+
+    def test_falls_back_to_spatial_mean(self):
+        """구형 CSV는 채널별 열이 없어 공간평균으로 폴백함"""
+        rng = np.random.default_rng(1)
+        wave = rng.normal(size=60)
+        a = _session("2026-08-01 10:00:00", 60, {"gamma": wave})
+        b = _session("2026-08-01 10:00:00", 60, {"gamma": wave})
+        _, meta = compute_synchrony(a, b)
+        assert meta["sync_column_used"] == "gamma"
+
+    def test_missing_column_returns_none(self):
+        """후보 열이 하나도 없으면 미측정임"""
+        wave = np.arange(60, dtype=float)
+        a = _session("2026-08-01 10:00:00", 60, {"alpha": wave})
+        b = _session("2026-08-01 10:00:00", 60, {"alpha": wave})
+        rho, meta = compute_synchrony(a, b)
+        assert rho is None
+        assert meta["sync_column_used"] is None
+
+    def test_constant_series_returns_none(self):
+        """한쪽이 상수면 순위상관이 nan이므로 미측정으로 낮춤"""
+        n = 60
+        a = _session("2026-08-01 10:00:00", n, {"alpha": np.arange(n, dtype=float)})
+        b = _session("2026-08-01 10:00:00", n, {"alpha": np.ones(n)})
+        rho, _ = compute_synchrony(a, b, ALPHA_PARAMS)
+        assert rho is None
+
+    def test_spearman_beats_pearson_on_monotonic_nonlinear(self):
+        """단조 비선형 관계에서 순위상관은 1.0이고 피어슨은 그보다 낮음"""
+        n = 60
+        x = np.linspace(1.0, 5.0, n)
+        pairs = {"alpha": x}
+        a = _session("2026-08-01 10:00:00", n, pairs)
+        b = _session("2026-08-01 10:00:00", n, {"alpha": x**5})
+
+        spearman, _ = compute_synchrony(a, b, ALPHA_PARAMS)
+        pearson, _ = compute_synchrony(
+            a,
+            b,
+            ScoreParams(sync_channel=None, sync_band="alpha", corr_method="pearson"),
+        )
+        assert spearman == pytest.approx(1.0)
+        assert pearson < spearman

--- a/tests/services/test_friendship.py
+++ b/tests/services/test_friendship.py
@@ -65,6 +65,12 @@ class TestFriendshipScore:
         assert score is None
         assert meta["reason"] == "no_effective_term"
 
+    def test_nan_synchrony_is_none_not_zero(self):
+        """nan은 clamp에서 0으로 접히므로 명시적으로 미산출 처리함"""
+        score, meta = compute_friendship_score(float("nan"), None, ScoreParams())
+        assert score is None
+        assert meta["reason"] == "synchrony_missing"
+
     def test_avoidance_out_of_range_raises(self):
         """회피율은 [0, 1] 계약임"""
         with pytest.raises(ValueError):
@@ -84,6 +90,21 @@ class TestScoreParams:
         """필요 측정 시간은 상수가 아니라 trim에서 파생됨"""
         assert ScoreParams().required_total_sec == 210
         assert ScoreParams(trim_start_sec=45).required_total_sec == 225
+
+    def test_negative_trim_rejected(self):
+        """음수 trim은 iloc 슬라이스를 조용히 뒤집으므로 로딩에서 거부함"""
+        with pytest.raises(ValueError):
+            ScoreParams(trim_start_sec=-5)
+
+    def test_non_finite_weight_rejected(self):
+        """nan 가중치는 부호 검사를 전부 통과해 결과가 nan이 됨"""
+        with pytest.raises(ValueError):
+            ScoreParams(w_sync=float("nan"))
+
+    def test_corr_method_env_is_case_insensitive(self, monkeypatch):
+        """설정 오타 하나가 모듈 로드 실패로 이어지지 않게 함"""
+        monkeypatch.setenv("FS_CORR_METHOD", "Spearman")
+        assert ScoreParams.from_env().corr_method == "spearman"
 
     def test_negative_weight_rejected(self):
         with pytest.raises(ValueError):

--- a/tests/services/test_friendship.py
+++ b/tests/services/test_friendship.py
@@ -74,10 +74,16 @@ class TestFriendshipScore:
 class TestScoreParams:
     """파라미터 검증과 파생값 계약 검증함"""
 
+    def test_canonical_trim_is_leading_thirty_seconds(self):
+        """정본은 초반 30초만 제외함. 뒤는 자르지 않음"""
+        params = ScoreParams()
+        assert params.trim_start_sec == 30
+        assert params.trim_end_sec == 0
+
     def test_required_total_derives_from_trim(self):
         """필요 측정 시간은 상수가 아니라 trim에서 파생됨"""
         assert ScoreParams().required_total_sec == 210
-        assert ScoreParams(trim_start_sec=30).required_total_sec == 225
+        assert ScoreParams(trim_start_sec=45).required_total_sec == 225
 
     def test_negative_weight_rejected(self):
         with pytest.raises(ValueError):
@@ -118,7 +124,7 @@ class TestSessionTier:
 
     def test_tier_follows_trim_params(self):
         """trim을 늘리면 같은 측정이 등급을 잃음"""
-        params = ScoreParams(trim_start_sec=30, trim_end_sec=30)
+        params = ScoreParams(trim_start_sec=45, trim_end_sec=15)
         assert classify_session_tier(210, params) == "PARTIAL"
 
 

--- a/tests/services/test_friendship.py
+++ b/tests/services/test_friendship.py
@@ -12,7 +12,7 @@ from server.services.analysis import classify_session_tier, compute_synchrony
 from server.services.friendship import compute_friendship_score
 from server.services.score_params import ScoreParams
 
-ALPHA_PARAMS = ScoreParams(sync_channel=None, sync_band="alpha")
+ALPHA_PARAMS = ScoreParams(sync_channels=(), sync_band="alpha")
 
 
 def _session(start: str, n: int, values: dict[str, np.ndarray]) -> pd.DataFrame:
@@ -105,10 +105,38 @@ class TestScoreParams:
         assert params.sync_band == "beta"
         assert params.w_faa == 0.25
 
-    def test_blank_channel_env_means_spatial_mean(self, monkeypatch):
-        """FS_SYNC_CHANNEL이 빈 값이면 공간평균 열을 대상으로 삼음"""
-        monkeypatch.setenv("FS_SYNC_CHANNEL", "")
-        assert ScoreParams.from_env().sync_column_candidates == ["gamma"]
+    def test_canonical_channels_are_temporo_parietal(self):
+        """정본 대상은 측두-두정엽 셋임 (제안서 원문 T7, T8, Pz)"""
+        params = ScoreParams()
+        assert params.sync_channels == ("T7", "T8", "Pz")
+        assert params.channel_columns == ["T7_gamma", "T8_gamma", "Pz_gamma"]
+
+    def test_channels_env_is_comma_separated(self, monkeypatch):
+        """FS_SYNC_CHANNELS로 채널 조합을 바꿀 수 있음"""
+        monkeypatch.setenv("FS_SYNC_CHANNELS", "Pz")
+        assert ScoreParams.from_env().sync_channels == ("Pz",)
+
+    def test_channels_env_none_means_spatial_mean(self, monkeypatch):
+        """none을 주면 채널별 열 대신 공간평균 열을 대상으로 삼음"""
+        monkeypatch.setenv("FS_SYNC_CHANNELS", "none")
+        params = ScoreParams.from_env()
+        assert params.channel_columns == []
+        assert params.spatial_column == "gamma"
+
+    def test_from_env_defaults_match_field_defaults(self, monkeypatch):
+        """환경변수 미설정이면 필드 기본값과 완전히 같아야 함"""
+        for name in (
+            "FS_W_SYNC",
+            "FS_W_FAA",
+            "FS_CORR_METHOD",
+            "FS_SYNC_CHANNELS",
+            "FS_SYNC_BAND",
+            "FS_TRIM_START_SEC",
+            "FS_TRIM_END_SEC",
+            "MIN_ANALYSIS_SECONDS",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        assert ScoreParams.from_env() == ScoreParams()
 
 
 class TestSessionTier:
@@ -131,40 +159,81 @@ class TestSessionTier:
 class TestSynchronyColumnSelection:
     """대상 열 해석과 폴백 계약 검증함"""
 
-    def test_prefers_channel_column(self):
-        """현행 CSV에서는 Pz 감마를 씀"""
+    def test_prefers_temporo_parietal_channels(self):
+        """현행 CSV에서는 T7, T8, Pz 감마 평균을 씀"""
         rng = np.random.default_rng(0)
-        wave = rng.normal(size=60)
-        cols = {"gamma": wave, "Pz_gamma": wave}
-        a = _session("2026-08-01 10:00:00", 60, cols)
-        b = _session("2026-08-01 10:00:00", 60, cols)
+        n = 90
+        cols = {
+            "gamma": rng.normal(size=n),
+            "T7_gamma": rng.normal(size=n),
+            "T8_gamma": rng.normal(size=n),
+            "Pz_gamma": rng.normal(size=n),
+        }
+        a = _session("2026-08-01 10:00:00", n, cols)
+        b = _session("2026-08-01 10:00:00", n, cols)
         rho, meta = compute_synchrony(a, b)
-        assert meta["sync_column_used"] == "Pz_gamma"
+        assert meta["sync_columns_used"] == ["T7_gamma", "T8_gamma", "Pz_gamma"]
         assert rho == pytest.approx(1.0)
         # 공간평균 병기값도 함께 계산됨 (감마 오염 사후 판별용)
         assert meta["sync_secondary"] == pytest.approx(1.0)
 
+    def test_uses_available_channels_only(self):
+        """일부 채널 열만 있으면 있는 것끼리 평균함"""
+        rng = np.random.default_rng(5)
+        n = 90
+        cols = {"gamma": rng.normal(size=n), "Pz_gamma": rng.normal(size=n)}
+        a = _session("2026-08-01 10:00:00", n, cols)
+        b = _session("2026-08-01 10:00:00", n, cols)
+        _, meta = compute_synchrony(a, b)
+        assert meta["sync_columns_used"] == ["Pz_gamma"]
+
+    def test_channel_mean_differs_from_single_channel(self):
+        """채널 평균은 단일 채널과 다른 값을 냄 (평균이 실제로 적용됨)"""
+        rng = np.random.default_rng(7)
+        n = 90
+        a = _session(
+            "2026-08-01 10:00:00",
+            n,
+            {
+                "T7_gamma": rng.normal(size=n),
+                "T8_gamma": rng.normal(size=n),
+                "Pz_gamma": rng.normal(size=n),
+            },
+        )
+        b = _session(
+            "2026-08-01 10:00:00",
+            n,
+            {
+                "T7_gamma": rng.normal(size=n),
+                "T8_gamma": rng.normal(size=n),
+                "Pz_gamma": rng.normal(size=n),
+            },
+        )
+        mean_rho, _ = compute_synchrony(a, b)
+        pz_rho, _ = compute_synchrony(a, b, ScoreParams(sync_channels=("Pz",)))
+        assert mean_rho != pytest.approx(pz_rho)
+
     def test_falls_back_to_spatial_mean(self):
         """구형 CSV는 채널별 열이 없어 공간평균으로 폴백함"""
         rng = np.random.default_rng(1)
-        wave = rng.normal(size=60)
-        a = _session("2026-08-01 10:00:00", 60, {"gamma": wave})
-        b = _session("2026-08-01 10:00:00", 60, {"gamma": wave})
+        wave = rng.normal(size=90)
+        a = _session("2026-08-01 10:00:00", 90, {"gamma": wave})
+        b = _session("2026-08-01 10:00:00", 90, {"gamma": wave})
         _, meta = compute_synchrony(a, b)
-        assert meta["sync_column_used"] == "gamma"
+        assert meta["sync_columns_used"] == ["gamma"]
 
     def test_missing_column_returns_none(self):
         """후보 열이 하나도 없으면 미측정임"""
-        wave = np.arange(60, dtype=float)
-        a = _session("2026-08-01 10:00:00", 60, {"alpha": wave})
-        b = _session("2026-08-01 10:00:00", 60, {"alpha": wave})
+        wave = np.arange(90, dtype=float)
+        a = _session("2026-08-01 10:00:00", 90, {"alpha": wave})
+        b = _session("2026-08-01 10:00:00", 90, {"alpha": wave})
         rho, meta = compute_synchrony(a, b)
         assert rho is None
-        assert meta["sync_column_used"] is None
+        assert meta["sync_columns_used"] == []
 
     def test_constant_series_returns_none(self):
         """한쪽이 상수면 순위상관이 nan이므로 미측정으로 낮춤"""
-        n = 60
+        n = 90
         a = _session("2026-08-01 10:00:00", n, {"alpha": np.arange(n, dtype=float)})
         b = _session("2026-08-01 10:00:00", n, {"alpha": np.ones(n)})
         rho, _ = compute_synchrony(a, b, ALPHA_PARAMS)
@@ -172,7 +241,7 @@ class TestSynchronyColumnSelection:
 
     def test_spearman_beats_pearson_on_monotonic_nonlinear(self):
         """단조 비선형 관계에서 순위상관은 1.0이고 피어슨은 그보다 낮음"""
-        n = 60
+        n = 90
         x = np.linspace(1.0, 5.0, n)
         pairs = {"alpha": x}
         a = _session("2026-08-01 10:00:00", n, pairs)
@@ -182,7 +251,7 @@ class TestSynchronyColumnSelection:
         pearson, _ = compute_synchrony(
             a,
             b,
-            ScoreParams(sync_channel=None, sync_band="alpha", corr_method="pearson"),
+            ScoreParams(sync_channels=(), sync_band="alpha", corr_method="pearson"),
         )
         assert spearman == pytest.approx(1.0)
         assert pearson < spearman

--- a/tests/test_analyzer_dsp.py
+++ b/tests/test_analyzer_dsp.py
@@ -149,19 +149,64 @@ def test_short_window_raises_instead_of_returning_zero(entry):
 
 
 def test_synchrony_recovers_common_alpha_modulation():
-    """[회귀 C] 공통 알파 변조를 가진 두 피실험자의 동조율이 0.90 이상이어야 함"""
+    """[회귀 C] 공통 알파 변조를 가진 두 피실험자의 동조율이 0.90 이상이어야 함
+
+    이 픽스처는 공통 변조를 알파 톤에만 걸므로 대역을 alpha로 명시 주입함.
+    정본 지표(감마)로 이 픽스처를 돌리면 감마는 잡음에서만 나와 상관이 0
+    근처다 — 아래 감마 버전이 그 대비다.
+    """
     from server.services.analysis import compute_synchrony
+    from server.services.score_params import ScoreParams
 
     n_sec = 260
     modulation = 1.0 + 0.5 * np.sin(2 * np.pi * np.arange(n_sec) / 50.0)
     frames = [_synthesize_session(seed, n_sec, modulation) for seed in (11, 22)]
-    score = compute_synchrony(frames[0], frames[1])
+    score, meta = compute_synchrony(
+        frames[0], frames[1], ScoreParams(sync_channel=None, sync_band="alpha")
+    )
     assert score is not None
     assert score >= 0.90
+    assert meta["sync_column_used"] == "alpha"
 
 
-def _synthesize_session(seed: int, n_sec: int, modulation: np.ndarray) -> pd.DataFrame:
-    """공통 알파 변조와 개별 위상 및 잡음을 가진 합성 세션 DataFrame 생성함"""
+def test_synchrony_recovers_common_gamma_modulation():
+    """정본 지표(감마)로도 공통 변조가 있으면 동조율이 회복돼야 함
+
+    광대역 잡음 진폭에 공통 변조를 걸어 감마 대역이 함께 움직이게 함.
+    스피어만 순위상관은 단조 변환에 불변이라 대역 값이 RMS인지 파워인지에
+    영향받지 않음.
+    """
+    from server.services.analysis import compute_synchrony
+    from server.services.score_params import ScoreParams
+
+    n_sec = 260
+    # 알파 버전보다 변조를 깊게 검. 감마는 잡음에서만 나오고 단일 세그먼트
+    # 피리오도그램이라 창당 추정 분산이 커(백색잡음 실측 변동계수 0.31)
+    # 같은 변조 깊이에서는 상관이 알파보다 감쇠함
+    modulation = 1.0 + 1.0 * np.sin(2 * np.pi * np.arange(n_sec) / 50.0)
+    frames = [
+        _synthesize_session(seed, n_sec, modulation, noise_modulated=True)
+        for seed in (33, 44)
+    ]
+    score, meta = compute_synchrony(
+        frames[0], frames[1], ScoreParams(sync_channel=None, sync_band="gamma")
+    )
+    assert score is not None
+    assert score >= 0.90
+    assert meta["sync_column_used"] == "gamma"
+
+
+def _synthesize_session(
+    seed: int,
+    n_sec: int,
+    modulation: np.ndarray,
+    noise_modulated: bool = False,
+) -> pd.DataFrame:
+    """공통 변조와 개별 위상 및 잡음을 가진 합성 세션 DataFrame 생성함
+
+    noise_modulated면 광대역 잡음 진폭에도 같은 변조를 걸어 감마 대역이
+    공통으로 움직이게 함.
+    """
     analyzer = MindSignalAnalyzer()
     rng = np.random.default_rng(seed)
     t = np.arange(128) / FS
@@ -169,11 +214,12 @@ def _synthesize_session(seed: int, n_sec: int, modulation: np.ndarray) -> pd.Dat
     rows = []
     for i in range(n_sec):
         amplitude = TONE_AMPLITUDE * modulation[i] * (1.0 + 0.05 * rng.normal())
+        noise_scale = 5.0 * (modulation[i] if noise_modulated else 1.0)
         window = (
             DC_LEVEL
             + 30.0 * rng.normal()
             + amplitude * np.sin(2 * np.pi * 10 * t + rng.uniform(0, 2 * np.pi))
-            + rng.normal(0, 5.0, 128)
+            + rng.normal(0, noise_scale, 128)
         )
         rows.append(
             {

--- a/tests/test_analyzer_dsp.py
+++ b/tests/test_analyzer_dsp.py
@@ -179,11 +179,13 @@ def test_synchrony_recovers_common_gamma_modulation():
     from server.services.analysis import compute_synchrony
     from server.services.score_params import ScoreParams
 
+    # 알파 테스트와 **같은 변조 깊이(0.5)**를 쓰고 임계만 낮춤. 감마는 잡음
+    # 진폭에서만 나오고 단일 세그먼트 피리오도그램이라 창당 추정 분산이 커
+    # 같은 조건에서 알파 0.9x, 감마 0.82로 실측됨(깊이 0.3은 0.61, 0.7은 0.90).
+    # 깊이를 올려 0.90을 맞추면 잡음 진폭이 골에서 0이 되는 비물리 영역이라
+    # 테스트가 변조 배열을 되읽는 것에 가까워짐
     n_sec = 260
-    # 알파 버전보다 변조를 깊게 검. 감마는 잡음에서만 나오고 단일 세그먼트
-    # 피리오도그램이라 창당 추정 분산이 커(백색잡음 실측 변동계수 0.31)
-    # 같은 변조 깊이에서는 상관이 알파보다 감쇠함
-    modulation = 1.0 + 1.0 * np.sin(2 * np.pi * np.arange(n_sec) / 50.0)
+    modulation = 1.0 + 0.5 * np.sin(2 * np.pi * np.arange(n_sec) / 50.0)
     frames = [
         _synthesize_session(seed, n_sec, modulation, noise_modulated=True)
         for seed in (33, 44)
@@ -192,7 +194,7 @@ def test_synchrony_recovers_common_gamma_modulation():
         frames[0], frames[1], ScoreParams(sync_channels=(), sync_band="gamma")
     )
     assert score is not None
-    assert score >= 0.90
+    assert score >= 0.75
     assert meta["sync_columns_used"] == ["gamma"]
 
 

--- a/tests/test_analyzer_dsp.py
+++ b/tests/test_analyzer_dsp.py
@@ -162,11 +162,11 @@ def test_synchrony_recovers_common_alpha_modulation():
     modulation = 1.0 + 0.5 * np.sin(2 * np.pi * np.arange(n_sec) / 50.0)
     frames = [_synthesize_session(seed, n_sec, modulation) for seed in (11, 22)]
     score, meta = compute_synchrony(
-        frames[0], frames[1], ScoreParams(sync_channel=None, sync_band="alpha")
+        frames[0], frames[1], ScoreParams(sync_channels=(), sync_band="alpha")
     )
     assert score is not None
     assert score >= 0.90
-    assert meta["sync_column_used"] == "alpha"
+    assert meta["sync_columns_used"] == ["alpha"]
 
 
 def test_synchrony_recovers_common_gamma_modulation():
@@ -189,11 +189,11 @@ def test_synchrony_recovers_common_gamma_modulation():
         for seed in (33, 44)
     ]
     score, meta = compute_synchrony(
-        frames[0], frames[1], ScoreParams(sync_channel=None, sync_band="gamma")
+        frames[0], frames[1], ScoreParams(sync_channels=(), sync_band="gamma")
     )
     assert score is not None
     assert score >= 0.90
-    assert meta["sync_column_used"] == "gamma"
+    assert meta["sync_columns_used"] == ["gamma"]
 
 
 def _synthesize_session(

--- a/tests/test_synchrony_alignment.py
+++ b/tests/test_synchrony_alignment.py
@@ -22,6 +22,11 @@ from server.services.analysis import (
     align_on_second,
     compute_synchrony,
 )
+from server.services.score_params import ScoreParams
+
+# 이 픽스처는 alpha 열만 만들므로 정본 대상(Pz 감마) 대신 공간평균 alpha를
+# 명시 주입함. 검증 대상이 지표 선택이 아니라 시간축 정렬 로직이기 때문임
+ALPHA_PARAMS = ScoreParams(sync_channel=None, sync_band="alpha")
 
 
 def _make_df(start: str, n: int, alpha: np.ndarray) -> pd.DataFrame:
@@ -65,7 +70,9 @@ def test_positional_alignment_would_report_spurious_correlation():
     assert len(b) - trim >= 10  # 픽스처가 유효 구간을 남기는지 확인함
 
     # 수정 후: 절대시각 정렬이라 완전 상관
-    assert compute_synchrony(a, b) == pytest.approx(1.0, abs=1e-9)
+    rho, meta = compute_synchrony(a, b, ALPHA_PARAMS)
+    assert rho == pytest.approx(1.0, abs=1e-9)
+    assert meta["sync_column_used"] == "alpha"
 
     # 구 동작(위치 정렬)을 직접 재현하면 1.0이 아님
     t1 = a.iloc[TRIM_START_SECONDS : len(a) - TRIM_END_SECONDS].reset_index(drop=True)
@@ -80,7 +87,8 @@ def test_returns_none_when_overlap_too_short():
     wave = np.random.default_rng(0).normal(size=60)
     a = _make_df("2026-07-10 15:00:00", 60, wave)
     b = _make_df("2026-07-10 15:10:00", 60, wave)  # 겹침 없음
-    assert compute_synchrony(a, b) is None
+    rho, _ = compute_synchrony(a, b, ALPHA_PARAMS)
+    assert rho is None
 
 
 def test_duplicate_seconds_are_averaged_not_duplicated():

--- a/tests/test_synchrony_alignment.py
+++ b/tests/test_synchrony_alignment.py
@@ -16,12 +16,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from server.services.analysis import (
-    TRIM_END_SECONDS,
-    TRIM_START_SECONDS,
-    align_on_second,
-    compute_synchrony,
-)
+from server.services.analysis import align_on_second, compute_synchrony
 from server.services.score_params import ScoreParams
 
 # 이 픽스처는 alpha 열만 만들므로 정본 대상(Pz 감마) 대신 공간평균 alpha를
@@ -66,7 +61,7 @@ def test_positional_alignment_would_report_spurious_correlation():
     a = _make_df("2026-07-10 15:00:00", 130, wave)
     b = _make_df("2026-07-10 15:00:30", 100, wave[30:])
 
-    trim = TRIM_START_SECONDS + TRIM_END_SECONDS
+    trim = ALPHA_PARAMS.trim_start_sec + ALPHA_PARAMS.trim_end_sec
     assert len(b) - trim >= 10  # 픽스처가 유효 구간을 남기는지 확인함
 
     # 수정 후: 절대시각 정렬이라 완전 상관
@@ -75,8 +70,9 @@ def test_positional_alignment_would_report_spurious_correlation():
     assert meta["sync_columns_used"] == ["alpha"]
 
     # 구 동작(위치 정렬)을 직접 재현하면 1.0이 아님
-    t1 = a.iloc[TRIM_START_SECONDS : len(a) - TRIM_END_SECONDS].reset_index(drop=True)
-    t2 = b.iloc[TRIM_START_SECONDS : len(b) - TRIM_END_SECONDS].reset_index(drop=True)
+    start, end = ALPHA_PARAMS.trim_start_sec, ALPHA_PARAMS.trim_end_sec
+    t1 = a.iloc[start : len(a) - end].reset_index(drop=True)
+    t2 = b.iloc[start : len(b) - end].reset_index(drop=True)
     n = min(len(t1), len(t2))
     positional = np.corrcoef(t1["alpha"].values[:n], t2["alpha"].values[:n])[0, 1]
     assert abs(positional - 1.0) > 0.1

--- a/tests/test_synchrony_alignment.py
+++ b/tests/test_synchrony_alignment.py
@@ -26,7 +26,7 @@ from server.services.score_params import ScoreParams
 
 # 이 픽스처는 alpha 열만 만들므로 정본 대상(Pz 감마) 대신 공간평균 alpha를
 # 명시 주입함. 검증 대상이 지표 선택이 아니라 시간축 정렬 로직이기 때문임
-ALPHA_PARAMS = ScoreParams(sync_channel=None, sync_band="alpha")
+ALPHA_PARAMS = ScoreParams(sync_channels=(), sync_band="alpha")
 
 
 def _make_df(start: str, n: int, alpha: np.ndarray) -> pd.DataFrame:
@@ -72,7 +72,7 @@ def test_positional_alignment_would_report_spurious_correlation():
     # 수정 후: 절대시각 정렬이라 완전 상관
     rho, meta = compute_synchrony(a, b, ALPHA_PARAMS)
     assert rho == pytest.approx(1.0, abs=1e-9)
-    assert meta["sync_column_used"] == "alpha"
+    assert meta["sync_columns_used"] == ["alpha"]
 
     # 구 동작(위치 정렬)을 직접 재현하면 1.0이 아님
     t1 = a.iloc[TRIM_START_SECONDS : len(a) - TRIM_END_SECONDS].reset_index(drop=True)


### PR DESCRIPTION
2026-06-22 회의 정본 수식 대비 6개 계약 중 일치가 1개뿐이던 것을 FAA를 뺀 1단계까지 맞춘다. FAA 항은 2026-08-03 회의 확정 후 2단계다.

## 무엇이 바뀌나

- 동조율을 피어슨에서 **스피어만 순위상관**으로 바꾼다. 순위상관은 단조 변환에 불변이라 대역 값이 파워인지 RMS인지에 영향받지 않는다.
- 대상을 공간평균 `alpha` 열에서 **측두-두정엽 감마(T7, T8, Pz) 평균**으로 바꾼다. 제안서 원문이 "두 참여자의 측두, 두정엽 감마파의 시계열 데이터 간의 스피어만 순위 상관계수"이고 지표 표도 (T7, T8, Pz)다. 채널별 열이 없는 구형 CSV는 공간평균으로 폴백하고 무엇을 썼는지 `sync_columns_used`에 남긴다.
- **trim을 정본의 초반 30초 제외로 맞춘다.** 기존 앞뒤 15초는 계약 위반이었고 feature baseline 구간(30초)과도 어긋나 같은 세션을 두 기준으로 잘랐다. 필요 측정 시간은 여전히 210초다.
- 점수를 **민맥스 정규화 가중합**으로 낸다. 상관 0이 0점이 아니라 **50점**이다. 지금까지 저장되던 값은 Friendship Score가 아니라 동조율에 100을 곱하고 음수를 자른 값이었다.
- 가중치와 구간과 채널을 전부 `ScoreParams`로 파라미터화하고 **실제 사용값을 `score_params`에 실어** 어떤 설정으로 나온 점수인지 사후 구분되게 한다. `formula_version`도 함께 실어 파라미터가 같고 구현이 바뀐 경우를 구분한다.

## 설계 판단

- **동조율은 필수 항, FAA는 선택 항이다.** 동조율 미측정은 점수를 내지 않고(0점으로 대체하면 완전 역상관과 구분 불가), FAA 결측은 항만 빼고 분모를 줄인다.
- **상관 계산은 `MindSignalAnalyzer.calculate_synchrony` 한 곳으로만 들어간다.** 호출부가 scipy를 직접 부르면 이 메서드를 mock한 기존 테스트가 조용히 무력화된다.
- **공간평균 기준 rho를 `sync_secondary`로 병기한다.** 감마가 근전도로 오염됐을 때 "정본 준수와 강건성 중 무엇이 문제였나"를 사후에 판별할 유일한 수단이다(타당도 위협 조사 권고).
- `from_env()`의 기본값은 dataclass 필드 기본값을 그대로 쓴다. 두 자리에 숫자를 적으면 반드시 갈라진다.

## 검증

- `black`, `isort`, `flake8` 통과. **295건 PASS**(기존 267 더하기 신규 28).
- 핵심 회귀 고정: 상관 0이 50점, 미측정이 0이 아닌 None, 3분 측정이 PARTIAL, 210초가 VALID, 채널 평균이 단일 채널과 다른 값을 냄.
- 이 변경으로 깨질 것을 예상하고 고친 기존 테스트 3파일: `test_synchrony_alignment.py`(alpha 픽스처에 대역 명시 주입), `test_analyzer_dsp.py`(알파 전용 픽스처 + 감마 버전 신설), `test_analysis_pipeline.py`(반환 키 집합).

## 함께 나가야 하는 것

백엔드 저장 경로는 [BE PR #80](https://github.com/mind-signal/mind-signal-backend/pull/80)이다. 순서 의존은 없다 — BE는 `friendshipScore` 필드가 없으면 기존 변환으로 폴백한다.

계획과 fable 검토 반영 내역, 제안서 PDF 대조 결과는 `.plans/ANALYSIS-W004-friendship-score-formula/PLAN.md`에 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * EEG 분석 결과에 Friendship Score(0~100)를 제공합니다.
  * 동조율과 FAA 회피율을 반영한 점수 및 산출 정보를 함께 확인할 수 있습니다.
  * Pearson 또는 Spearman 상관 방식을 선택할 수 있습니다.
  * 분석 구간, 최소 분석 시간, 채널·대역, 점수 가중치를 환경 설정으로 조정할 수 있습니다.
  * 분석 결과에 사용된 설정과 유효 데이터 정보가 포함됩니다.

* **개선 사항**
  * 결측값, 짧은 분석 구간, 유효하지 않은 데이터가 있는 경우에도 결과를 안전하게 처리합니다.
  * 동조율 계산 시 시간축 정렬과 채널 선택 정확도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->