### PR TITLE
test(tracing): TS ID를 테스트 클래스 docstring에 태깅 (DOCS-W003)

### DIFF
--- a/tests/routes/test_analyze_pipeline.py
+++ b/tests/routes/test_analyze_pipeline.py
@@ -9,7 +9,10 @@ from tests.conftest import TEST_GROUP_ID, TEST_SECRET  # noqa: F401
 
 
 class TestAnalyzePipelineEndpoint:
-    """POST /api/analyze/pipeline 엔드포인트 검증함"""
+    """[TS-ANALYSIS-08] 인증 없는 분석 파이프라인 요청 거부.
+
+    POST /api/analyze/pipeline 엔드포인트 검증함
+    """
 
     def test_missing_secret_header_returns_422(self, test_client):
         """Header 미제공 시 FastAPI validation error (422) 반환함"""
@@ -288,7 +291,10 @@ class TestAnalyzePipelineEndpoint:
 
 
 class TestAnalyzePipelineModeField:
-    """mode / algorithm 필드 검증 테스트 수행함"""
+    """[TS-ANALYSIS-09] 정의되지 않은 분석 모드 요청 거부.
+
+    mode / algorithm 필드 검증 테스트 수행함
+    """
 
     @patch("server.services.analysis.run_full_pipeline")
     def test_omitting_mode_defaults_to_dual(

--- a/tests/services/test_analysis_pipeline.py
+++ b/tests/services/test_analysis_pipeline.py
@@ -234,6 +234,8 @@ class TestSplitStimulusWindows:
 
 
 class TestExtractFeatures:
+    """[TS-ANALYSIS-02] 뇌파 주파수 지표 계산."""
+
     def _make_windows(self, n_stim=2, n_win=2, band_cols=None):
         """테스트용 windows 구조 생성함"""
         if band_cols is None:
@@ -426,6 +428,8 @@ class TestComputeY:
 
 
 class TestRunFullPipeline:
+    """[TS-ANALYSIS-04] DUAL 모드 반응 유사도 계산."""
+
     @pytest.fixture(autouse=True)
     def _mock_io(self, monkeypatch, full_session_df):
         """CSV I/O와 MindSignalAnalyzer를 mock함"""

--- a/tests/services/test_friendship.py
+++ b/tests/services/test_friendship.py
@@ -22,7 +22,10 @@ def _session(start: str, n: int, values: dict[str, np.ndarray]) -> pd.DataFrame:
 
 
 class TestFriendshipScore:
-    """가중 합과 정규화 계약 검증함"""
+    """[TS-AI-01] 뇌파 통합 분석 궁합 점수 산출 (설문은 제거됨).
+
+    가중 합과 정규화 계약 검증함
+    """
 
     def test_zero_correlation_is_fifty(self):
         """[핵심 회귀] 상관 0은 0점이 아니라 50점임"""

--- a/tests/services/test_markdown.py
+++ b/tests/services/test_markdown.py
@@ -4,6 +4,8 @@ from server.services.markdown import features_to_markdown
 
 
 class TestFeaturesToMarkdown:
+    """[TS-ANALYSIS-07] 마크다운 포함 분석 응답 반환."""
+
     def test_returns_string(self, sample_features):
         """반환 타입이 str임"""
         result = features_to_markdown(1, sample_features)

--- a/tests/test_analyzer_dsp.py
+++ b/tests/test_analyzer_dsp.py
@@ -33,7 +33,10 @@ def test_constant_dc_input_yields_zero_band_power():
 
 
 def test_alpha_rms_recovers_true_amplitude():
-    """[회귀 B] 10Hz 20uV 알파의 RMS 회복률이 참값의 95~105%여야 함"""
+    """[TS-ANALYSIS-01] 주파수 대역별 파워 계산.
+
+    [회귀 B] 10Hz 20uV 알파의 RMS 회복률이 참값의 95~105%여야 함
+    """
     powers = MindSignalAnalyzer().get_all_powers(_tone(10.0))
     ratio = powers["alpha"] / TRUE_RMS
     assert 0.95 <= ratio <= 1.05
@@ -77,7 +80,7 @@ def test_alpha_recovery_is_phase_stable(phase_index):
 
 
 def test_dc_level_does_not_change_result():
-    """DC 준위가 3000/4200/5000으로 달라져도 알파 값이 동일해야 함"""
+    """[TS-ANALYSIS-10] DC 준위가 3000/4200/5000으로 달라져도 알파 값이 동일해야 함"""
     analyzer = MindSignalAnalyzer()
     values = [
         analyzer.get_all_powers(_tone(10.0, dc=dc))["alpha"]


### PR DESCRIPTION
## 무엇을

RTM의 TS 식별자를 테스트 코드에 `[TS-XXX-NN]` 형태로 태깅한다. pytest는 `describe`가 없어 **클래스 docstring 첫 줄**(클래스가 없으면 함수 docstring 첫 줄)에 붙인다. 이 레포는 7곳이다.

`pytest.mark`는 쓰지 않았다. 마커는 `pytest.ini` 등록이 필요해 비용이 늘고 grep 대상이 docstring과 갈린다.

## 태깅한 곳

| TS | 위치 |
|---|---|
| TS-ANALYSIS-01 | `tests/test_analyzer_dsp.py::test_alpha_rms_recovers_true_amplitude` |
| TS-ANALYSIS-02 | `tests/services/test_analysis_pipeline.py::TestExtractFeatures` |
| TS-ANALYSIS-04 | 같은 파일 `TestRunFullPipeline` |
| TS-ANALYSIS-07 | `tests/services/test_markdown.py::TestFeaturesToMarkdown` |
| TS-ANALYSIS-08 | `tests/routes/test_analyze_pipeline.py::TestAnalyzePipelineEndpoint` |
| TS-ANALYSIS-09 | 같은 파일 `TestAnalyzePipelineModeField` |
| TS-ANALYSIS-10 | `tests/test_analyzer_dsp.py::test_dc_level_does_not_change_result` |
| TS-AI-01 | `tests/services/test_friendship.py::TestFriendshipScore` |

## TS-ANALYSIS-10은 새 테스트를 쓰지 않았다

계획은 "합성 신호로 대역 파워가 DC가 아닌 신호에서 오는지 확인하는 단위 테스트를 새로 쓴다"였다. 그런데 **`test_dc_level_does_not_change_result`가 정확히 그 계약을 이미 검증하고 있었다** — DC 준위 3000, 4200, 5000에서 알파 값이 불변임을 본다. 같은 파일의 `test_constant_dc_input_yields_zero_band_power`가 짝을 이룬다.

**없는 줄 알고 새로 썼다면 ANALYSIS-W001이 세운 "DC 제거자는 `_remove_dc` 하나" 설계를 깨뜨릴 뻔했다.** 두 번째 DC 제거 경로가 생기면 어느 쪽을 없애도 결과가 같아져 회귀 테스트가 무력해진다.

그래서 새 테스트 없이 RTM에 채번만 하고 기존 테스트에 태그를 붙였다. TS 총계는 62에서 63이 됐다.

## docstring 병합 주의

기존 docstring이 있던 클래스 넷은 태그 줄을 새로 만들지 않고 **한 docstring 안으로 병합**했다. 두 문자열을 나란히 두면 뒤의 것이 docstring이 아니라 무의미한 표현식이 된다.

## 검증

- `pytest -q --basetemp=<쓰기가능경로>` **299건 PASS**
- `black --check .` 57파일 무변경, `flake8 .` 무출력
- 게이트 `docs/builder/check_ts_tags.py --check --strict` 통과 (orphan 0)

## 남은 공백

BTI 분석(TS-ANALYSIS-05)과 신호 불량 구간 보간(TS-ANALYSIS-03)은 대응 테스트가 없어 문서에 사유와 함께 `없음`으로 적었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XeGgJ5AzVWsGDHXubVDbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 분석 파이프라인, 인증, 분석 모드, 우정 점수, 마크다운 변환 및 DSP 회귀 테스트에 식별자와 검증 목적 설명을 보강했습니다.
  * 테스트 실행 로직과 검증 조건에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->